### PR TITLE
fix: align model list with routing constraints

### DIFF
--- a/src/app/api/proxy/v1/[...path]/route.ts
+++ b/src/app/api/proxy/v1/[...path]/route.ts
@@ -112,7 +112,6 @@ import { apiKeyQuotaTracker } from "@/lib/services/api-key-quota-tracker";
 import { resolveBillingModelPrice } from "@/lib/services/billing-price-service";
 import {
   createApiKeyModelListResponseBody,
-  filterApiKeyModelListResponseBody,
   isModelAllowedByApiKey,
   normalizeApiKeyAllowedModels,
 } from "@/lib/api-key-models";
@@ -613,6 +612,15 @@ function filterCandidatesByModelRules(
   }
 
   return { allowed, excluded };
+}
+
+function getApiKeyVisibleModelList(
+  apiKeyAllowedModels: string[],
+  candidates: Upstream[]
+): string[] {
+  return apiKeyAllowedModels.filter((model) =>
+    candidates.some((candidate) => resolvePathRoutingModelForUpstream(model, candidate).matched)
+  );
 }
 
 function mergeExcludedCandidates(
@@ -2331,32 +2339,6 @@ async function handleProxy(request: NextRequest, context: RouteContext): Promise
     return createUnifiedErrorResponse(errorCode, errorDetails);
   }
 
-  const apiKeyAllowedModels = normalizeApiKeyAllowedModels(validApiKey.allowedModels);
-  if (isOpenAIModelListRequest(request.method, path) && apiKeyAllowedModels) {
-    try {
-      await logLocalApiKeyModelListRequest({
-        apiKeyId: validApiKey.id,
-        apiKeyName: apiKeySnapshot.apiKeyName,
-        apiKeyPrefix: apiKeySnapshot.apiKeyPrefix,
-        request,
-        path,
-        requestId,
-        startTime,
-        matchedRouteCapability,
-        routeMatchSource: matchedRouteMatchSource,
-      });
-    } catch (error) {
-      log.error({ err: error, requestId }, "failed to log local API key model list request");
-    }
-
-    return new Response(Buffer.from(createApiKeyModelListResponseBody(apiKeyAllowedModels)), {
-      status: 200,
-      headers: {
-        "content-type": "application/json",
-      },
-    });
-  }
-
   await apiKeyQuotaTracker.initialize();
   const apiKeyQuotaStatus = apiKeyQuotaTracker.getQuotaStatus(validApiKey.id);
 
@@ -2629,6 +2611,34 @@ async function handleProxy(request: NextRequest, context: RouteContext): Promise
     }
 
     return rejectedResponse;
+  }
+
+  const apiKeyAllowedModels = normalizeApiKeyAllowedModels(validApiKey.allowedModels);
+  if (isOpenAIModelListRequest(request.method, path) && apiKeyAllowedModels) {
+    const visibleModels = getApiKeyVisibleModelList(apiKeyAllowedModels, finalCapabilityCandidates);
+
+    try {
+      await logLocalApiKeyModelListRequest({
+        apiKeyId: validApiKey.id,
+        apiKeyName: apiKeySnapshot.apiKeyName,
+        apiKeyPrefix: apiKeySnapshot.apiKeyPrefix,
+        request,
+        path,
+        requestId,
+        startTime,
+        matchedRouteCapability,
+        routeMatchSource: matchedRouteMatchSource,
+      });
+    } catch (error) {
+      log.error({ err: error, requestId }, "failed to log local API key model list request");
+    }
+
+    return new Response(Buffer.from(createApiKeyModelListResponseBody(visibleModels)), {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+      },
+    });
   }
 
   let selectedCandidate = finalCapabilityCandidates[0];
