### PR TITLE
ci: derive release version from tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,21 +34,25 @@ jobs:
         run: |
           set -euo pipefail
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          EXPECTED_TAG="v${PACKAGE_VERSION}"
           ACTUAL_TAG="${GITHUB_REF_NAME}"
 
-          if [[ "${ACTUAL_TAG}" != "${EXPECTED_TAG}" ]]; then
-            echo "::error::Tag ${ACTUAL_TAG} does not match package.json version ${EXPECTED_TAG}"
+          if [[ ! "${ACTUAL_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]]; then
+            echo "::error::Tag ${ACTUAL_TAG} must match vMAJOR.MINOR.PATCH, vMAJOR.MINOR.PATCH-alpha.N, or vMAJOR.MINOR.PATCH-beta.N"
             exit 1
           fi
 
-          git fetch origin master --depth=1
-          if ! git branch -r --contains "${GITHUB_SHA}" | grep -q "origin/master"; then
+          RELEASE_VERSION="${ACTUAL_TAG#v}"
+          RELEASE_COMMIT="$(git rev-parse "${GITHUB_SHA}^{commit}")"
+
+          git fetch origin master
+          if ! git merge-base --is-ancestor "${RELEASE_COMMIT}" origin/master; then
             echo "::error::Release tag must point to a commit contained in origin/master"
             exit 1
           fi
 
           echo "package_version=${PACKAGE_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "release_version=${RELEASE_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "release_commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -66,6 +70,7 @@ jobs:
         env:
           DB_TYPE: postgres
           NEXT_TELEMETRY_DISABLED: "1"
+          NEXT_PUBLIC_APP_VERSION: ${{ steps.validate.outputs.release_version }}
         run: pnpm build
 
       - name: Run actionlint
@@ -91,8 +96,8 @@ jobs:
           tags: |
             type=raw,value=${{ github.ref_name }}
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(steps.validate.outputs.release_version, '-') }}
+            type=raw,value=latest,enable=${{ !contains(steps.validate.outputs.release_version, '-') }}
 
       - name: Build and push Docker image
         id: build_push
@@ -102,6 +107,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NEXT_PUBLIC_APP_VERSION=${{ steps.validate.outputs.release_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
@@ -126,8 +133,9 @@ jobs:
           ## Release Metadata
 
           - Tag: \`${GITHUB_REF_NAME}\`
+          - Release version: \`${{ steps.validate.outputs.release_version }}\`
           - Package version: \`${{ steps.validate.outputs.package_version }}\`
-          - Commit: \`${GITHUB_SHA}\`
+          - Commit: \`${{ steps.validate.outputs.release_commit }}\`
           - Image: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF_NAME}\`
           - Image digest: \`${{ steps.build_push.outputs.digest }}\`
 
@@ -139,8 +147,9 @@ jobs:
           cat > release-metadata.json <<EOF
           {
             "tag": "${GITHUB_REF_NAME}",
+            "releaseVersion": "${{ steps.validate.outputs.release_version }}",
             "packageVersion": "${{ steps.validate.outputs.package_version }}",
-            "commitSha": "${GITHUB_SHA}",
+            "commitSha": "${{ steps.validate.outputs.release_commit }}",
             "image": "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF_NAME}",
             "imageDigest": "${{ steps.build_push.outputs.digest }}",
             "runId": "${GITHUB_RUN_ID}",
@@ -155,6 +164,7 @@ jobs:
           body_path: release-body.md
           files: release-metadata.json
           generate_release_notes: false
+          prerelease: ${{ contains(steps.validate.outputs.release_version, '-') }}
 
       - name: Upload release metadata artifact
         uses: actions/upload-artifact@v7
@@ -171,7 +181,8 @@ jobs:
             echo "## Release Published"
             echo
             echo "- Tag: \`${GITHUB_REF_NAME}\`"
-            echo "- Commit: \`${GITHUB_SHA}\`"
+            echo "- Release version: \`${{ steps.validate.outputs.release_version }}\`"
+            echo "- Commit: \`${{ steps.validate.outputs.release_commit }}\`"
             echo "- Image: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF_NAME}\`"
             echo "- Digest: \`${{ steps.build_push.outputs.digest }}\`"
             echo "- Release URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${GITHUB_REF_NAME}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,10 @@ COPY . .
 # Build the application
 # DB_TYPE avoids the production fail-fast check that requires DATABASE_URL.
 # The actual connection string is provided at runtime; db access is lazy.
+ARG NEXT_PUBLIC_APP_VERSION=0.0.0-dev
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV DB_TYPE=postgres
+ENV NEXT_PUBLIC_APP_VERSION=${NEXT_PUBLIC_APP_VERSION}
 RUN pnpm build
 
 # Production stage

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,11 +3,12 @@ import createNextIntlPlugin from "next-intl/plugin";
 import packageJson from "./package.json";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
+const appVersion = process.env.NEXT_PUBLIC_APP_VERSION ?? `${packageJson.version}-dev`;
 
 const nextConfig: NextConfig = {
   output: "standalone",
   env: {
-    NEXT_PUBLIC_APP_VERSION: packageJson.version,
+    NEXT_PUBLIC_APP_VERSION: appVersion,
   },
   images: {
     remotePatterns: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autorouter",
-  "version": "0.2.0",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.12.0",


### PR DESCRIPTION
## Summary

Change release versioning so Git tags provide the runtime application version for published builds. `package.json.version` now stays at a development placeholder, while Release injects the tag-derived version into Next.js and Docker builds.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (code improvement without changing functionality)
- [ ] Tests (adding or updating tests)
- [x] Build/CI (changes to build system or CI configuration)

## Changes

- Validate release tags by semver-like tag format instead of requiring `package.json.version` to match.
- Derive `releaseVersion` from `v*` tags and inject it through `NEXT_PUBLIC_APP_VERSION` during `pnpm build` and Docker builds.
- Keep prerelease tags as GitHub prereleases and avoid moving `latest` / major-minor Docker tags for prereleases.
- Keep `package.json.version` as a development placeholder.

## Test Plan

- [x] Local tests pass (`pnpm test:run`)
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`)
- [x] Manual testing completed
- [x] `pnpm format:check`
- [x] `NEXT_PUBLIC_APP_VERSION=0.2.1-alpha.1 pnpm build`
- [x] Verified build output contains `APP_VERSION_TAG` as `v0.2.1-alpha.1`

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

N/A

## Additional Notes

After this change is merged, a test release can be published by tagging `master` with `v0.2.1-alpha.1`.