### PR TITLE
fix: show app version on mobile settings

### DIFF
--- a/src/app/[locale]/(dashboard)/settings/page.tsx
+++ b/src/app/[locale]/(dashboard)/settings/page.tsx
@@ -19,7 +19,7 @@ import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Link } from "@/i18n/navigation";
-import { APP_REPOSITORY_URL } from "@/lib/app-version";
+import { APP_REPOSITORY_URL, APP_VERSION_TAG } from "@/lib/app-version";
 import { useAuth } from "@/providers/auth-provider";
 import { cn } from "@/lib/utils";
 
@@ -221,6 +221,12 @@ export default function SettingsPage() {
               </div>
             </CardContent>
           </Card>
+
+          <div className="flex justify-center pt-1 md:hidden">
+            <p className="type-caption text-muted-foreground">
+              {tCommon("appName")} {APP_VERSION_TAG}
+            </p>
+          </div>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary

Show the runtime application version on the mobile Settings page so mobile users can find the same version information that desktop users see in the sidebar.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (code improvement without changing functionality)
- [ ] Tests (adding or updating tests)
- [ ] Build/CI (changes to build system or CI configuration)

## Changes

- Import `APP_VERSION_TAG` into the Settings page.
- Add a mobile-only version line at the bottom of Settings.
- Keep desktop version display in the sidebar only.

## Test Plan

- [ ] Local tests pass (`pnpm test:run`)
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`)
- [x] Manual testing completed
- [x] `pnpm format:check`
- [x] `NEXT_PUBLIC_APP_VERSION=0.2.1-alpha.2 pnpm build`
- [x] Verified built output contains `v0.2.1-alpha.2`

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

N/A

## Additional Notes

After merge, publish `v0.2.1-alpha.2` to verify the deployed mobile version display.