### PR TITLE
fix: 支持显示并选择所有可用的upstream

### DIFF
--- a/apps/web/src/components/admin/create-key-dialog.tsx
+++ b/apps/web/src/components/admin/create-key-dialog.tsx
@@ -37,7 +37,7 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { useCreateAPIKey } from "@/hooks/use-api-keys";
-import { useUpstreams } from "@/hooks/use-upstreams";
+import { useAllUpstreams } from "@/hooks/use-upstreams";
 import type { APIKeyCreateResponse } from "@/types/api";
 import { ShowKeyDialog } from "./show-key-dialog";
 import { getDateLocale } from "@/lib/date-locale";
@@ -56,10 +56,7 @@ export function CreateKeyDialog() {
   const locale = useLocale();
   const dateLocale = getDateLocale(locale);
 
-  const { data: upstreamsData, isLoading: upstreamsLoading } = useUpstreams(
-    1,
-    100
-  );
+  const { data: upstreams, isLoading: upstreamsLoading } = useAllUpstreams();
 
   const createKeySchema = z.object({
     name: z.string().min(1, t("keyNameRequired")).max(100),
@@ -160,12 +157,12 @@ export function CreateKeyDialog() {
                         <div className="type-body-medium text-[rgb(var(--md-sys-color-on-surface-variant))] text-center py-4">
                           {tCommon("loading")}
                         </div>
-                      ) : upstreamsData?.items.length === 0 ? (
+                      ) : !upstreams || upstreams.length === 0 ? (
                         <div className="type-body-medium text-[rgb(var(--md-sys-color-on-surface-variant))] text-center py-4">
                           {tCommon("noData")}
                         </div>
                       ) : (
-                        upstreamsData?.items.map((upstream) => (
+                        upstreams.map((upstream) => (
                           <FormField
                             key={upstream.id}
                             control={form.control}


### PR DESCRIPTION
### 概述

修复了创建API Key时选择upstream只能显示前100个的限制。

### 修改内容

1. **apps/web/src/hooks/use-upstreams.ts** - 新增 `useAllUpstreams()` hook
   - 智能分页加载：首次获取100条，如有更多则并行获取剩余页面
   - 优化性能：所有数据在第一页时直接返回，无需额外请求
   - 使用独立的查询键 `["upstreams", "all"]` 避免与分页查询冲突
   
2. **apps/web/src/components/admin/create-key-dialog.tsx** - 更新使用新hook
   - 替换 `useUpstreams(1, 100)` 为 `useAllUpstreams()`
   - 现在能显示并选择所有可用的upstreams（无数量限制）
   - 保持原有的多选复选框功能

### 技术细节
- 新hook会首先获取第一页（100条）来确定总数
- 如果总数超过100，则并行获取所有剩余页面
- 所有请求完成后合并结果并返回完整列表
- 这种方法兼顾了性能和完整性

Closes #3

---

Generated with [Claude Code](https://claude.ai/code)