### PR TITLE
fix: center catalog refresh loading state

### DIFF
--- a/src/components/admin/upstream-form-dialog.tsx
+++ b/src/components/admin/upstream-form-dialog.tsx
@@ -2547,7 +2547,7 @@ export function UpstreamFormDialog({
                                   {t("catalogCreateHint")}
                                 </div>
                               ) : catalogIsRefreshing ? (
-                                <div className="flex min-h-[180px] items-center gap-2 rounded-cf-sm bg-card/15 px-3 py-4 text-sm text-muted-foreground ring-1 ring-divider/50">
+                                <div className="flex min-h-[180px] items-center justify-center gap-2 rounded-cf-sm bg-card/15 px-3 py-4 text-sm text-muted-foreground ring-1 ring-divider/50">
                                   <Loader2 className="h-4 w-4 animate-spin" />
                                   {t("catalogLoading")}
                                 </div>


### PR DESCRIPTION
## Summary

- Center the model catalog refresh loading indicator inside the catalog panel.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (code improvement without changing functionality)
- [ ] Tests (adding or updating tests)
- [ ] Build/CI (changes to build system or CI configuration)

## Changes

- Add horizontal centering to the upstream model catalog loading state so the spinner and loading label sit in the middle of the catalog box.

## Test Plan

- [x] Local tests pass (`pnpm test:run tests/components/upstream-form-dialog.test.tsx`)
- [x] Type check passes (`tsc` via commit hook)
- [x] Lint passes (`eslint` via commit hook)
- [ ] Manual testing completed

Additional local validation:

- `pnpm format:check`

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

N/A

## Additional Notes

- This is a one-line layout fix for the catalog refresh state.
