### PR TITLE
fix(api): add allow_key_reveal to Settings class

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -7,6 +7,14 @@ LOG_LEVEL=INFO
 # Admin Token for web console access (required for /admin endpoints)
 ADMIN_TOKEN=your-secure-admin-token-here
 
+# Allow revealing full API key values in admin console (default: false)
+# Set to true/1/yes/on to enable the reveal feature
+ALLOW_KEY_REVEAL=false
+
+# Encryption key for storing API keys (Fernet, base64-encoded 32-byte key)
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+ENCRYPTION_KEY=
+
 # API Configuration
 API_PREFIX=/api
 PROXY_PREFIX=/proxy
@@ -17,28 +25,13 @@ DATABASE_URL=sqlite:///./data.db
 # CORS
 CORS_ORIGINS=["http://localhost:3000"]
 
-# Upstream AI Services Configuration
+# Upstream AI Services Configuration (OPTIONAL)
+# Upstreams are now stored in the database and managed via Admin API.
+# This env var is only used for initial import on first startup (if database is empty).
+# After first run, manage upstreams through the Admin console or API.
+#
 # Format: JSON array of upstream configurations
 # Each upstream must have: name, provider, base_url, api_key
 # Optionally: is_default (bool), timeout (int, seconds)
-UPSTREAMS='[
-  {
-    "name": "primary-openai",
-    "provider": "openai",
-    "base_url": "https://api.openai.com",
-    "api_key": "sk-your-openai-api-key-here",
-    "is_default": true,
-    "timeout": 60
-  },
-  {
-    "name": "backup-anthropic",
-    "provider": "anthropic",
-    "base_url": "https://api.anthropic.com",
-    "api_key": "sk-ant-your-anthropic-api-key-here",
-    "is_default": false,
-    "timeout": 60
-  }
-]'
-
-# For Docker/Kubernetes, you can also set individual upstream configs:
-# UPSTREAMS='[{"name":"openai-1","provider":"openai","base_url":"https://api.openai.com","api_key":"${OPENAI_API_KEY}","is_default":true}]'
+#
+# UPSTREAMS='[{"name":"openai","provider":"openai","base_url":"https://api.openai.com","api_key":"sk-...","is_default":true,"timeout":60}]'

--- a/apps/api/app/api/routes/admin.py
+++ b/apps/api/app/api/routes/admin.py
@@ -3,7 +3,6 @@
 All endpoints require admin authentication (Bearer token from ADMIN_TOKEN env var).
 """
 
-import os
 from datetime import datetime
 from uuid import UUID
 
@@ -12,6 +11,7 @@ from fastapi.responses import JSONResponse
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.deps import get_db, verify_admin_token
 from app.core.encryption import EncryptionError
 from app.models.schemas import (
@@ -31,13 +31,6 @@ from app.models.schemas import (
 from app.services import key_manager, request_logger, stats_service, upstream_service
 
 router = APIRouter(prefix="/admin", tags=["admin"])
-
-_ALLOW_KEY_REVEAL = os.getenv("ALLOW_KEY_REVEAL", "false").strip().lower() in {
-    "1",
-    "true",
-    "yes",
-    "on",
-}
 
 
 # ============================================================================
@@ -138,7 +131,7 @@ async def reveal_api_key_endpoint(
         HTTPException(400): Legacy key without encryption
         HTTPException(500): Decryption failed
     """
-    if not _ALLOW_KEY_REVEAL:
+    if not settings.allow_key_reveal:
         await request_logger.log_request(
             db=db,
             api_key_id=None,

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -31,6 +31,9 @@ class Settings(BaseSettings):
     # Admin authentication
     admin_token: str | None = None
 
+    # Allow revealing full API key values in admin console
+    allow_key_reveal: bool = False
+
     # Request log retention
     log_retention_days: int = 90
 


### PR DESCRIPTION
## Summary

- 修复 `ALLOW_KEY_REVEAL` 环境变量导致 pydantic-settings 验证失败的问题
- 将 `allow_key_reveal` 配置项正式添加到 `Settings` 类中
- 更新 `.env.example` 添加缺失的配置项文档

## Changes

1. **`apps/api/app/core/config.py`**: 添加 `allow_key_reveal: bool = False` 字段
2. **`apps/api/app/api/routes/admin.py`**: 使用 `settings.allow_key_reveal` 替代 `os.getenv()`
3. **`.env.example`**: 
   - 添加 `ALLOW_KEY_REVEAL` 配置说明
   - 添加 `ENCRYPTION_KEY` 配置说明及生成命令
   - 简化 `UPSTREAMS` 文档（现为可选，数据库优先架构）

## Test plan

- [x] 应用可正常启动（`uv run python -c 'from app.main import app'`）
- [x] pyright 类型检查通过
- [x] pre-commit hooks 全部通过