@@ -3269,15 +3279,7 @@ async function handleProxy(request: NextRequest, context: RouteContext): Promise
       });
     } else {
       // Regular response
-      let bodyBytes = result.body as Uint8Array;
-      const modelListFilter = isOpenAIModelListRequest(request.method, path)
-        ? filterApiKeyModelListResponseBody(bodyBytes, validApiKey.allowedModels)
-        : { bodyBytes, filtered: false };
-      if (modelListFilter.filtered) {
-        bodyBytes = modelListFilter.bodyBytes;
-        responseHeaders.set("content-type", "application/json");
-        responseHeaders.delete("content-length");
-      }
+      const bodyBytes = result.body as Uint8Array;
       const durationMs = Date.now() - startTime;
 
       // Try to extract usage from response

--- a/src/components/admin/key-model-allowlist-section.tsx
+++ b/src/components/admin/key-model-allowlist-section.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { useDeferredValue, useMemo, useState, type ReactNode, type UIEvent } from "react";
+import {
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+  type ReactNode,
+  type UIEvent,
+} from "react";
 import { ArrowDownToLine, Plus, Search, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
@@ -23,21 +32,46 @@ function mergeModels(current: string[], additions: string[]): string[] {
   return normalizeApiKeyAllowedModels([...current, ...additions]) ?? [];
 }
 
-function useVirtualModelRows(itemCount: number) {
+function useVirtualModelRows(
+  itemCount: number,
+  resetKey: string,
+  scrollRef: RefObject<HTMLDivElement | null>
+) {
   const [viewport, setViewport] = useState({
     scrollTop: 0,
     height: DEFAULT_MODEL_LIST_HEIGHT,
+    resetKey,
   });
+  const currentViewport =
+    viewport.resetKey === resetKey
+      ? viewport
+      : {
+          scrollTop: 0,
+          height: DEFAULT_MODEL_LIST_HEIGHT,
+          resetKey,
+        };
+
+  useEffect(() => {
+    const viewportElement = scrollRef.current;
+    if (viewportElement) {
+      viewportElement.scrollTop = 0;
+    }
+  }, [resetKey, scrollRef]);
+
   const startIndex =
     itemCount === 0
       ? 0
       : Math.min(
-          Math.max(0, Math.floor(viewport.scrollTop / MODEL_ROW_HEIGHT) - MODEL_LIST_OVERSCAN),
+          Math.max(
+            0,
+            Math.floor(currentViewport.scrollTop / MODEL_ROW_HEIGHT) - MODEL_LIST_OVERSCAN
+          ),
           itemCount - 1
         );
   const endIndex = Math.min(
     itemCount,
-    Math.ceil((viewport.scrollTop + viewport.height) / MODEL_ROW_HEIGHT) + MODEL_LIST_OVERSCAN
+    Math.ceil((currentViewport.scrollTop + currentViewport.height) / MODEL_ROW_HEIGHT) +
+      MODEL_LIST_OVERSCAN
   );
 
   return {
@@ -48,6 +82,7 @@ function useVirtualModelRows(itemCount: number) {
       setViewport({
         scrollTop: event.currentTarget.scrollTop,
         height: event.currentTarget.clientHeight || DEFAULT_MODEL_LIST_HEIGHT,
+        resetKey,
       });
     },
   };
@@ -64,11 +99,14 @@ function VirtualModelList({
   onToggle: (model: string, checked: boolean) => void;
   trailingAction?: (model: string) => ReactNode;
 }) {
-  const virtualRows = useVirtualModelRows(models.length);
+  const resetKey = models.join("\u0000");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const virtualRows = useVirtualModelRows(models.length, resetKey, scrollRef);
   const visibleModels = models.slice(virtualRows.startIndex, virtualRows.endIndex);
 
   return (
     <div
+      ref={scrollRef}
       className="max-h-40 overflow-auto rounded-cf-sm border border-divider/70"
       onScroll={virtualRows.onScroll}
     >

--- a/src/components/admin/upstream-form-dialog.tsx
+++ b/src/components/admin/upstream-form-dialog.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useDeferredValue, useEffect, useMemo, useRef, useState, type UIEvent } from "react";
+import {
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+  type UIEvent,
+} from "react";
 import { useForm, useWatch, useFieldArray, type DeepPartial } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -767,21 +775,46 @@ function formatCatalogTimestamp(value: string | null): string | null {
   return parsed.toLocaleString();
 }
 
-function useVirtualCatalogRows(itemCount: number) {
+function useVirtualCatalogRows(
+  itemCount: number,
+  resetKey: string,
+  scrollRef: RefObject<HTMLDivElement | null>
+) {
   const [viewport, setViewport] = useState({
     scrollTop: 0,
     height: DEFAULT_MODEL_LIST_HEIGHT,
+    resetKey,
   });
+  const currentViewport =
+    viewport.resetKey === resetKey
+      ? viewport
+      : {
+          scrollTop: 0,
+          height: DEFAULT_MODEL_LIST_HEIGHT,
+          resetKey,
+        };
+
+  useEffect(() => {
+    const viewportElement = scrollRef.current;
+    if (viewportElement) {
+      viewportElement.scrollTop = 0;
+    }
+  }, [resetKey, scrollRef]);
+
   const startIndex =
     itemCount === 0
       ? 0
       : Math.min(
-          Math.max(0, Math.floor(viewport.scrollTop / MODEL_ROW_HEIGHT) - MODEL_LIST_OVERSCAN),
+          Math.max(
+            0,
+            Math.floor(currentViewport.scrollTop / MODEL_ROW_HEIGHT) - MODEL_LIST_OVERSCAN
+          ),
           itemCount - 1
         );
   const endIndex = Math.min(
     itemCount,
-    Math.ceil((viewport.scrollTop + viewport.height) / MODEL_ROW_HEIGHT) + MODEL_LIST_OVERSCAN
+    Math.ceil((currentViewport.scrollTop + currentViewport.height) / MODEL_ROW_HEIGHT) +
+      MODEL_LIST_OVERSCAN
   );
 
   return {
@@ -792,6 +825,7 @@ function useVirtualCatalogRows(itemCount: number) {
       setViewport({
         scrollTop: event.currentTarget.scrollTop,
         height: event.currentTarget.clientHeight || DEFAULT_MODEL_LIST_HEIGHT,
+        resetKey,
       });
     },
   };
@@ -806,11 +840,14 @@ function VirtualCatalogEntryList({
   selectedModels: ReadonlySet<string>;
   onToggle: (model: string, checked: boolean) => void;
 }) {
-  const virtualRows = useVirtualCatalogRows(entries.length);
+  const resetKey = entries.map((entry) => `${entry.model}:${entry.source}`).join("\u0000");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const virtualRows = useVirtualCatalogRows(entries.length, resetKey, scrollRef);
   const visibleEntries = entries.slice(virtualRows.startIndex, virtualRows.endIndex);
 
   return (
     <div
+      ref={scrollRef}
       className="min-h-0 flex-1 overflow-auto rounded-cf-sm border border-divider/70 bg-card/15"
       onScroll={virtualRows.onScroll}
     >

--- a/src/lib/api-key-models.ts
+++ b/src/lib/api-key-models.ts
@@ -34,56 +34,6 @@ export function createApiKeyModelListResponseBody(models: string[]): Uint8Array 
   );
 }
 
-export function filterApiKeyModelListResponseBody(
-  bodyBytes: Uint8Array,
-  allowedModels: string[] | null | undefined
-): { bodyBytes: Uint8Array; filtered: boolean } {
-  const normalizedAllowedModels = normalizeApiKeyAllowedModels(allowedModels);
-  if (!normalizedAllowedModels) {
-    return { bodyBytes, filtered: false };
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(new TextDecoder().decode(bodyBytes));
-  } catch {
-    parsed = { object: "list" };
-  }
-
-  const payload =
-    parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as { object?: unknown; data?: unknown })
-      : { object: "list" };
-  const upstreamModelsById = new Map<string, Record<string, unknown>>();
-  if (Array.isArray(payload.data)) {
-    for (const item of payload.data) {
-      if (!item || typeof item !== "object" || Array.isArray(item)) {
-        continue;
-      }
-
-      const id = (item as { id?: unknown }).id;
-      if (typeof id === "string") {
-        upstreamModelsById.set(id, item as Record<string, unknown>);
-      }
-    }
-  }
-
-  const filteredData = normalizedAllowedModels.map(
-    (model) => upstreamModelsById.get(model) ?? createOpenAIModelListItem(model)
-  );
-
-  return {
-    bodyBytes: new TextEncoder().encode(
-      JSON.stringify({
-        ...payload,
-        object: typeof payload.object === "string" ? payload.object : "list",
-        data: filteredData,
-      })
-    ),
-    filtered: true,
-  };
-}
-
 function createOpenAIModelListItem(model: string): Record<string, unknown> {
   return {
     id: model,

--- a/tests/unit/api/proxy/route.test.ts
+++ b/tests/unit/api/proxy/route.test.ts
@@ -5925,6 +5925,9 @@ describe("proxy route upstream selection", () => {
         allowedModels: ["gpt-4.1", "gpt-5.2"],
       },
     ]);
+    vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([
+      { upstreamId: "up-openai" },
+    ]);
 
     const request = new NextRequest("http://localhost/api/proxy/v1/models", {
       method: "GET",
@@ -5947,9 +5950,9 @@ describe("proxy route upstream selection", () => {
       ],
     });
     expect(response.headers.get("content-type")).toBe("application/json");
-    expect(mockApiKeyQuotaTracker.initialize).not.toHaveBeenCalled();
-    expect(db.query.apiKeyUpstreams.findMany).not.toHaveBeenCalled();
-    expect(db.query.upstreams.findMany).not.toHaveBeenCalled();
+    expect(mockApiKeyQuotaTracker.initialize).toHaveBeenCalledTimes(1);
+    expect(db.query.apiKeyUpstreams.findMany).toHaveBeenCalledTimes(1);
+    expect(db.query.upstreams.findMany).toHaveBeenCalledTimes(1);
     expect(selectFromProviderType).not.toHaveBeenCalled();
     expect(forwardRequest).not.toHaveBeenCalled();
     expect(logRequest).toHaveBeenCalledWith(
@@ -5967,6 +5970,114 @@ describe("proxy route upstream selection", () => {
         }),
       })
     );
+  });
+
+  it("should intersect API key model list with authorized upstream model rules", async () => {
+    const { db } = await import("@/lib/db");
+    const { forwardRequest } = await import("@/lib/services/proxy-client");
+
+    vi.mocked(db.query.apiKeys.findMany).mockResolvedValueOnce([
+      {
+        id: "key-1",
+        keyHash: "hash-1",
+        keyPrefix: "sk-test",
+        name: "Restricted Model List Key",
+        expiresAt: null,
+        isActive: true,
+        allowedModels: ["gpt-4.1", "gpt-5.2", "gpt-5.3"],
+      },
+    ]);
+    vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([
+      { upstreamId: "up-openai" },
+      { upstreamId: "up-alias" },
+    ]);
+    vi.mocked(db.query.upstreams.findMany).mockResolvedValueOnce([
+      {
+        id: "up-openai",
+        name: "openai-main",
+        providerType: "openai",
+        routeCapabilities: ["openai_chat_compatible"],
+        baseUrl: "https://api.openai.com",
+        isDefault: false,
+        isActive: true,
+        timeout: 60,
+        priority: 0,
+        weight: 1,
+        modelRules: [
+          {
+            type: "exact",
+            value: "gpt-4.1",
+            targetModel: null,
+            source: "manual",
+            displayLabel: null,
+          },
+        ],
+        allowedModels: null,
+        modelRedirects: null,
+      },
+      {
+        id: "up-alias",
+        name: "openai-alias",
+        providerType: "openai",
+        routeCapabilities: ["openai_chat_compatible"],
+        baseUrl: "https://api.openai.com",
+        isDefault: false,
+        isActive: true,
+        timeout: 60,
+        priority: 0,
+        weight: 1,
+        modelRules: [
+          {
+            type: "alias",
+            value: "gpt-5.2",
+            targetModel: "gpt-5.2-internal",
+            source: "manual",
+            displayLabel: null,
+          },
+        ],
+        allowedModels: null,
+        modelRedirects: null,
+      },
+      {
+        id: "up-hidden",
+        name: "openai-hidden",
+        providerType: "openai",
+        routeCapabilities: ["openai_chat_compatible"],
+        baseUrl: "https://api.openai.com",
+        isDefault: false,
+        isActive: true,
+        timeout: 60,
+        priority: 0,
+        weight: 1,
+        modelRules: [
+          {
+            type: "exact",
+            value: "gpt-5.3",
+            targetModel: null,
+            source: "manual",
+            displayLabel: null,
+          },
+        ],
+        allowedModels: null,
+        modelRedirects: null,
+      },
+    ]);
+
+    const request = new NextRequest("http://localhost/api/proxy/v1/models", {
+      method: "GET",
+      headers: {
+        authorization: "Bearer sk-test",
+      },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["models"] }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.data.map((item: { id: string }) => item.id)).toEqual(["gpt-4.1", "gpt-5.2"]);
+    expect(forwardRequest).not.toHaveBeenCalled();
   });
 
   it("should reject when API key not authorized for selected upstream", async () => {


### PR DESCRIPTION
## Summary

Fixes two review findings in the recent model access changes:

- Aligns OpenAI-compatible `GET /models` responses with authorized upstream candidates and upstream model rules before applying API key model limits.
- Resets virtualized model lists when filtered data changes so searches start at the top of the new result set.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (code improvement without changing functionality)
- [x] Tests (adding or updating tests)
- [ ] Build/CI (changes to build system or CI configuration)

## Changes

- Moves local API key model-list handling until after route capability matching, upstream authorization, active upstream loading, and upstream model-rule filtering.
- Returns only key-allowed models that at least one authorized upstream can actually accept, including exact and alias model rules.
- Removes the previous response-body filtering helper that could advertise API-key allowed models without verifying upstream route-rule support.
- Resets the Key model allowlist virtual list and upstream catalog virtual list when their filtered model data changes.
- Adds a proxy route regression test covering the intersection between API key model limits, authorized upstreams, exact rules, and alias rules.

## Test Plan

- [x] Local tests pass (`pnpm test:run`)
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`)
- [ ] Manual testing completed

Additional verification run:

- `pnpm test:run tests/unit/api/proxy/route.test.ts tests/components/upstream-form-dialog.test.tsx tests/components/create-key-dialog.test.tsx tests/components/edit-key-dialog.test.tsx`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm format:check`
- `pnpm lint`
- `$env:DB_TYPE='sqlite'; pnpm build`
- `git diff --check`

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

N/A

## Additional Notes

`pnpm lint` exits successfully but still reports existing JSDoc warnings outside this patch. Remote PR checks have passed: Quality, Production Build, Migration Consistency, Proxy Stability, Playwright E2E, GitHub Actions, CodeQL, and Verify Status.