### PR TITLE
fix(admin): 恢复日志详情展开显示 token 与路由信息

### DIFF
--- a/src/components/admin/logs-table.tsx
+++ b/src/components/admin/logs-table.tsx
@@ -340,7 +340,11 @@ export function LogsTable({ logs, isLive = false }: LogsTableProps) {
                   const isExpanded = expandedRows.has(log.id);
                   const hasFailover = log.failover_attempts > 0;
                   const hasRoutingDecision = !!log.routing_decision;
-                  const canExpand = hasFailover;
+                  // Token details moved from tooltip into the expanded row, so allow expansion
+                  // whenever there is something meaningful to show.
+                  // - In-progress requests: tokens may be 0 but routing_decision can exist
+                  // - Normal requests: routing_decision may be null but token stats usually exist
+                  const canExpand = hasFailover || hasRoutingDecision || log.total_tokens > 0;
                   const isNew = newLogIds.has(log.id);
                   const isError = hasErrorState(log);
                   const upstreamDisplayName =

--- a/tests/components/logs-table.test.tsx
+++ b/tests/components/logs-table.test.tsx
@@ -686,8 +686,28 @@ describe("LogsTable", () => {
       ],
     };
 
-    it("does not show expand indicator when no failover attempts", () => {
+    it("shows expand indicator when token details exist even without failover", () => {
       render(<LogsTable logs={[mockLog]} />);
+
+      expect(screen.getByRole("button", { name: "expandDetails" })).toBeInTheDocument();
+    });
+
+    it("does not show expand indicator when no details are available", () => {
+      const logWithoutDetails: RequestLog = {
+        ...mockLog,
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        total_tokens: 0,
+        cached_tokens: 0,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 0,
+        reasoning_tokens: 0,
+        routing_decision: null,
+        failover_attempts: 0,
+        failover_history: null,
+      };
+
+      render(<LogsTable logs={[logWithoutDetails]} />);
 
       expect(screen.queryByRole("button", { name: "expandDetails" })).not.toBeInTheDocument();
     });


### PR DESCRIPTION
原因：token 详情从 tooltip 迁移到展开行后，展开条件仍仅依赖 failover，导致无 failover 的正常请求无法展开，token/路由详情在 UI 中无法查看。

改动：
- 放宽 logs 表格行展开条件：存在 routing_decision / total_tokens / failover 任一即可展开
- 更新 logs-table 单测覆盖“无详情不显示展开”的场景
