### PR TITLE
Fix admin mobile layout clipping

### DIFF
--- a/src/app/[locale]/(dashboard)/keys/page.tsx
+++ b/src/app/[locale]/(dashboard)/keys/page.tsx
@@ -20,42 +20,38 @@ interface KeysLoadingSkeletonProps {
 
 function KeysLoadingSkeleton({ loadingLabel }: KeysLoadingSkeletonProps) {
   return (
-    <Card variant="outlined" className="border-divider bg-surface-200/70">
-      <CardContent className="p-0">
-        <div
-          role="status"
-          aria-label={loadingLabel}
-          className="overflow-hidden rounded-cf-md border border-divider/85 bg-surface-200/55"
-        >
-          <div className="border-b border-divider bg-surface-300/70 px-4 py-2.5">
-            <div className="grid grid-cols-12 gap-3">
-              <div className="col-span-2 h-3 animate-pulse rounded-cf-sm bg-surface-400/70" />
-              <div className="col-span-3 h-3 animate-pulse rounded-cf-sm bg-surface-400/70" />
-              <div className="col-span-2 h-3 animate-pulse rounded-cf-sm bg-surface-400/70" />
-              <div className="col-span-1 h-3 animate-pulse rounded-cf-sm bg-surface-400/70" />
-              <div className="col-span-2 h-3 animate-pulse rounded-cf-sm bg-surface-400/70" />
-              <div className="col-span-2 h-3 animate-pulse rounded-cf-sm bg-surface-400/70" />
-            </div>
-          </div>
-
-          <div className="divide-y divide-divider/70">
-            {Array.from({ length: 7 }).map((_, index) => (
-              <div
-                key={`keys-loading-row-${index}`}
-                className="grid grid-cols-12 items-center gap-3 px-4 py-3"
-              >
-                <div className="col-span-2 h-3 animate-pulse rounded-cf-sm bg-surface-300/80" />
-                <div className="col-span-3 h-3 animate-pulse rounded-cf-sm bg-surface-300/80" />
-                <div className="col-span-2 h-3 animate-pulse rounded-cf-sm bg-surface-300/80" />
-                <div className="col-span-1 h-3 animate-pulse rounded-cf-sm bg-surface-300/80" />
-                <div className="col-span-2 h-3 animate-pulse rounded-cf-sm bg-surface-300/80" />
-                <div className="col-span-2 h-8 animate-pulse rounded-cf-sm bg-surface-300/80" />
-              </div>
-            ))}
-          </div>
+    <div
+      role="status"
+      aria-label={loadingLabel}
+      className="overflow-hidden rounded-cf-md border border-divider/85 bg-surface-200/55"
+    >
+      <div className="border-b border-divider bg-surface-300/70 px-4 py-2.5">
+        <div className="grid grid-cols-12 gap-3">
+          <div className="col-span-2 h-3 animate-pulse rounded-cf-sm bg-surface-400/70" />
+          <div className="col-span-3 h-3 animate-pulse rounded-cf-sm bg-surface-400/70" />
+          <div className="col-span-2 h-3 animate-pulse rounded-cf-sm bg-surface-400/70" />
+          <div className="col-span-1 h-3 animate-pulse rounded-cf-sm bg-surface-400/70" />
+          <div className="col-span-2 h-3 animate-pulse rounded-cf-sm bg-surface-400/70" />
+          <div className="col-span-2 h-3 animate-pulse rounded-cf-sm bg-surface-400/70" />
         </div>
-      </CardContent>
-    </Card>
+      </div>
+
+      <div className="divide-y divide-divider/70">
+        {Array.from({ length: 7 }).map((_, index) => (
+          <div
+            key={`keys-loading-row-${index}`}
+            className="grid grid-cols-12 items-center gap-3 px-4 py-3"
+          >
+            <div className="col-span-2 h-3 animate-pulse rounded-cf-sm bg-surface-300/80" />
+            <div className="col-span-3 h-3 animate-pulse rounded-cf-sm bg-surface-300/80" />
+            <div className="col-span-2 h-3 animate-pulse rounded-cf-sm bg-surface-300/80" />
+            <div className="col-span-1 h-3 animate-pulse rounded-cf-sm bg-surface-300/80" />
+            <div className="col-span-2 h-3 animate-pulse rounded-cf-sm bg-surface-300/80" />
+            <div className="col-span-2 h-8 animate-pulse rounded-cf-sm bg-surface-300/80" />
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/src/app/[locale]/(dashboard)/logs/page.tsx
+++ b/src/app/[locale]/(dashboard)/logs/page.tsx
@@ -38,7 +38,11 @@ function LogsLoadingSkeleton({ loadingLabel }: LogsLoadingSkeletonProps) {
       className="border-divider bg-surface-200/70 overflow-hidden"
     >
       <span className="sr-only">{loadingLabel}</span>
-      <Table aria-hidden="true">
+      <Table
+        aria-hidden="true"
+        frame="none"
+        containerClassName="rounded-none border-0 bg-transparent"
+      >
         <TableHeader>
           <TableRow>
             <TableHead className="w-9 px-1.5"></TableHead>

--- a/src/app/[locale]/(dashboard)/system/billing/page.tsx
+++ b/src/app/[locale]/(dashboard)/system/billing/page.tsx
@@ -290,7 +290,7 @@ function UnresolvedRepairTable({
 
   return (
     <div className="space-y-3">
-      <div className="rounded-cf-sm border border-divider bg-surface-300/45 p-3">
+      <div className="border-t border-divider/70 pt-3">
         <div className="mb-3">
           <p className="font-medium text-foreground">{t("manualEntryTitle")}</p>
           <p className="text-xs text-muted-foreground">{t("manualEntryDesc")}</p>
@@ -1132,7 +1132,7 @@ export default function BillingPage() {
               </div>
             </div>
 
-            <div className="rounded-cf-sm border border-divider bg-surface-300/45 p-3">
+            <div className="border-t border-divider/70 pt-3">
               {!isTierRuleCreating ? (
                 <Button
                   data-testid="billing-tier-rule-add-button"
@@ -1346,181 +1346,359 @@ export default function BillingPage() {
                   </p>
                 )}
 
-                <div className="space-y-2 lg:hidden">
-                  {priceCatalogExtraOverrides.map((override) => (
-                    <div
-                      key={override.id}
-                      className={[
-                        "rounded-cf-sm border border-divider bg-surface-300/30 p-3",
-                        recentlySavedModel === override.model ? "ring-1 ring-amber-500/50" : "",
-                      ].join(" ")}
-                    >
-                      <div className="flex items-start gap-3">
-                        <div className="pt-0.5">
-                          <Checkbox
-                            checked={selectedResetModels.includes(override.model)}
-                            onCheckedChange={(value) =>
-                              toggleSelectedResetModel(override.model, value === true)
-                            }
-                            aria-label={t("priceCatalogSelectModel", { model: override.model })}
-                          />
+                <div
+                  data-testid="billing-price-catalog-scroll-region"
+                  className="max-h-[min(62vh,48rem)] overflow-y-auto overscroll-contain pr-1 [scrollbar-gutter:stable] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                  aria-label={t("priceCatalogTitle")}
+                  tabIndex={0}
+                >
+                  <div className="space-y-2 lg:hidden">
+                    {priceCatalogExtraOverrides.map((override) => (
+                      <div
+                        key={override.id}
+                        className={[
+                          "rounded-cf-sm border border-divider bg-surface-300/30 p-3",
+                          recentlySavedModel === override.model ? "ring-1 ring-amber-500/50" : "",
+                        ].join(" ")}
+                      >
+                        <div className="flex items-start gap-3">
+                          <div className="pt-0.5">
+                            <Checkbox
+                              checked={selectedResetModels.includes(override.model)}
+                              onCheckedChange={(value) =>
+                                toggleSelectedResetModel(override.model, value === true)
+                              }
+                              aria-label={t("priceCatalogSelectModel", { model: override.model })}
+                            />
+                          </div>
+                          <div className="min-w-0 flex-1 space-y-2">
+                            <div className="flex items-start justify-between gap-2">
+                              <div className="min-w-0">
+                                <p className="break-all font-mono text-sm text-foreground">
+                                  {override.model}
+                                </p>
+                                <div className="mt-1 flex flex-wrap items-center gap-2">
+                                  <Badge variant="success">
+                                    {t("priceCatalogEffectiveManual")}
+                                  </Badge>
+                                  {allTierRulesMap.has(override.model) && (
+                                    <Badge variant="neutral">{t("tierRulesTitle")}</Badge>
+                                  )}
+                                  {override.has_official_price === false && (
+                                    <Badge variant="warning">
+                                      {t("priceCatalogNoOfficialPrice")}
+                                    </Badge>
+                                  )}
+                                </div>
+                                {tierRuleThresholdMap.has(override.model) && (
+                                  <p className="mt-1 text-[11px] text-muted-foreground">
+                                    {t("tierRulesThreshold")}:{" "}
+                                    {tierRuleThresholdMap.get(override.model)}
+                                  </p>
+                                )}
+                              </div>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-8 w-8 shrink-0"
+                                onClick={() => openResetDialog([override.model])}
+                                disabled={resetOverrides.isPending}
+                                title={
+                                  override.has_official_price === false
+                                    ? t("priceCatalogDeleteManualPrice")
+                                    : t("priceCatalogResetToOfficial")
+                                }
+                              >
+                                <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                                <span className="sr-only">
+                                  {override.has_official_price === false
+                                    ? t("priceCatalogDeleteManualPrice")
+                                    : t("priceCatalogResetToOfficial")}
+                                </span>
+                              </Button>
+                            </div>
+
+                            {isEditingPrice(override.model) ? (
+                              <div className="space-y-2" onClick={(e) => e.stopPropagation()}>
+                                <div className="grid grid-cols-2 gap-2 text-xs">
+                                  {(
+                                    [
+                                      ["input", t("priceCatalogInputPrice")],
+                                      ["output", t("priceCatalogOutputPrice")],
+                                      ["cacheRead", t("priceCatalogCacheReadPrice")],
+                                      ["cacheWrite", t("priceCatalogCacheWritePrice")],
+                                    ] as const
+                                  ).map(([field, label]) => (
+                                    <div
+                                      key={field}
+                                      className="rounded-cf-sm bg-surface-200/45 px-2 py-1.5"
+                                    >
+                                      <p className="text-muted-foreground">{label}</p>
+                                      <Input
+                                        type="number"
+                                        step="0.0001"
+                                        className="mt-0.5 h-6 text-xs"
+                                        value={editDraft[field]}
+                                        onChange={(e) => setDraftField(field, e.target.value)}
+                                      />
+                                    </div>
+                                  ))}
+                                </div>
+                                <div className="flex items-center gap-2">
+                                  <span className="shrink-0 text-[11px] text-muted-foreground">
+                                    {t("overrideNote")}
+                                  </span>
+                                  <Input
+                                    className="h-7 text-xs"
+                                    value={editDraft.note}
+                                    onChange={(e) => setDraftField("note", e.target.value)}
+                                  />
+                                </div>
+                                <div className="flex items-center gap-2">
+                                  <Button
+                                    size="sm"
+                                    className="h-7 gap-1"
+                                    onClick={() => void saveEdit()}
+                                    disabled={editIsSaving}
+                                  >
+                                    <Check className="h-3 w-3" />
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-7 gap-1"
+                                    onClick={cancelEditing}
+                                  >
+                                    <X className="h-3 w-3" />
+                                  </Button>
+                                </div>
+                              </div>
+                            ) : (
+                              <div
+                                className="grid cursor-pointer grid-cols-2 gap-2 rounded-cf-sm text-xs transition-colors"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  startEditingPrice(override.model, override);
+                                }}
+                                role="button"
+                                tabIndex={0}
+                              >
+                                <div className="rounded-cf-sm bg-surface-200/45 px-2 py-1.5">
+                                  <p className="text-muted-foreground">
+                                    {t("priceCatalogInputPrice")}
+                                  </p>
+                                  <p className="mt-0.5 text-right font-medium tabular-nums text-foreground">
+                                    {formatPriceNumber(override.input_price_per_million)}
+                                  </p>
+                                </div>
+                                <div className="rounded-cf-sm bg-surface-200/45 px-2 py-1.5">
+                                  <p className="text-muted-foreground">
+                                    {t("priceCatalogOutputPrice")}
+                                  </p>
+                                  <p className="mt-0.5 text-right font-medium tabular-nums text-foreground">
+                                    {formatPriceNumber(override.output_price_per_million)}
+                                  </p>
+                                </div>
+                                <div className="rounded-cf-sm bg-surface-200/45 px-2 py-1.5">
+                                  <p className="text-muted-foreground">
+                                    {t("priceCatalogCacheReadPrice")}
+                                  </p>
+                                  <p className="mt-0.5 text-right font-medium tabular-nums text-foreground">
+                                    {formatPriceNumber(override.cache_read_input_price_per_million)}
+                                  </p>
+                                </div>
+                                <div className="rounded-cf-sm bg-surface-200/45 px-2 py-1.5">
+                                  <p className="text-muted-foreground">
+                                    {t("priceCatalogCacheWritePrice")}
+                                  </p>
+                                  <p className="mt-0.5 text-right font-medium tabular-nums text-foreground">
+                                    {formatPriceNumber(
+                                      override.cache_write_input_price_per_million
+                                    )}
+                                  </p>
+                                </div>
+                              </div>
+                            )}
+
+                            {(() => {
+                              const modelTiers = allTierRulesMap.get(override.model);
+                              const hasMobileTiers = !!modelTiers && modelTiers.length > 0;
+                              const isOpen = expandedPriceRows.has(override.model);
+                              if (!hasMobileTiers) return null;
+                              return (
+                                <div className="mt-2">
+                                  <button
+                                    type="button"
+                                    className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                                    onClick={() => togglePriceRow(override.model)}
+                                  >
+                                    <ExpandChevron expanded={isOpen} className="h-3 w-3" />
+                                    {t("priceCatalogTiersCount", { count: modelTiers.length })}
+                                  </button>
+                                  {isOpen && (
+                                    <div className="mt-2 space-y-1.5">
+                                      {modelTiers.map((rule) => {
+                                        const isTierEditing =
+                                          rule.source === "manual"
+                                            ? isEditingTierRule(rule.id)
+                                            : isEditingTierOverride(
+                                                override.model,
+                                                rule.threshold_input_tokens
+                                              );
+                                        return isTierEditing ? (
+                                          <div
+                                            key={rule.id}
+                                            className="space-y-2 border-t border-divider/60 pt-2 text-xs"
+                                            onClick={(e) => e.stopPropagation()}
+                                          >
+                                            <span className="text-muted-foreground">
+                                              {t("tierRulesThresholdTokens", {
+                                                count: rule.threshold_input_tokens / 1000,
+                                              })}
+                                            </span>
+                                            <div className="grid grid-cols-2 gap-2">
+                                              {(
+                                                [
+                                                  ["input", t("priceCatalogInputPrice")],
+                                                  ["output", t("priceCatalogOutputPrice")],
+                                                  ["cacheRead", t("priceCatalogCacheReadPrice")],
+                                                  ["cacheWrite", t("priceCatalogCacheWritePrice")],
+                                                ] as const
+                                              ).map(([field, label]) => (
+                                                <div key={field}>
+                                                  <p className="text-muted-foreground">{label}</p>
+                                                  <Input
+                                                    type="number"
+                                                    step="0.0001"
+                                                    className="mt-0.5 h-6 text-xs"
+                                                    value={editDraft[field]}
+                                                    onChange={(e) =>
+                                                      setDraftField(field, e.target.value)
+                                                    }
+                                                  />
+                                                </div>
+                                              ))}
+                                            </div>
+                                            <div className="flex items-center gap-2">
+                                              <Button
+                                                size="sm"
+                                                className="h-6 gap-1"
+                                                onClick={() => void saveEdit()}
+                                                disabled={editIsSaving}
+                                              >
+                                                <Check className="h-3 w-3" />
+                                              </Button>
+                                              <Button
+                                                variant="ghost"
+                                                size="sm"
+                                                className="h-6 gap-1"
+                                                onClick={cancelEditing}
+                                              >
+                                                <X className="h-3 w-3" />
+                                              </Button>
+                                            </div>
+                                          </div>
+                                        ) : (
+                                          <div
+                                            key={rule.id}
+                                            className={cn(
+                                              "flex cursor-pointer items-center justify-between border-t border-divider/60 px-1 py-2 text-xs transition-colors hover:bg-surface-300/30",
+                                              !rule.is_active && "opacity-50"
+                                            )}
+                                            onClick={(e) => {
+                                              e.stopPropagation();
+                                              if (rule.source === "manual") {
+                                                startEditingTierRule(rule);
+                                              } else {
+                                                startEditingTierOverride(override.model, rule);
+                                              }
+                                            }}
+                                          >
+                                            <div className="space-y-0.5">
+                                              <span className="text-muted-foreground">
+                                                {t("tierRulesThresholdTokens", {
+                                                  count: rule.threshold_input_tokens / 1000,
+                                                })}
+                                              </span>
+                                              <div className="tabular-nums">
+                                                {formatPriceNumber(rule.input_price_per_million)} /{" "}
+                                                {formatPriceNumber(rule.output_price_per_million)}
+                                              </div>
+                                            </div>
+                                            <div
+                                              className="flex items-center gap-1"
+                                              onClick={(e) => e.stopPropagation()}
+                                            >
+                                              <Badge
+                                                variant={
+                                                  rule.source === "manual" ? "success" : "neutral"
+                                                }
+                                              >
+                                                {rule.source === "manual"
+                                                  ? t("tierRulesSourceManual")
+                                                  : t("tierRulesSourceLitellm")}
+                                              </Badge>
+                                              {rule.source === "manual" && (
+                                                <>
+                                                  <Switch
+                                                    checked={rule.is_active}
+                                                    onCheckedChange={(checked) =>
+                                                      updateTierRule.mutate({
+                                                        id: rule.id,
+                                                        data: { is_active: checked },
+                                                      })
+                                                    }
+                                                    disabled={updateTierRule.isPending}
+                                                  />
+                                                  <Button
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    className="h-6 w-6"
+                                                    onClick={() => deleteTierRule.mutate(rule.id)}
+                                                    disabled={deleteTierRule.isPending}
+                                                  >
+                                                    <Trash2 className="h-3 w-3" />
+                                                  </Button>
+                                                </>
+                                              )}
+                                            </div>
+                                          </div>
+                                        );
+                                      })}
+                                    </div>
+                                  )}
+                                </div>
+                              );
+                            })()}
+                          </div>
                         </div>
-                        <div className="min-w-0 flex-1 space-y-2">
+                      </div>
+                    ))}
+
+                    {priceCatalogTierOnlyModels.map((model) => {
+                      const modelTiers = allTierRulesMap.get(model);
+                      const isOpen = expandedPriceRows.has(model);
+                      return (
+                        <div
+                          key={model}
+                          className="rounded-cf-sm border border-divider bg-surface-300/30 p-3"
+                        >
                           <div className="flex items-start justify-between gap-2">
                             <div className="min-w-0">
-                              <p className="break-all font-mono text-sm text-foreground">
-                                {override.model}
-                              </p>
-                              <div className="mt-1 flex flex-wrap items-center gap-2">
-                                <Badge variant="success">{t("priceCatalogEffectiveManual")}</Badge>
-                                {allTierRulesMap.has(override.model) && (
-                                  <Badge variant="neutral">{t("tierRulesTitle")}</Badge>
-                                )}
-                                {override.has_official_price === false && (
-                                  <Badge variant="warning">
-                                    {t("priceCatalogNoOfficialPrice")}
-                                  </Badge>
-                                )}
+                              <p className="break-all font-mono text-sm text-foreground">{model}</p>
+                              <div className="mt-1">
+                                <Badge variant="neutral">{t("tierRulesTitle")}</Badge>
                               </div>
-                              {tierRuleThresholdMap.has(override.model) && (
-                                <p className="mt-1 text-[11px] text-muted-foreground">
-                                  {t("tierRulesThreshold")}:{" "}
-                                  {tierRuleThresholdMap.get(override.model)}
-                                </p>
-                              )}
                             </div>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="h-8 w-8 shrink-0"
-                              onClick={() => openResetDialog([override.model])}
-                              disabled={resetOverrides.isPending}
-                              title={
-                                override.has_official_price === false
-                                  ? t("priceCatalogDeleteManualPrice")
-                                  : t("priceCatalogResetToOfficial")
-                              }
-                            >
-                              <RotateCcw className="h-4 w-4" aria-hidden="true" />
-                              <span className="sr-only">
-                                {override.has_official_price === false
-                                  ? t("priceCatalogDeleteManualPrice")
-                                  : t("priceCatalogResetToOfficial")}
-                              </span>
-                            </Button>
                           </div>
-
-                          {isEditingPrice(override.model) ? (
-                            <div className="space-y-2" onClick={(e) => e.stopPropagation()}>
-                              <div className="grid grid-cols-2 gap-2 text-xs">
-                                {(
-                                  [
-                                    ["input", t("priceCatalogInputPrice")],
-                                    ["output", t("priceCatalogOutputPrice")],
-                                    ["cacheRead", t("priceCatalogCacheReadPrice")],
-                                    ["cacheWrite", t("priceCatalogCacheWritePrice")],
-                                  ] as const
-                                ).map(([field, label]) => (
-                                  <div
-                                    key={field}
-                                    className="rounded-cf-sm border border-divider bg-surface-200/40 px-2 py-1.5"
-                                  >
-                                    <p className="text-muted-foreground">{label}</p>
-                                    <Input
-                                      type="number"
-                                      step="0.0001"
-                                      className="mt-0.5 h-6 text-xs"
-                                      value={editDraft[field]}
-                                      onChange={(e) => setDraftField(field, e.target.value)}
-                                    />
-                                  </div>
-                                ))}
-                              </div>
-                              <div className="flex items-center gap-2">
-                                <span className="shrink-0 text-[11px] text-muted-foreground">
-                                  {t("overrideNote")}
-                                </span>
-                                <Input
-                                  className="h-7 text-xs"
-                                  value={editDraft.note}
-                                  onChange={(e) => setDraftField("note", e.target.value)}
-                                />
-                              </div>
-                              <div className="flex items-center gap-2">
-                                <Button
-                                  size="sm"
-                                  className="h-7 gap-1"
-                                  onClick={() => void saveEdit()}
-                                  disabled={editIsSaving}
-                                >
-                                  <Check className="h-3 w-3" />
-                                </Button>
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  className="h-7 gap-1"
-                                  onClick={cancelEditing}
-                                >
-                                  <X className="h-3 w-3" />
-                                </Button>
-                              </div>
-                            </div>
-                          ) : (
-                            <div
-                              className="grid cursor-pointer grid-cols-2 gap-2 rounded-cf-sm text-xs transition-colors"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                startEditingPrice(override.model, override);
-                              }}
-                              role="button"
-                              tabIndex={0}
-                            >
-                              <div className="rounded-cf-sm border border-divider bg-surface-200/40 px-2 py-1.5">
-                                <p className="text-muted-foreground">
-                                  {t("priceCatalogInputPrice")}
-                                </p>
-                                <p className="mt-0.5 text-right font-medium tabular-nums text-foreground">
-                                  {formatPriceNumber(override.input_price_per_million)}
-                                </p>
-                              </div>
-                              <div className="rounded-cf-sm border border-divider bg-surface-200/40 px-2 py-1.5">
-                                <p className="text-muted-foreground">
-                                  {t("priceCatalogOutputPrice")}
-                                </p>
-                                <p className="mt-0.5 text-right font-medium tabular-nums text-foreground">
-                                  {formatPriceNumber(override.output_price_per_million)}
-                                </p>
-                              </div>
-                              <div className="rounded-cf-sm border border-divider bg-surface-200/40 px-2 py-1.5">
-                                <p className="text-muted-foreground">
-                                  {t("priceCatalogCacheReadPrice")}
-                                </p>
-                                <p className="mt-0.5 text-right font-medium tabular-nums text-foreground">
-                                  {formatPriceNumber(override.cache_read_input_price_per_million)}
-                                </p>
-                              </div>
-                              <div className="rounded-cf-sm border border-divider bg-surface-200/40 px-2 py-1.5">
-                                <p className="text-muted-foreground">
-                                  {t("priceCatalogCacheWritePrice")}
-                                </p>
-                                <p className="mt-0.5 text-right font-medium tabular-nums text-foreground">
-                                  {formatPriceNumber(override.cache_write_input_price_per_million)}
-                                </p>
-                              </div>
-                            </div>
-                          )}
-
                           {(() => {
-                            const modelTiers = allTierRulesMap.get(override.model);
-                            const hasMobileTiers = !!modelTiers && modelTiers.length > 0;
-                            const isOpen = expandedPriceRows.has(override.model);
-                            if (!hasMobileTiers) return null;
+                            if (!modelTiers || modelTiers.length === 0) return null;
                             return (
                               <div className="mt-2">
                                 <button
                                   type="button"
                                   className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-                                  onClick={() => togglePriceRow(override.model)}
+                                  onClick={() => togglePriceRow(model)}
                                 >
                                   <ExpandChevron expanded={isOpen} className="h-3 w-3" />
                                   {t("priceCatalogTiersCount", { count: modelTiers.length })}
@@ -1532,13 +1710,13 @@ export default function BillingPage() {
                                         rule.source === "manual"
                                           ? isEditingTierRule(rule.id)
                                           : isEditingTierOverride(
-                                              override.model,
+                                              model,
                                               rule.threshold_input_tokens
                                             );
                                       return isTierEditing ? (
                                         <div
                                           key={rule.id}
-                                          className="space-y-2 rounded-cf-sm border border-divider/60 bg-surface-200/30 px-2 py-1.5 text-xs"
+                                          className="space-y-2 border-t border-divider/60 pt-2 text-xs"
                                           onClick={(e) => e.stopPropagation()}
                                         >
                                           <span className="text-muted-foreground">
@@ -1565,6 +1743,7 @@ export default function BillingPage() {
                                                   onChange={(e) =>
                                                     setDraftField(field, e.target.value)
                                                   }
+                                                  onKeyDown={editKeyDown}
                                                 />
                                               </div>
                                             ))}
@@ -1592,7 +1771,7 @@ export default function BillingPage() {
                                         <div
                                           key={rule.id}
                                           className={cn(
-                                            "flex cursor-pointer items-center justify-between rounded-cf-sm border border-divider/60 bg-surface-200/30 px-2 py-1.5 text-xs transition-colors hover:bg-surface-300/40",
+                                            "flex cursor-pointer items-center justify-between border-t border-divider/60 px-1 py-2 text-xs transition-colors hover:bg-surface-300/30",
                                             !rule.is_active && "opacity-50"
                                           )}
                                           onClick={(e) => {
@@ -1600,7 +1779,7 @@ export default function BillingPage() {
                                             if (rule.source === "manual") {
                                               startEditingTierRule(rule);
                                             } else {
-                                              startEditingTierOverride(override.model, rule);
+                                              startEditingTierOverride(model, rule);
                                             }
                                           }}
                                         >
@@ -1661,1168 +1840,350 @@ export default function BillingPage() {
                             );
                           })()}
                         </div>
-                      </div>
-                    </div>
-                  ))}
+                      );
+                    })}
 
-                  {priceCatalogTierOnlyModels.map((model) => {
-                    const modelTiers = allTierRulesMap.get(model);
-                    const isOpen = expandedPriceRows.has(model);
-                    return (
-                      <div
-                        key={model}
-                        className="rounded-cf-sm border border-divider bg-surface-300/30 p-3"
-                      >
-                        <div className="flex items-start justify-between gap-2">
-                          <div className="min-w-0">
-                            <p className="break-all font-mono text-sm text-foreground">{model}</p>
-                            <div className="mt-1">
-                              <Badge variant="neutral">{t("tierRulesTitle")}</Badge>
+                    {priceCatalogVisibleSyncedItems.map((item: BillingModelPrice) => {
+                      const override = manualOverrideMap.get(item.model);
+                      const effective = override
+                        ? {
+                            input: override.input_price_per_million,
+                            output: override.output_price_per_million,
+                            cacheRead: override.cache_read_input_price_per_million,
+                            cacheWrite: override.cache_write_input_price_per_million,
+                          }
+                        : {
+                            input: item.input_price_per_million,
+                            output: item.output_price_per_million,
+                            cacheRead: item.cache_read_input_price_per_million,
+                            cacheWrite: item.cache_write_input_price_per_million,
+                          };
+
+                      const renderCardPrice = (options: {
+                        effectiveValue: number | null;
+                        syncedValue: number | null;
+                        showSynced: boolean;
+                      }) => {
+                        const { effectiveValue, syncedValue, showSynced } = options;
+                        if (effectiveValue == null) {
+                          return <span className="text-muted-foreground">-</span>;
+                        }
+                        if (!showSynced) {
+                          return (
+                            <span className="tabular-nums font-medium text-foreground">
+                              {effectiveValue.toFixed(4)}
+                            </span>
+                          );
+                        }
+                        const syncedLabel = syncedValue == null ? "-" : syncedValue.toFixed(4);
+                        return (
+                          <div className="space-y-0.5 text-right">
+                            <div className="tabular-nums font-medium text-foreground">
+                              {effectiveValue.toFixed(4)}
+                            </div>
+                            <div className="text-[11px] tabular-nums text-muted-foreground">
+                              litellm: {syncedLabel}
                             </div>
                           </div>
-                        </div>
-                        {(() => {
-                          if (!modelTiers || modelTiers.length === 0) return null;
-                          return (
-                            <div className="mt-2">
-                              <button
-                                type="button"
-                                className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-                                onClick={() => togglePriceRow(model)}
-                              >
-                                <ExpandChevron expanded={isOpen} className="h-3 w-3" />
-                                {t("priceCatalogTiersCount", { count: modelTiers.length })}
-                              </button>
-                              {isOpen && (
-                                <div className="mt-2 space-y-1.5">
-                                  {modelTiers.map((rule) => {
-                                    const isTierEditing =
-                                      rule.source === "manual"
-                                        ? isEditingTierRule(rule.id)
-                                        : isEditingTierOverride(model, rule.threshold_input_tokens);
-                                    return isTierEditing ? (
-                                      <div
-                                        key={rule.id}
-                                        className="space-y-2 rounded-cf-sm border border-divider/60 bg-surface-200/30 px-2 py-1.5 text-xs"
-                                        onClick={(e) => e.stopPropagation()}
-                                      >
-                                        <span className="text-muted-foreground">
-                                          {t("tierRulesThresholdTokens", {
-                                            count: rule.threshold_input_tokens / 1000,
-                                          })}
-                                        </span>
-                                        <div className="grid grid-cols-2 gap-2">
-                                          {(
-                                            [
-                                              ["input", t("priceCatalogInputPrice")],
-                                              ["output", t("priceCatalogOutputPrice")],
-                                              ["cacheRead", t("priceCatalogCacheReadPrice")],
-                                              ["cacheWrite", t("priceCatalogCacheWritePrice")],
-                                            ] as const
-                                          ).map(([field, label]) => (
-                                            <div key={field}>
-                                              <p className="text-muted-foreground">{label}</p>
-                                              <Input
-                                                type="number"
-                                                step="0.0001"
-                                                className="mt-0.5 h-6 text-xs"
-                                                value={editDraft[field]}
-                                                onChange={(e) =>
-                                                  setDraftField(field, e.target.value)
-                                                }
-                                                onKeyDown={editKeyDown}
-                                              />
-                                            </div>
-                                          ))}
-                                        </div>
-                                        <div className="flex items-center gap-2">
-                                          <Button
-                                            size="sm"
-                                            className="h-6 gap-1"
-                                            onClick={() => void saveEdit()}
-                                            disabled={editIsSaving}
-                                          >
-                                            <Check className="h-3 w-3" />
-                                          </Button>
-                                          <Button
-                                            variant="ghost"
-                                            size="sm"
-                                            className="h-6 gap-1"
-                                            onClick={cancelEditing}
-                                          >
-                                            <X className="h-3 w-3" />
-                                          </Button>
-                                        </div>
-                                      </div>
-                                    ) : (
-                                      <div
-                                        key={rule.id}
-                                        className={cn(
-                                          "flex cursor-pointer items-center justify-between rounded-cf-sm border border-divider/60 bg-surface-200/30 px-2 py-1.5 text-xs transition-colors hover:bg-surface-300/40",
-                                          !rule.is_active && "opacity-50"
-                                        )}
-                                        onClick={(e) => {
-                                          e.stopPropagation();
-                                          if (rule.source === "manual") {
-                                            startEditingTierRule(rule);
-                                          } else {
-                                            startEditingTierOverride(model, rule);
-                                          }
-                                        }}
-                                      >
-                                        <div className="space-y-0.5">
-                                          <span className="text-muted-foreground">
-                                            {t("tierRulesThresholdTokens", {
-                                              count: rule.threshold_input_tokens / 1000,
-                                            })}
-                                          </span>
-                                          <div className="tabular-nums">
-                                            {formatPriceNumber(rule.input_price_per_million)} /{" "}
-                                            {formatPriceNumber(rule.output_price_per_million)}
-                                          </div>
-                                        </div>
-                                        <div
-                                          className="flex items-center gap-1"
-                                          onClick={(e) => e.stopPropagation()}
-                                        >
-                                          <Badge
-                                            variant={
-                                              rule.source === "manual" ? "success" : "neutral"
-                                            }
-                                          >
-                                            {rule.source === "manual"
-                                              ? t("tierRulesSourceManual")
-                                              : t("tierRulesSourceLitellm")}
-                                          </Badge>
-                                          {rule.source === "manual" && (
-                                            <>
-                                              <Switch
-                                                checked={rule.is_active}
-                                                onCheckedChange={(checked) =>
-                                                  updateTierRule.mutate({
-                                                    id: rule.id,
-                                                    data: { is_active: checked },
-                                                  })
-                                                }
-                                                disabled={updateTierRule.isPending}
-                                              />
-                                              <Button
-                                                variant="ghost"
-                                                size="icon"
-                                                className="h-6 w-6"
-                                                onClick={() => deleteTierRule.mutate(rule.id)}
-                                                disabled={deleteTierRule.isPending}
-                                              >
-                                                <Trash2 className="h-3 w-3" />
-                                              </Button>
-                                            </>
-                                          )}
-                                        </div>
-                                      </div>
-                                    );
-                                  })}
-                                </div>
+                        );
+                      };
+
+                      return (
+                        <div
+                          key={item.id}
+                          className={[
+                            "rounded-cf-sm border border-divider bg-surface-300/30 p-3",
+                            recentlySavedModel === item.model ? "ring-1 ring-amber-500/50" : "",
+                          ].join(" ")}
+                        >
+                          <div className="flex items-start gap-3">
+                            <div className="pt-0.5">
+                              {override ? (
+                                <Checkbox
+                                  checked={selectedResetModels.includes(item.model)}
+                                  onCheckedChange={(value) =>
+                                    toggleSelectedResetModel(item.model, value === true)
+                                  }
+                                  aria-label={t("priceCatalogSelectModel", { model: item.model })}
+                                />
+                              ) : (
+                                <span className="sr-only">-</span>
                               )}
                             </div>
-                          );
-                        })()}
-                      </div>
-                    );
-                  })}
-
-                  {priceCatalogVisibleSyncedItems.map((item: BillingModelPrice) => {
-                    const override = manualOverrideMap.get(item.model);
-                    const effective = override
-                      ? {
-                          input: override.input_price_per_million,
-                          output: override.output_price_per_million,
-                          cacheRead: override.cache_read_input_price_per_million,
-                          cacheWrite: override.cache_write_input_price_per_million,
-                        }
-                      : {
-                          input: item.input_price_per_million,
-                          output: item.output_price_per_million,
-                          cacheRead: item.cache_read_input_price_per_million,
-                          cacheWrite: item.cache_write_input_price_per_million,
-                        };
-
-                    const renderCardPrice = (options: {
-                      effectiveValue: number | null;
-                      syncedValue: number | null;
-                      showSynced: boolean;
-                    }) => {
-                      const { effectiveValue, syncedValue, showSynced } = options;
-                      if (effectiveValue == null) {
-                        return <span className="text-muted-foreground">-</span>;
-                      }
-                      if (!showSynced) {
-                        return (
-                          <span className="tabular-nums font-medium text-foreground">
-                            {effectiveValue.toFixed(4)}
-                          </span>
-                        );
-                      }
-                      const syncedLabel = syncedValue == null ? "-" : syncedValue.toFixed(4);
-                      return (
-                        <div className="space-y-0.5 text-right">
-                          <div className="tabular-nums font-medium text-foreground">
-                            {effectiveValue.toFixed(4)}
-                          </div>
-                          <div className="text-[11px] tabular-nums text-muted-foreground">
-                            litellm: {syncedLabel}
-                          </div>
-                        </div>
-                      );
-                    };
-
-                    return (
-                      <div
-                        key={item.id}
-                        className={[
-                          "rounded-cf-sm border border-divider bg-surface-300/30 p-3",
-                          recentlySavedModel === item.model ? "ring-1 ring-amber-500/50" : "",
-                        ].join(" ")}
-                      >
-                        <div className="flex items-start gap-3">
-                          <div className="pt-0.5">
-                            {override ? (
-                              <Checkbox
-                                checked={selectedResetModels.includes(item.model)}
-                                onCheckedChange={(value) =>
-                                  toggleSelectedResetModel(item.model, value === true)
-                                }
-                                aria-label={t("priceCatalogSelectModel", { model: item.model })}
-                              />
-                            ) : (
-                              <span className="sr-only">-</span>
-                            )}
-                          </div>
-                          <div className="min-w-0 flex-1 space-y-2">
-                            <div className="flex items-start justify-between gap-2">
-                              <div className="min-w-0">
-                                <p className="break-all font-mono text-sm text-foreground">
-                                  {item.model}
-                                </p>
-                                <div className="mt-1 flex flex-wrap items-center gap-2">
-                                  <Badge variant={override ? "success" : "neutral"}>
-                                    {override
-                                      ? t("priceCatalogEffectiveManual")
-                                      : t("priceCatalogEffectiveSynced")}
-                                  </Badge>
-                                  {allTierRulesMap.has(item.model) && (
-                                    <Badge variant="neutral">{t("tierRulesTitle")}</Badge>
+                            <div className="min-w-0 flex-1 space-y-2">
+                              <div className="flex items-start justify-between gap-2">
+                                <div className="min-w-0">
+                                  <p className="break-all font-mono text-sm text-foreground">
+                                    {item.model}
+                                  </p>
+                                  <div className="mt-1 flex flex-wrap items-center gap-2">
+                                    <Badge variant={override ? "success" : "neutral"}>
+                                      {override
+                                        ? t("priceCatalogEffectiveManual")
+                                        : t("priceCatalogEffectiveSynced")}
+                                    </Badge>
+                                    {allTierRulesMap.has(item.model) && (
+                                      <Badge variant="neutral">{t("tierRulesTitle")}</Badge>
+                                    )}
+                                  </div>
+                                  {tierRuleThresholdMap.has(item.model) && (
+                                    <p className="mt-1 text-[11px] text-muted-foreground">
+                                      {t("tierRulesThreshold")}:{" "}
+                                      {tierRuleThresholdMap.get(item.model)}
+                                    </p>
+                                  )}
+                                  {(item.max_input_tokens != null ||
+                                    item.max_output_tokens != null) && (
+                                    <p className="mt-1 text-[11px] text-muted-foreground">
+                                      {item.max_input_tokens != null &&
+                                        `${t("priceCatalogMaxInput")}: ${item.max_input_tokens.toLocaleString()} · `}
+                                      {item.max_output_tokens != null &&
+                                        `${t("priceCatalogMaxOutput")}: ${item.max_output_tokens.toLocaleString()}`}
+                                    </p>
                                   )}
                                 </div>
-                                {tierRuleThresholdMap.has(item.model) && (
-                                  <p className="mt-1 text-[11px] text-muted-foreground">
-                                    {t("tierRulesThreshold")}:{" "}
-                                    {tierRuleThresholdMap.get(item.model)}
-                                  </p>
-                                )}
-                                {(item.max_input_tokens != null ||
-                                  item.max_output_tokens != null) && (
-                                  <p className="mt-1 text-[11px] text-muted-foreground">
-                                    {item.max_input_tokens != null &&
-                                      `${t("priceCatalogMaxInput")}: ${item.max_input_tokens.toLocaleString()} · `}
-                                    {item.max_output_tokens != null &&
-                                      `${t("priceCatalogMaxOutput")}: ${item.max_output_tokens.toLocaleString()}`}
-                                  </p>
-                                )}
-                              </div>
-                              {override ? (
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="h-8 w-8 shrink-0"
-                                  onClick={() => openResetDialog([item.model])}
-                                  disabled={resetOverrides.isPending}
-                                  title={t("priceCatalogResetToOfficial")}
-                                >
-                                  <RotateCcw className="h-4 w-4" aria-hidden="true" />
-                                  <span className="sr-only">
-                                    {t("priceCatalogResetToOfficial")}
-                                  </span>
-                                </Button>
-                              ) : null}
-                            </div>
-
-                            {isEditingPrice(item.model) ? (
-                              <div className="space-y-2" onClick={(e) => e.stopPropagation()}>
-                                <div className="grid grid-cols-2 gap-2 text-xs">
-                                  {(
-                                    [
-                                      ["input", t("priceCatalogInputPrice")],
-                                      ["output", t("priceCatalogOutputPrice")],
-                                      ["cacheRead", t("priceCatalogCacheReadPrice")],
-                                      ["cacheWrite", t("priceCatalogCacheWritePrice")],
-                                    ] as const
-                                  ).map(([field, label]) => (
-                                    <div
-                                      key={field}
-                                      className="rounded-cf-sm border border-divider bg-surface-200/40 px-2 py-1.5"
-                                    >
-                                      <p className="text-muted-foreground">{label}</p>
-                                      <Input
-                                        type="number"
-                                        step="0.0001"
-                                        className="mt-0.5 h-6 text-xs"
-                                        value={editDraft[field]}
-                                        onChange={(e) => setDraftField(field, e.target.value)}
-                                      />
-                                    </div>
-                                  ))}
-                                </div>
-                                <Input
-                                  placeholder="Note"
-                                  className="h-7 text-xs"
-                                  value={editDraft.note}
-                                  onChange={(e) => setDraftField("note", e.target.value)}
-                                />
-                                <div className="flex items-center gap-2">
-                                  <Button
-                                    size="sm"
-                                    className="h-7 gap-1"
-                                    onClick={() => void saveEdit()}
-                                    disabled={editIsSaving}
-                                  >
-                                    <Check className="h-3 w-3" />
-                                  </Button>
+                                {override ? (
                                   <Button
                                     variant="ghost"
-                                    size="sm"
-                                    className="h-7 gap-1"
-                                    onClick={cancelEditing}
+                                    size="icon"
+                                    className="h-8 w-8 shrink-0"
+                                    onClick={() => openResetDialog([item.model])}
+                                    disabled={resetOverrides.isPending}
+                                    title={t("priceCatalogResetToOfficial")}
                                   >
-                                    <X className="h-3 w-3" />
+                                    <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                                    <span className="sr-only">
+                                      {t("priceCatalogResetToOfficial")}
+                                    </span>
                                   </Button>
-                                </div>
+                                ) : null}
                               </div>
-                            ) : (
-                              <div
-                                className="grid cursor-pointer grid-cols-2 gap-2 rounded-cf-sm text-xs transition-colors"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  startEditingPrice(item.model, override);
-                                }}
-                                role="button"
-                                tabIndex={0}
-                              >
-                                <div className="rounded-cf-sm border border-divider bg-surface-200/40 px-2 py-1.5">
-                                  <p className="text-muted-foreground">
-                                    {t("priceCatalogInputPrice")}
-                                  </p>
-                                  <div className="mt-0.5">
-                                    {renderCardPrice({
-                                      effectiveValue: effective.input,
-                                      syncedValue: item.input_price_per_million,
-                                      showSynced: !!override,
-                                    })}
-                                  </div>
-                                </div>
-                                <div className="rounded-cf-sm border border-divider bg-surface-200/40 px-2 py-1.5">
-                                  <p className="text-muted-foreground">
-                                    {t("priceCatalogOutputPrice")}
-                                  </p>
-                                  <div className="mt-0.5">
-                                    {renderCardPrice({
-                                      effectiveValue: effective.output,
-                                      syncedValue: item.output_price_per_million,
-                                      showSynced: !!override,
-                                    })}
-                                  </div>
-                                </div>
-                                <div className="rounded-cf-sm border border-divider bg-surface-200/40 px-2 py-1.5">
-                                  <p className="text-muted-foreground">
-                                    {t("priceCatalogCacheReadPrice")}
-                                  </p>
-                                  <div className="mt-0.5">
-                                    {renderCardPrice({
-                                      effectiveValue: effective.cacheRead,
-                                      syncedValue: item.cache_read_input_price_per_million,
-                                      showSynced: !!override,
-                                    })}
-                                  </div>
-                                </div>
-                                <div className="rounded-cf-sm border border-divider bg-surface-200/40 px-2 py-1.5">
-                                  <p className="text-muted-foreground">
-                                    {t("priceCatalogCacheWritePrice")}
-                                  </p>
-                                  <div className="mt-0.5">
-                                    {renderCardPrice({
-                                      effectiveValue: effective.cacheWrite,
-                                      syncedValue: item.cache_write_input_price_per_million,
-                                      showSynced: !!override,
-                                    })}
-                                  </div>
-                                </div>
-                              </div>
-                            )}
 
-                            {(() => {
-                              const modelTiers = allTierRulesMap.get(item.model);
-                              const hasMobileTiers = !!modelTiers && modelTiers.length > 0;
-                              const isOpen = expandedPriceRows.has(item.model);
-                              if (!hasMobileTiers) return null;
-                              return (
-                                <div>
-                                  <button
-                                    type="button"
-                                    className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-                                    onClick={() => togglePriceRow(item.model)}
-                                  >
-                                    <ExpandChevron expanded={isOpen} className="h-3 w-3" />
-                                    {t("priceCatalogTiersCount", { count: modelTiers.length })}
-                                  </button>
-                                  {isOpen && (
-                                    <div className="mt-2 space-y-1.5">
-                                      {modelTiers.map((rule) => {
-                                        const isTierEditing =
-                                          rule.source === "manual"
-                                            ? isEditingTierRule(rule.id)
-                                            : isEditingTierOverride(
-                                                item.model,
-                                                rule.threshold_input_tokens
-                                              );
-                                        return isTierEditing ? (
-                                          <div
-                                            key={rule.id}
-                                            className="space-y-2 rounded-cf-sm border border-divider/60 bg-surface-200/30 px-2 py-1.5 text-xs"
-                                            onClick={(e) => e.stopPropagation()}
-                                          >
-                                            <span className="text-muted-foreground">
-                                              {t("tierRulesThresholdTokens", {
-                                                count: rule.threshold_input_tokens / 1000,
-                                              })}
-                                            </span>
-                                            <div className="grid grid-cols-2 gap-2">
-                                              {(
-                                                [
-                                                  ["input", t("priceCatalogInputPrice")],
-                                                  ["output", t("priceCatalogOutputPrice")],
-                                                  ["cacheRead", t("priceCatalogCacheReadPrice")],
-                                                  ["cacheWrite", t("priceCatalogCacheWritePrice")],
-                                                ] as const
-                                              ).map(([field, label]) => (
-                                                <div key={field}>
-                                                  <p className="text-muted-foreground">{label}</p>
-                                                  <Input
-                                                    type="number"
-                                                    step="0.0001"
-                                                    className="mt-0.5 h-6 text-xs"
-                                                    value={editDraft[field]}
-                                                    onChange={(e) =>
-                                                      setDraftField(field, e.target.value)
-                                                    }
-                                                  />
-                                                </div>
-                                              ))}
-                                            </div>
-                                            <div className="flex items-center gap-2">
-                                              <Button
-                                                size="sm"
-                                                className="h-6 gap-1"
-                                                onClick={() => void saveEdit()}
-                                                disabled={editIsSaving}
-                                              >
-                                                <Check className="h-3 w-3" />
-                                              </Button>
-                                              <Button
-                                                variant="ghost"
-                                                size="sm"
-                                                className="h-6 gap-1"
-                                                onClick={cancelEditing}
-                                              >
-                                                <X className="h-3 w-3" />
-                                              </Button>
-                                            </div>
-                                          </div>
-                                        ) : (
-                                          <div
-                                            key={rule.id}
-                                            className={cn(
-                                              "flex cursor-pointer items-center justify-between rounded-cf-sm border border-divider/60 bg-surface-200/30 px-2 py-1.5 text-xs transition-colors hover:bg-surface-300/40",
-                                              !rule.is_active && "opacity-50"
-                                            )}
-                                            onClick={(e) => {
-                                              e.stopPropagation();
-                                              if (rule.source === "manual") {
-                                                startEditingTierRule(rule);
-                                              } else {
-                                                startEditingTierOverride(item.model, rule);
-                                              }
-                                            }}
-                                          >
-                                            <div className="space-y-0.5">
+                              {isEditingPrice(item.model) ? (
+                                <div className="space-y-2" onClick={(e) => e.stopPropagation()}>
+                                  <div className="grid grid-cols-2 gap-2 text-xs">
+                                    {(
+                                      [
+                                        ["input", t("priceCatalogInputPrice")],
+                                        ["output", t("priceCatalogOutputPrice")],
+                                        ["cacheRead", t("priceCatalogCacheReadPrice")],
+                                        ["cacheWrite", t("priceCatalogCacheWritePrice")],
+                                      ] as const
+                                    ).map(([field, label]) => (
+                                      <div
+                                        key={field}
+                                        className="rounded-cf-sm bg-surface-200/45 px-2 py-1.5"
+                                      >
+                                        <p className="text-muted-foreground">{label}</p>
+                                        <Input
+                                          type="number"
+                                          step="0.0001"
+                                          className="mt-0.5 h-6 text-xs"
+                                          value={editDraft[field]}
+                                          onChange={(e) => setDraftField(field, e.target.value)}
+                                        />
+                                      </div>
+                                    ))}
+                                  </div>
+                                  <Input
+                                    placeholder="Note"
+                                    className="h-7 text-xs"
+                                    value={editDraft.note}
+                                    onChange={(e) => setDraftField("note", e.target.value)}
+                                  />
+                                  <div className="flex items-center gap-2">
+                                    <Button
+                                      size="sm"
+                                      className="h-7 gap-1"
+                                      onClick={() => void saveEdit()}
+                                      disabled={editIsSaving}
+                                    >
+                                      <Check className="h-3 w-3" />
+                                    </Button>
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      className="h-7 gap-1"
+                                      onClick={cancelEditing}
+                                    >
+                                      <X className="h-3 w-3" />
+                                    </Button>
+                                  </div>
+                                </div>
+                              ) : (
+                                <div
+                                  className="grid cursor-pointer grid-cols-2 gap-2 rounded-cf-sm text-xs transition-colors"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    startEditingPrice(item.model, override);
+                                  }}
+                                  role="button"
+                                  tabIndex={0}
+                                >
+                                  <div className="rounded-cf-sm bg-surface-200/45 px-2 py-1.5">
+                                    <p className="text-muted-foreground">
+                                      {t("priceCatalogInputPrice")}
+                                    </p>
+                                    <div className="mt-0.5">
+                                      {renderCardPrice({
+                                        effectiveValue: effective.input,
+                                        syncedValue: item.input_price_per_million,
+                                        showSynced: !!override,
+                                      })}
+                                    </div>
+                                  </div>
+                                  <div className="rounded-cf-sm bg-surface-200/45 px-2 py-1.5">
+                                    <p className="text-muted-foreground">
+                                      {t("priceCatalogOutputPrice")}
+                                    </p>
+                                    <div className="mt-0.5">
+                                      {renderCardPrice({
+                                        effectiveValue: effective.output,
+                                        syncedValue: item.output_price_per_million,
+                                        showSynced: !!override,
+                                      })}
+                                    </div>
+                                  </div>
+                                  <div className="rounded-cf-sm bg-surface-200/45 px-2 py-1.5">
+                                    <p className="text-muted-foreground">
+                                      {t("priceCatalogCacheReadPrice")}
+                                    </p>
+                                    <div className="mt-0.5">
+                                      {renderCardPrice({
+                                        effectiveValue: effective.cacheRead,
+                                        syncedValue: item.cache_read_input_price_per_million,
+                                        showSynced: !!override,
+                                      })}
+                                    </div>
+                                  </div>
+                                  <div className="rounded-cf-sm bg-surface-200/45 px-2 py-1.5">
+                                    <p className="text-muted-foreground">
+                                      {t("priceCatalogCacheWritePrice")}
+                                    </p>
+                                    <div className="mt-0.5">
+                                      {renderCardPrice({
+                                        effectiveValue: effective.cacheWrite,
+                                        syncedValue: item.cache_write_input_price_per_million,
+                                        showSynced: !!override,
+                                      })}
+                                    </div>
+                                  </div>
+                                </div>
+                              )}
+
+                              {(() => {
+                                const modelTiers = allTierRulesMap.get(item.model);
+                                const hasMobileTiers = !!modelTiers && modelTiers.length > 0;
+                                const isOpen = expandedPriceRows.has(item.model);
+                                if (!hasMobileTiers) return null;
+                                return (
+                                  <div>
+                                    <button
+                                      type="button"
+                                      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                                      onClick={() => togglePriceRow(item.model)}
+                                    >
+                                      <ExpandChevron expanded={isOpen} className="h-3 w-3" />
+                                      {t("priceCatalogTiersCount", { count: modelTiers.length })}
+                                    </button>
+                                    {isOpen && (
+                                      <div className="mt-2 space-y-1.5">
+                                        {modelTiers.map((rule) => {
+                                          const isTierEditing =
+                                            rule.source === "manual"
+                                              ? isEditingTierRule(rule.id)
+                                              : isEditingTierOverride(
+                                                  item.model,
+                                                  rule.threshold_input_tokens
+                                                );
+                                          return isTierEditing ? (
+                                            <div
+                                              key={rule.id}
+                                              className="space-y-2 border-t border-divider/60 pt-2 text-xs"
+                                              onClick={(e) => e.stopPropagation()}
+                                            >
                                               <span className="text-muted-foreground">
                                                 {t("tierRulesThresholdTokens", {
                                                   count: rule.threshold_input_tokens / 1000,
                                                 })}
                                               </span>
-                                              <div className="tabular-nums">
-                                                {formatPriceNumber(rule.input_price_per_million)} /{" "}
-                                                {formatPriceNumber(rule.output_price_per_million)}
+                                              <div className="grid grid-cols-2 gap-2">
+                                                {(
+                                                  [
+                                                    ["input", t("priceCatalogInputPrice")],
+                                                    ["output", t("priceCatalogOutputPrice")],
+                                                    ["cacheRead", t("priceCatalogCacheReadPrice")],
+                                                    [
+                                                      "cacheWrite",
+                                                      t("priceCatalogCacheWritePrice"),
+                                                    ],
+                                                  ] as const
+                                                ).map(([field, label]) => (
+                                                  <div key={field}>
+                                                    <p className="text-muted-foreground">{label}</p>
+                                                    <Input
+                                                      type="number"
+                                                      step="0.0001"
+                                                      className="mt-0.5 h-6 text-xs"
+                                                      value={editDraft[field]}
+                                                      onChange={(e) =>
+                                                        setDraftField(field, e.target.value)
+                                                      }
+                                                    />
+                                                  </div>
+                                                ))}
+                                              </div>
+                                              <div className="flex items-center gap-2">
+                                                <Button
+                                                  size="sm"
+                                                  className="h-6 gap-1"
+                                                  onClick={() => void saveEdit()}
+                                                  disabled={editIsSaving}
+                                                >
+                                                  <Check className="h-3 w-3" />
+                                                </Button>
+                                                <Button
+                                                  variant="ghost"
+                                                  size="sm"
+                                                  className="h-6 gap-1"
+                                                  onClick={cancelEditing}
+                                                >
+                                                  <X className="h-3 w-3" />
+                                                </Button>
                                               </div>
                                             </div>
+                                          ) : (
                                             <div
-                                              className="flex items-center gap-1"
-                                              onClick={(e) => e.stopPropagation()}
-                                            >
-                                              <Badge
-                                                variant={
-                                                  rule.source === "manual" ? "success" : "neutral"
-                                                }
-                                              >
-                                                {rule.source === "manual"
-                                                  ? t("tierRulesSourceManual")
-                                                  : t("tierRulesSourceLitellm")}
-                                              </Badge>
-                                              {rule.source === "manual" && (
-                                                <>
-                                                  <Switch
-                                                    checked={rule.is_active}
-                                                    onCheckedChange={(checked) =>
-                                                      updateTierRule.mutate({
-                                                        id: rule.id,
-                                                        data: { is_active: checked },
-                                                      })
-                                                    }
-                                                    disabled={updateTierRule.isPending}
-                                                  />
-                                                  <Button
-                                                    variant="ghost"
-                                                    size="icon"
-                                                    className="h-6 w-6"
-                                                    onClick={() => deleteTierRule.mutate(rule.id)}
-                                                    disabled={deleteTierRule.isPending}
-                                                  >
-                                                    <Trash2 className="h-3 w-3" />
-                                                  </Button>
-                                                </>
-                                              )}
-                                            </div>
-                                          </div>
-                                        );
-                                      })}
-                                    </div>
-                                  )}
-                                </div>
-                              );
-                            })()}
-
-                            <p className="text-[11px] text-muted-foreground">
-                              {t("priceCatalogSyncedAt")}:{" "}
-                              {new Date(item.synced_at).toLocaleString(locale)}
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-
-                <div className="hidden w-full overflow-x-auto lg:block">
-                  <Table className="w-full min-w-[850px] text-sm">
-                    <TableHeader>
-                      <TableRow className="border-b border-divider text-left text-xs uppercase tracking-wide text-muted-foreground hover:bg-transparent">
-                        <TableHead className="w-10 px-3 py-2 h-auto">
-                          <Checkbox
-                            checked={priceCatalogHeaderSelectionState}
-                            onCheckedChange={(value) =>
-                              toggleSelectAllVisible(value === true || value === "indeterminate")
-                            }
-                            aria-label={t("priceCatalogSelectAll")}
-                            disabled={priceCatalogSelectableModels.length === 0}
-                          />
-                        </TableHead>
-                        <TableHead className="w-[220px] px-3 py-2 h-auto text-left">
-                          {t("priceCatalogModel")}
-                        </TableHead>
-                        <TableHead className="w-[88px] px-3 py-2 h-auto text-left whitespace-nowrap">
-                          {t("priceCatalogEffective")}
-                        </TableHead>
-                        <TableHead className="hidden w-[130px] px-3 py-2 h-auto text-left lg:table-cell whitespace-nowrap">
-                          {t("tierRulesThreshold")} / {t("priceCatalogMaxInput")}
-                        </TableHead>
-                        <TableHead className="w-[300px] px-3 py-2 h-auto text-left">
-                          {t("priceCatalogInputOutputPrice")} /{" "}
-                          {t("priceCatalogCacheReadWritePrice")}
-                        </TableHead>
-                        <TableHead className="hidden w-[130px] px-3 py-2 h-auto lg:table-cell text-left">
-                          {t("priceCatalogSyncedAt")}
-                        </TableHead>
-                        <TableHead className="w-[72px] px-3 py-2 h-auto text-left">
-                          {t("priceCatalogActions")}
-                        </TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {priceCatalogExtraOverrides.map((override) => {
-                        const tierPreview = tierRulePreviewMap.get(override.model);
-                        const tierPreviewLabel = tierPreview
-                          ? `>${t("tierRulesThresholdTokens", {
-                              count: tierPreview.threshold_input_tokens / 1000,
-                            })}`
-                          : null;
-                        const modelTierRules = allTierRulesMap.get(override.model);
-                        const hasTiers = !!modelTierRules && modelTierRules.length > 0;
-                        const isExpanded = expandedPriceRows.has(override.model);
-
-                        return (
-                          <Fragment key={override.id}>
-                            <TableRow
-                              className={cn(
-                                "border-b border-divider/60 align-top bg-surface-300/20",
-                                hasTiers && "cursor-pointer",
-                                recentlySavedModel === override.model && "bg-amber-500/10"
-                              )}
-                              onClick={hasTiers ? () => togglePriceRow(override.model) : undefined}
-                            >
-                              <TableCell className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
-                                <Checkbox
-                                  checked={selectedResetModels.includes(override.model)}
-                                  onCheckedChange={(value) =>
-                                    toggleSelectedResetModel(override.model, value === true)
-                                  }
-                                  aria-label={t("priceCatalogSelectModel", {
-                                    model: override.model,
-                                  })}
-                                />
-                              </TableCell>
-                              <TableCell className="px-3 py-2 font-mono">
-                                <span className="block whitespace-normal break-words leading-5">
-                                  {override.model}
-                                </span>
-                              </TableCell>
-                              <TableCell className="px-3 py-2 whitespace-nowrap">
-                                <div className="space-y-1">
-                                  <Badge variant="success">
-                                    {t("priceCatalogEffectiveManual")}
-                                  </Badge>
-                                  <p className="text-[11px] text-muted-foreground">
-                                    {t("priceCatalogSourceManual")}
-                                  </p>
-                                </div>
-                              </TableCell>
-                              <TableCell className="hidden px-3 py-2 text-xs text-muted-foreground lg:table-cell">
-                                <div className="space-y-1">
-                                  <div>{tierRuleThresholdMap.get(override.model) ?? "-"}</div>
-                                  <div>-</div>
-                                </div>
-                              </TableCell>
-                              {isEditingPrice(override.model) ? (
-                                <>
-                                  <TableCell
-                                    className="px-3 py-2"
-                                    onClick={(e) => e.stopPropagation()}
-                                  >
-                                    <div className="space-y-2">
-                                      <div className="grid grid-cols-2 gap-x-4 gap-y-1.5">
-                                        {PRICE_FIELDS_SHORT.map(([field, label]) => (
-                                          <div
-                                            key={field}
-                                            className="grid grid-cols-[24px_auto] items-center gap-2"
-                                          >
-                                            <span className="text-[11px] text-muted-foreground">
-                                              {label}
-                                            </span>
-                                            <Input
-                                              value={editDraft[field]}
-                                              onChange={(e) => setDraftField(field, e.target.value)}
-                                              className="h-7 text-xs tabular-nums"
-                                              onKeyDown={editKeyDown}
-                                            />
-                                          </div>
-                                        ))}
-                                      </div>
-                                      <div className="grid grid-cols-[24px_auto] items-center gap-2">
-                                        <span className="text-[11px] text-muted-foreground">
-                                          {t("overrideNote")}
-                                        </span>
-                                        <Input
-                                          value={editDraft.note}
-                                          onChange={(e) => setDraftField("note", e.target.value)}
-                                          className="h-7 text-xs"
-                                          onKeyDown={editKeyDown}
-                                        />
-                                      </div>
-                                    </div>
-                                  </TableCell>
-                                  <TableCell className="hidden px-3 py-2 lg:table-cell" />
-                                  <TableCell
-                                    className="px-3 py-2"
-                                    onClick={(e) => e.stopPropagation()}
-                                  >
-                                    <div className="flex items-center gap-1">
-                                      <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        className="h-8 w-8 text-green-600 hover:text-green-700"
-                                        onClick={() => void saveEdit()}
-                                        disabled={editIsSaving}
-                                      >
-                                        <Check className="h-4 w-4" />
-                                      </Button>
-                                      <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        className="h-8 w-8"
-                                        onClick={cancelEditing}
-                                      >
-                                        <X className="h-4 w-4" />
-                                      </Button>
-                                    </div>
-                                  </TableCell>
-                                </>
-                              ) : (
-                                <>
-                                  <TableCell
-                                    className="px-3 py-2 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      startEditingPrice(override.model, override);
-                                    }}
-                                  >
-                                    <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-                                      <div className="grid grid-cols-[24px_auto] items-center justify-start gap-2">
-                                        <span className="text-[11px] text-muted-foreground">
-                                          IN
-                                        </span>
-                                        <div>
-                                          <div>{override.input_price_per_million.toFixed(4)}</div>
-                                          {tierPreviewLabel ? (
-                                            <div className="text-[11px] text-muted-foreground">
-                                              {tierPreviewLabel}:{" "}
-                                              {formatPriceNumber(
-                                                tierPreview?.input_price_per_million ?? null
-                                              )}
-                                            </div>
-                                          ) : null}
-                                        </div>
-                                      </div>
-                                      <div className="grid grid-cols-[24px_auto] items-center justify-start gap-2">
-                                        <span className="text-[11px] text-muted-foreground">
-                                          CR
-                                        </span>
-                                        <div>
-                                          {override.cache_read_input_price_per_million == null
-                                            ? "-"
-                                            : override.cache_read_input_price_per_million.toFixed(
-                                                4
-                                              )}
-                                        </div>
-                                      </div>
-                                      <div className="grid grid-cols-[24px_auto] items-center justify-start gap-2">
-                                        <span className="text-[11px] text-muted-foreground">
-                                          OUT
-                                        </span>
-                                        <div>
-                                          <div>{override.output_price_per_million.toFixed(4)}</div>
-                                          {tierPreviewLabel ? (
-                                            <div className="text-[11px] text-muted-foreground">
-                                              {tierPreviewLabel}:{" "}
-                                              {formatPriceNumber(
-                                                tierPreview?.output_price_per_million ?? null
-                                              )}
-                                            </div>
-                                          ) : null}
-                                        </div>
-                                      </div>
-                                      <div className="grid grid-cols-[24px_auto] items-center justify-start gap-2">
-                                        <span className="text-[11px] text-muted-foreground">
-                                          CW
-                                        </span>
-                                        <div>
-                                          {override.cache_write_input_price_per_million == null
-                                            ? "-"
-                                            : override.cache_write_input_price_per_million.toFixed(
-                                                4
-                                              )}
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </TableCell>
-                                  <TableCell className="hidden px-3 py-2 text-xs text-muted-foreground lg:table-cell">
-                                    {new Date(override.updated_at).toLocaleString(locale)}
-                                  </TableCell>
-                                  <TableCell
-                                    className="px-3 py-2"
-                                    onClick={(e) => e.stopPropagation()}
-                                  >
-                                    <div className="flex items-center gap-1">
-                                      <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        className="h-8 w-8"
-                                        onClick={() => openResetDialog([override.model])}
-                                        disabled={resetOverrides.isPending}
-                                        title={
-                                          override.has_official_price === false
-                                            ? t("priceCatalogDeleteManualPrice")
-                                            : t("priceCatalogResetToOfficial")
-                                        }
-                                      >
-                                        <RotateCcw className="h-4 w-4" aria-hidden="true" />
-                                      </Button>
-                                      {hasTiers && (
-                                        <button
-                                          type="button"
-                                          className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-surface-300/60"
-                                          onClick={() => togglePriceRow(override.model)}
-                                          title={t(
-                                            isExpanded
-                                              ? "priceCatalogCollapseTiers"
-                                              : "priceCatalogExpandTiers"
-                                          )}
-                                        >
-                                          <ExpandChevron expanded={isExpanded} />
-                                        </button>
-                                      )}
-                                    </div>
-                                  </TableCell>
-                                </>
-                              )}
-                            </TableRow>
-                            {isExpanded && (
-                              <TableRow className="bg-surface-300/10">
-                                <TableCell colSpan={7} className="px-3 py-3">
-                                  <div className="space-y-4">
-                                    {hasTiers && modelTierRules && (
-                                      <div className="space-y-2">
-                                        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                                          {t("tierRulesTitle")} ({modelTierRules.length})
-                                        </p>
-                                        <Table className="w-full text-xs">
-                                          <TableHeader>
-                                            <TableRow className="border-b border-divider/40 text-left text-[11px] uppercase tracking-wide text-muted-foreground hover:bg-transparent">
-                                              <TableHead className="px-2 py-1 h-auto">
-                                                {t("tierRulesThreshold")}
-                                              </TableHead>
-                                              <TableHead className="px-2 py-1 h-auto">
-                                                {t("tierRulesSource")}
-                                              </TableHead>
-                                              <TableHead className="px-2 py-1 h-auto">IN</TableHead>
-                                              <TableHead className="px-2 py-1 h-auto">
-                                                OUT
-                                              </TableHead>
-                                              <TableHead className="px-2 py-1 h-auto">CR</TableHead>
-                                              <TableHead className="px-2 py-1 h-auto">CW</TableHead>
-                                              <TableHead className="px-2 py-1 h-auto">
-                                                {t("tierRulesActive")}
-                                              </TableHead>
-                                              <TableHead className="w-10 px-2 py-1 h-auto" />
-                                            </TableRow>
-                                          </TableHeader>
-                                          <TableBody>
-                                            {modelTierRules.map((rule) => {
-                                              const isTierEditing =
-                                                rule.source === "manual"
-                                                  ? isEditingTierRule(rule.id)
-                                                  : isEditingTierOverride(
-                                                      override.model,
-                                                      rule.threshold_input_tokens
-                                                    );
-                                              return (
-                                                <TableRow
-                                                  key={rule.id}
-                                                  className={cn(
-                                                    "border-b border-divider/30",
-                                                    !rule.is_active && "opacity-50"
-                                                  )}
-                                                >
-                                                  <TableCell className="px-2 py-1.5 tabular-nums">
-                                                    {t("tierRulesThresholdTokens", {
-                                                      count: rule.threshold_input_tokens / 1000,
-                                                    })}
-                                                  </TableCell>
-                                                  <TableCell className="px-2 py-1.5">
-                                                    <Badge
-                                                      variant={
-                                                        rule.source === "manual"
-                                                          ? "success"
-                                                          : "neutral"
-                                                      }
-                                                    >
-                                                      {rule.source === "manual"
-                                                        ? t("tierRulesSourceManual")
-                                                        : t("tierRulesSourceLitellm")}
-                                                    </Badge>
-                                                  </TableCell>
-                                                  {isTierEditing ? (
-                                                    <>
-                                                      <TableCell className="px-2 py-1.5">
-                                                        <Input
-                                                          value={editDraft.input}
-                                                          onChange={(e) =>
-                                                            setDraftField("input", e.target.value)
-                                                          }
-                                                          className="h-6 w-20 text-xs tabular-nums"
-                                                          onKeyDown={editKeyDown}
-                                                        />
-                                                      </TableCell>
-                                                      <TableCell className="px-2 py-1.5">
-                                                        <Input
-                                                          value={editDraft.output}
-                                                          onChange={(e) =>
-                                                            setDraftField("output", e.target.value)
-                                                          }
-                                                          className="h-6 w-20 text-xs tabular-nums"
-                                                          onKeyDown={editKeyDown}
-                                                        />
-                                                      </TableCell>
-                                                      <TableCell className="px-2 py-1.5">
-                                                        <Input
-                                                          value={editDraft.cacheRead}
-                                                          onChange={(e) =>
-                                                            setDraftField(
-                                                              "cacheRead",
-                                                              e.target.value
-                                                            )
-                                                          }
-                                                          className="h-6 w-20 text-xs tabular-nums"
-                                                          onKeyDown={editKeyDown}
-                                                        />
-                                                      </TableCell>
-                                                      <TableCell className="px-2 py-1.5">
-                                                        <Input
-                                                          value={editDraft.cacheWrite}
-                                                          onChange={(e) =>
-                                                            setDraftField(
-                                                              "cacheWrite",
-                                                              e.target.value
-                                                            )
-                                                          }
-                                                          className="h-6 w-20 text-xs tabular-nums"
-                                                          onKeyDown={editKeyDown}
-                                                        />
-                                                      </TableCell>
-                                                      <TableCell className="px-2 py-1.5" />
-                                                      <TableCell className="px-2 py-1.5">
-                                                        <div className="flex items-center gap-0.5">
-                                                          <Button
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="h-6 w-6 text-green-600 hover:text-green-700"
-                                                            onClick={() => void saveEdit()}
-                                                            disabled={editIsSaving}
-                                                          >
-                                                            <Check className="h-3 w-3" />
-                                                          </Button>
-                                                          <Button
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="h-6 w-6"
-                                                            onClick={cancelEditing}
-                                                          >
-                                                            <X className="h-3 w-3" />
-                                                          </Button>
-                                                        </div>
-                                                      </TableCell>
-                                                    </>
-                                                  ) : (
-                                                    <>
-                                                      <TableCell
-                                                        className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
-                                                        onClick={() =>
-                                                          rule.source === "manual"
-                                                            ? startEditingTierRule(rule)
-                                                            : startEditingTierOverride(
-                                                                override.model,
-                                                                rule
-                                                              )
-                                                        }
-                                                      >
-                                                        {formatPriceNumber(
-                                                          rule.input_price_per_million
-                                                        )}
-                                                      </TableCell>
-                                                      <TableCell
-                                                        className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
-                                                        onClick={() =>
-                                                          rule.source === "manual"
-                                                            ? startEditingTierRule(rule)
-                                                            : startEditingTierOverride(
-                                                                override.model,
-                                                                rule
-                                                              )
-                                                        }
-                                                      >
-                                                        {formatPriceNumber(
-                                                          rule.output_price_per_million
-                                                        )}
-                                                      </TableCell>
-                                                      <TableCell
-                                                        className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
-                                                        onClick={() =>
-                                                          rule.source === "manual"
-                                                            ? startEditingTierRule(rule)
-                                                            : startEditingTierOverride(
-                                                                override.model,
-                                                                rule
-                                                              )
-                                                        }
-                                                      >
-                                                        {formatPriceNumber(
-                                                          rule.cache_read_input_price_per_million
-                                                        )}
-                                                      </TableCell>
-                                                      <TableCell
-                                                        className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
-                                                        onClick={() =>
-                                                          rule.source === "manual"
-                                                            ? startEditingTierRule(rule)
-                                                            : startEditingTierOverride(
-                                                                override.model,
-                                                                rule
-                                                              )
-                                                        }
-                                                      >
-                                                        {formatPriceNumber(
-                                                          rule.cache_write_input_price_per_million
-                                                        )}
-                                                      </TableCell>
-                                                      <TableCell className="px-2 py-1.5">
-                                                        {rule.source === "manual" ? (
-                                                          <Switch
-                                                            checked={rule.is_active}
-                                                            onCheckedChange={(checked) =>
-                                                              updateTierRule.mutate({
-                                                                id: rule.id,
-                                                                data: { is_active: checked },
-                                                              })
-                                                            }
-                                                            disabled={updateTierRule.isPending}
-                                                          />
-                                                        ) : (
-                                                          <span className="text-muted-foreground">
-                                                            -
-                                                          </span>
-                                                        )}
-                                                      </TableCell>
-                                                      <TableCell className="px-2 py-1.5">
-                                                        {rule.source === "manual" && (
-                                                          <Button
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="h-6 w-6"
-                                                            onClick={() =>
-                                                              deleteTierRule.mutate(rule.id)
-                                                            }
-                                                            disabled={deleteTierRule.isPending}
-                                                            title={t("tierRulesDelete")}
-                                                          >
-                                                            <Trash2 className="h-3 w-3" />
-                                                          </Button>
-                                                        )}
-                                                      </TableCell>
-                                                    </>
-                                                  )}
-                                                </TableRow>
-                                              );
-                                            })}
-                                          </TableBody>
-                                        </Table>
-                                      </div>
-                                    )}
-                                  </div>
-                                </TableCell>
-                              </TableRow>
-                            )}
-                          </Fragment>
-                        );
-                      })}
-
-                      {priceCatalogTierOnlyModels.map((model) => {
-                        const modelTierRules = allTierRulesMap.get(model);
-                        const isExpanded = expandedPriceRows.has(model);
-                        return (
-                          <Fragment key={model}>
-                            <TableRow
-                              className="cursor-pointer border-b border-divider/60 align-top bg-surface-300/20"
-                              onClick={() => togglePriceRow(model)}
-                            >
-                              <TableCell
-                                className="px-3 py-2"
-                                onClick={(e) => e.stopPropagation()}
-                              />
-                              <TableCell className="px-3 py-2 font-mono">
-                                <span className="block whitespace-normal break-words leading-5">
-                                  {model}
-                                </span>
-                              </TableCell>
-                              <TableCell className="px-3 py-2 whitespace-nowrap">
-                                <Badge variant="neutral">{t("tierRulesTitle")}</Badge>
-                              </TableCell>
-                              <TableCell className="hidden px-3 py-2 text-xs text-muted-foreground lg:table-cell">
-                                <div>{tierRuleThresholdMap.get(model) ?? "-"}</div>
-                              </TableCell>
-                              <TableCell className="px-3 py-2 text-xs text-muted-foreground">
-                                -
-                              </TableCell>
-                              <TableCell className="hidden px-3 py-2 lg:table-cell" />
-                              <TableCell className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
-                                <button
-                                  type="button"
-                                  className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-surface-300/60"
-                                  onClick={() => togglePriceRow(model)}
-                                  title={t(
-                                    isExpanded
-                                      ? "priceCatalogCollapseTiers"
-                                      : "priceCatalogExpandTiers"
-                                  )}
-                                >
-                                  <ExpandChevron expanded={isExpanded} />
-                                </button>
-                              </TableCell>
-                            </TableRow>
-                            {isExpanded && modelTierRules && (
-                              <TableRow className="bg-surface-300/10">
-                                <TableCell colSpan={7} className="px-3 py-3">
-                                  <div className="space-y-2">
-                                    <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                                      {t("tierRulesTitle")} ({modelTierRules.length})
-                                    </p>
-                                    <Table className="w-full text-xs">
-                                      <TableHeader>
-                                        <TableRow className="border-b border-divider/40 text-left text-[11px] uppercase tracking-wide text-muted-foreground hover:bg-transparent">
-                                          <TableHead className="px-2 py-1 h-auto">
-                                            {t("tierRulesThreshold")}
-                                          </TableHead>
-                                          <TableHead className="px-2 py-1 h-auto">
-                                            {t("tierRulesSource")}
-                                          </TableHead>
-                                          <TableHead className="px-2 py-1 h-auto">IN</TableHead>
-                                          <TableHead className="px-2 py-1 h-auto">OUT</TableHead>
-                                          <TableHead className="px-2 py-1 h-auto">CR</TableHead>
-                                          <TableHead className="px-2 py-1 h-auto">CW</TableHead>
-                                          <TableHead className="px-2 py-1 h-auto">
-                                            {t("tierRulesActive")}
-                                          </TableHead>
-                                          <TableHead className="w-10 px-2 py-1 h-auto" />
-                                        </TableRow>
-                                      </TableHeader>
-                                      <TableBody>
-                                        {modelTierRules.map((rule) => {
-                                          const isTierEditing =
-                                            rule.source === "manual"
-                                              ? isEditingTierRule(rule.id)
-                                              : isEditingTierOverride(
-                                                  model,
-                                                  rule.threshold_input_tokens
-                                                );
-                                          return (
-                                            <TableRow
                                               key={rule.id}
                                               className={cn(
-                                                "border-b border-divider/30",
+                                                "flex cursor-pointer items-center justify-between border-t border-divider/60 px-1 py-2 text-xs transition-colors hover:bg-surface-300/30",
                                                 !rule.is_active && "opacity-50"
                                               )}
+                                              onClick={(e) => {
+                                                e.stopPropagation();
+                                                if (rule.source === "manual") {
+                                                  startEditingTierRule(rule);
+                                                } else {
+                                                  startEditingTierOverride(item.model, rule);
+                                                }
+                                              }}
                                             >
-                                              <TableCell className="px-2 py-1.5 tabular-nums">
-                                                {t("tierRulesThresholdTokens", {
-                                                  count: rule.threshold_input_tokens / 1000,
-                                                })}
-                                              </TableCell>
-                                              <TableCell className="px-2 py-1.5">
+                                              <div className="space-y-0.5">
+                                                <span className="text-muted-foreground">
+                                                  {t("tierRulesThresholdTokens", {
+                                                    count: rule.threshold_input_tokens / 1000,
+                                                  })}
+                                                </span>
+                                                <div className="tabular-nums">
+                                                  {formatPriceNumber(rule.input_price_per_million)}{" "}
+                                                  /{" "}
+                                                  {formatPriceNumber(rule.output_price_per_million)}
+                                                </div>
+                                              </div>
+                                              <div
+                                                className="flex items-center gap-1"
+                                                onClick={(e) => e.stopPropagation()}
+                                              >
                                                 <Badge
                                                   variant={
                                                     rule.source === "manual" ? "success" : "neutral"
@@ -2832,712 +2193,1427 @@ export default function BillingPage() {
                                                     ? t("tierRulesSourceManual")
                                                     : t("tierRulesSourceLitellm")}
                                                 </Badge>
-                                              </TableCell>
-                                              {isTierEditing ? (
-                                                <>
-                                                  <TableCell className="px-2 py-1.5">
-                                                    <Input
-                                                      value={editDraft.input}
-                                                      onChange={(e) =>
-                                                        setDraftField("input", e.target.value)
+                                                {rule.source === "manual" && (
+                                                  <>
+                                                    <Switch
+                                                      checked={rule.is_active}
+                                                      onCheckedChange={(checked) =>
+                                                        updateTierRule.mutate({
+                                                          id: rule.id,
+                                                          data: { is_active: checked },
+                                                        })
                                                       }
-                                                      className="h-6 w-20 text-xs tabular-nums"
-                                                      onKeyDown={editKeyDown}
+                                                      disabled={updateTierRule.isPending}
                                                     />
-                                                  </TableCell>
-                                                  <TableCell className="px-2 py-1.5">
-                                                    <Input
-                                                      value={editDraft.output}
-                                                      onChange={(e) =>
-                                                        setDraftField("output", e.target.value)
-                                                      }
-                                                      className="h-6 w-20 text-xs tabular-nums"
-                                                      onKeyDown={editKeyDown}
-                                                    />
-                                                  </TableCell>
-                                                  <TableCell className="px-2 py-1.5">
-                                                    <Input
-                                                      value={editDraft.cacheRead}
-                                                      onChange={(e) =>
-                                                        setDraftField("cacheRead", e.target.value)
-                                                      }
-                                                      className="h-6 w-20 text-xs tabular-nums"
-                                                      onKeyDown={editKeyDown}
-                                                    />
-                                                  </TableCell>
-                                                  <TableCell className="px-2 py-1.5">
-                                                    <Input
-                                                      value={editDraft.cacheWrite}
-                                                      onChange={(e) =>
-                                                        setDraftField("cacheWrite", e.target.value)
-                                                      }
-                                                      className="h-6 w-20 text-xs tabular-nums"
-                                                      onKeyDown={editKeyDown}
-                                                    />
-                                                  </TableCell>
-                                                  <TableCell className="px-2 py-1.5" />
-                                                  <TableCell className="px-2 py-1.5">
-                                                    <div className="flex items-center gap-0.5">
-                                                      <Button
-                                                        variant="ghost"
-                                                        size="icon"
-                                                        className="h-6 w-6 text-green-600 hover:text-green-700"
-                                                        onClick={() => void saveEdit()}
-                                                        disabled={editIsSaving}
-                                                      >
-                                                        <Check className="h-3 w-3" />
-                                                      </Button>
-                                                      <Button
-                                                        variant="ghost"
-                                                        size="icon"
-                                                        className="h-6 w-6"
-                                                        onClick={cancelEditing}
-                                                      >
-                                                        <X className="h-3 w-3" />
-                                                      </Button>
-                                                    </div>
-                                                  </TableCell>
-                                                </>
-                                              ) : (
-                                                <>
-                                                  <TableCell
-                                                    className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
-                                                    onClick={() =>
-                                                      rule.source === "manual"
-                                                        ? startEditingTierRule(rule)
-                                                        : startEditingTierOverride(model, rule)
-                                                    }
-                                                  >
-                                                    {formatPriceNumber(
-                                                      rule.input_price_per_million
-                                                    )}
-                                                  </TableCell>
-                                                  <TableCell
-                                                    className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
-                                                    onClick={() =>
-                                                      rule.source === "manual"
-                                                        ? startEditingTierRule(rule)
-                                                        : startEditingTierOverride(model, rule)
-                                                    }
-                                                  >
-                                                    {formatPriceNumber(
-                                                      rule.output_price_per_million
-                                                    )}
-                                                  </TableCell>
-                                                  <TableCell
-                                                    className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
-                                                    onClick={() =>
-                                                      rule.source === "manual"
-                                                        ? startEditingTierRule(rule)
-                                                        : startEditingTierOverride(model, rule)
-                                                    }
-                                                  >
-                                                    {formatPriceNumber(
-                                                      rule.cache_read_input_price_per_million
-                                                    )}
-                                                  </TableCell>
-                                                  <TableCell
-                                                    className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
-                                                    onClick={() =>
-                                                      rule.source === "manual"
-                                                        ? startEditingTierRule(rule)
-                                                        : startEditingTierOverride(model, rule)
-                                                    }
-                                                  >
-                                                    {formatPriceNumber(
-                                                      rule.cache_write_input_price_per_million
-                                                    )}
-                                                  </TableCell>
-                                                  <TableCell className="px-2 py-1.5">
-                                                    {rule.source === "manual" ? (
-                                                      <Switch
-                                                        checked={rule.is_active}
-                                                        onCheckedChange={(checked) =>
-                                                          updateTierRule.mutate({
-                                                            id: rule.id,
-                                                            data: { is_active: checked },
-                                                          })
-                                                        }
-                                                        disabled={updateTierRule.isPending}
-                                                      />
-                                                    ) : (
-                                                      <span className="text-muted-foreground">
-                                                        -
-                                                      </span>
-                                                    )}
-                                                  </TableCell>
-                                                  <TableCell className="px-2 py-1.5">
-                                                    {rule.source === "manual" && (
-                                                      <Button
-                                                        variant="ghost"
-                                                        size="icon"
-                                                        className="h-6 w-6"
-                                                        onClick={() =>
-                                                          deleteTierRule.mutate(rule.id)
-                                                        }
-                                                        disabled={deleteTierRule.isPending}
-                                                        title={t("tierRulesDelete")}
-                                                      >
-                                                        <Trash2 className="h-3 w-3" />
-                                                      </Button>
-                                                    )}
-                                                  </TableCell>
-                                                </>
-                                              )}
-                                            </TableRow>
+                                                    <Button
+                                                      variant="ghost"
+                                                      size="icon"
+                                                      className="h-6 w-6"
+                                                      onClick={() => deleteTierRule.mutate(rule.id)}
+                                                      disabled={deleteTierRule.isPending}
+                                                    >
+                                                      <Trash2 className="h-3 w-3" />
+                                                    </Button>
+                                                  </>
+                                                )}
+                                              </div>
+                                            </div>
                                           );
                                         })}
-                                      </TableBody>
-                                    </Table>
+                                      </div>
+                                    )}
                                   </div>
-                                </TableCell>
-                              </TableRow>
-                            )}
-                          </Fragment>
-                        );
-                      })}
+                                );
+                              })()}
 
-                      {priceCatalogVisibleSyncedItems.map((item: BillingModelPrice) => {
-                        const override = manualOverrideMap.get(item.model);
-                        const tierPreview = tierRulePreviewMap.get(item.model);
-                        const tierPreviewLabel = tierPreview
-                          ? `>${t("tierRulesThresholdTokens", {
-                              count: tierPreview.threshold_input_tokens / 1000,
-                            })}`
-                          : null;
-                        const effective = override
-                          ? {
-                              input: override.input_price_per_million,
-                              output: override.output_price_per_million,
-                              cacheRead: override.cache_read_input_price_per_million,
-                              cacheWrite: override.cache_write_input_price_per_million,
-                              source: "manual" as const,
-                            }
-                          : {
-                              input: item.input_price_per_million,
-                              output: item.output_price_per_million,
-                              cacheRead: item.cache_read_input_price_per_million,
-                              cacheWrite: item.cache_write_input_price_per_million,
-                              source: "litellm" as const,
-                            };
-                        const modelTierRules = allTierRulesMap.get(item.model);
-                        const hasTiers = !!modelTierRules && modelTierRules.length > 0;
-                        const isExpanded = expandedPriceRows.has(item.model);
-
-                        const renderEffectiveNumber = (options: {
-                          effectiveValue: number | null;
-                          syncedValue: number | null;
-                        }) => {
-                          const { effectiveValue, syncedValue } = options;
-                          if (effectiveValue == null) {
-                            return <span className="text-muted-foreground">-</span>;
-                          }
-
-                          if (!override) {
-                            return (
-                              <span className="tabular-nums">{effectiveValue.toFixed(4)}</span>
-                            );
-                          }
-
-                          const syncedLabel =
-                            syncedValue == null ? "-" : (syncedValue as number).toFixed(4);
-                          return (
-                            <div className="space-y-0.5">
-                              <div className="tabular-nums font-medium text-foreground">
-                                {effectiveValue.toFixed(4)}
-                              </div>
-                              <div className="text-[11px] tabular-nums text-muted-foreground">
-                                litellm: {syncedLabel}
-                              </div>
+                              <p className="text-[11px] text-muted-foreground">
+                                {t("priceCatalogSyncedAt")}:{" "}
+                                {new Date(item.synced_at).toLocaleString(locale)}
+                              </p>
                             </div>
-                          );
-                        };
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
 
-                        return (
-                          <Fragment key={item.id}>
-                            <TableRow
-                              className={cn(
-                                "border-b border-divider/60 align-top",
-                                hasTiers && "cursor-pointer",
-                                recentlySavedModel === item.model && "bg-amber-500/10"
-                              )}
-                              onClick={hasTiers ? () => togglePriceRow(item.model) : undefined}
-                            >
-                              <TableCell className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
-                                {override ? (
+                  <div className="hidden w-full overflow-x-auto lg:block">
+                    <Table
+                      className="w-full min-w-[850px] text-sm"
+                      frame="none"
+                      containerClassName="rounded-none border-0 bg-transparent"
+                    >
+                      <TableHeader>
+                        <TableRow className="border-b border-divider text-left text-xs uppercase tracking-wide text-muted-foreground hover:bg-transparent">
+                          <TableHead className="w-10 px-3 py-2 h-auto">
+                            <Checkbox
+                              checked={priceCatalogHeaderSelectionState}
+                              onCheckedChange={(value) =>
+                                toggleSelectAllVisible(value === true || value === "indeterminate")
+                              }
+                              aria-label={t("priceCatalogSelectAll")}
+                              disabled={priceCatalogSelectableModels.length === 0}
+                            />
+                          </TableHead>
+                          <TableHead className="w-[220px] px-3 py-2 h-auto text-left">
+                            {t("priceCatalogModel")}
+                          </TableHead>
+                          <TableHead className="w-[88px] px-3 py-2 h-auto text-left whitespace-nowrap">
+                            {t("priceCatalogEffective")}
+                          </TableHead>
+                          <TableHead className="hidden w-[130px] px-3 py-2 h-auto text-left lg:table-cell whitespace-nowrap">
+                            {t("tierRulesThreshold")} / {t("priceCatalogMaxInput")}
+                          </TableHead>
+                          <TableHead className="w-[300px] px-3 py-2 h-auto text-left">
+                            {t("priceCatalogInputOutputPrice")} /{" "}
+                            {t("priceCatalogCacheReadWritePrice")}
+                          </TableHead>
+                          <TableHead className="hidden w-[130px] px-3 py-2 h-auto lg:table-cell text-left">
+                            {t("priceCatalogSyncedAt")}
+                          </TableHead>
+                          <TableHead className="w-[72px] px-3 py-2 h-auto text-left">
+                            {t("priceCatalogActions")}
+                          </TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {priceCatalogExtraOverrides.map((override) => {
+                          const tierPreview = tierRulePreviewMap.get(override.model);
+                          const tierPreviewLabel = tierPreview
+                            ? `>${t("tierRulesThresholdTokens", {
+                                count: tierPreview.threshold_input_tokens / 1000,
+                              })}`
+                            : null;
+                          const modelTierRules = allTierRulesMap.get(override.model);
+                          const hasTiers = !!modelTierRules && modelTierRules.length > 0;
+                          const isExpanded = expandedPriceRows.has(override.model);
+
+                          return (
+                            <Fragment key={override.id}>
+                              <TableRow
+                                className={cn(
+                                  "border-b border-divider/60 align-top bg-surface-300/20",
+                                  hasTiers && "cursor-pointer",
+                                  recentlySavedModel === override.model && "bg-amber-500/10"
+                                )}
+                                onClick={
+                                  hasTiers ? () => togglePriceRow(override.model) : undefined
+                                }
+                              >
+                                <TableCell
+                                  className="px-3 py-2"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
                                   <Checkbox
-                                    checked={selectedResetModels.includes(item.model)}
+                                    checked={selectedResetModels.includes(override.model)}
                                     onCheckedChange={(value) =>
-                                      toggleSelectedResetModel(item.model, value === true)
+                                      toggleSelectedResetModel(override.model, value === true)
                                     }
                                     aria-label={t("priceCatalogSelectModel", {
-                                      model: item.model,
+                                      model: override.model,
                                     })}
                                   />
-                                ) : (
-                                  <span className="sr-only">-</span>
-                                )}
-                              </TableCell>
-                              <TableCell className="px-3 py-2 font-mono">
-                                <span className="block whitespace-normal break-words leading-5">
-                                  {item.model}
-                                </span>
-                              </TableCell>
-                              <TableCell className="px-3 py-2 whitespace-nowrap">
-                                <div className="space-y-1">
-                                  <Badge variant={override ? "success" : "neutral"}>
-                                    {override
-                                      ? t("priceCatalogEffectiveManual")
-                                      : t("priceCatalogEffectiveSynced")}
-                                  </Badge>
-                                  <p className="text-[11px] text-muted-foreground">{item.source}</p>
-                                </div>
-                              </TableCell>
-                              <TableCell className="hidden px-3 py-2 text-xs text-muted-foreground lg:table-cell">
-                                <div className="space-y-1">
-                                  <div>{tierRuleThresholdMap.get(item.model) ?? "-"}</div>
-                                  <div>
-                                    {item.max_input_tokens != null
-                                      ? item.max_input_tokens.toLocaleString()
-                                      : "-"}{" "}
-                                    /{" "}
-                                    {item.max_output_tokens != null
-                                      ? item.max_output_tokens.toLocaleString()
-                                      : "-"}
+                                </TableCell>
+                                <TableCell className="px-3 py-2 font-mono">
+                                  <span className="block whitespace-normal break-words leading-5">
+                                    {override.model}
+                                  </span>
+                                </TableCell>
+                                <TableCell className="px-3 py-2 whitespace-nowrap">
+                                  <div className="space-y-1">
+                                    <Badge variant="success">
+                                      {t("priceCatalogEffectiveManual")}
+                                    </Badge>
+                                    <p className="text-[11px] text-muted-foreground">
+                                      {t("priceCatalogSourceManual")}
+                                    </p>
                                   </div>
-                                </div>
-                              </TableCell>
-                              {isEditingPrice(item.model) ? (
-                                <>
-                                  <TableCell
-                                    className="px-3 py-2"
-                                    onClick={(e) => e.stopPropagation()}
-                                  >
-                                    <div className="space-y-2">
-                                      <div className="grid grid-cols-2 gap-x-4 gap-y-1.5">
-                                        {PRICE_FIELDS_SHORT.map(([field, label]) => (
-                                          <div
-                                            key={field}
-                                            className="grid grid-cols-[24px_auto] items-center gap-2"
-                                          >
-                                            <span className="text-[11px] text-muted-foreground">
-                                              {label}
-                                            </span>
-                                            <Input
-                                              value={editDraft[field]}
-                                              onChange={(e) => setDraftField(field, e.target.value)}
-                                              className="h-7 text-xs tabular-nums"
-                                              onKeyDown={editKeyDown}
-                                            />
-                                          </div>
-                                        ))}
-                                      </div>
-                                      <div className="grid grid-cols-[24px_auto] items-center gap-2">
-                                        <span className="text-[11px] text-muted-foreground">
-                                          {t("overrideNote")}
-                                        </span>
-                                        <Input
-                                          value={editDraft.note}
-                                          onChange={(e) => setDraftField("note", e.target.value)}
-                                          className="h-7 text-xs"
-                                          onKeyDown={editKeyDown}
-                                        />
-                                      </div>
-                                    </div>
-                                  </TableCell>
-                                  <TableCell className="hidden px-3 py-2 lg:table-cell" />
-                                  <TableCell
-                                    className="px-3 py-2"
-                                    onClick={(e) => e.stopPropagation()}
-                                  >
-                                    <div className="flex items-center gap-1">
-                                      <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        className="h-8 w-8 text-green-600 hover:text-green-700"
-                                        onClick={() => void saveEdit()}
-                                        disabled={editIsSaving}
-                                      >
-                                        <Check className="h-4 w-4" />
-                                      </Button>
-                                      <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        className="h-8 w-8"
-                                        onClick={cancelEditing}
-                                      >
-                                        <X className="h-4 w-4" />
-                                      </Button>
-                                    </div>
-                                  </TableCell>
-                                </>
-                              ) : (
-                                <>
-                                  <TableCell
-                                    className="px-3 py-2 cursor-pointer hover:bg-surface-300/40 transition-colors"
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      startEditingPrice(item.model, override);
-                                    }}
-                                  >
-                                    <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-                                      <div className="grid grid-cols-[24px_auto] items-start justify-start gap-2">
-                                        <span className="pt-0.5 text-[11px] text-muted-foreground">
-                                          IN
-                                        </span>
-                                        <div>
-                                          {renderEffectiveNumber({
-                                            effectiveValue: effective.input,
-                                            syncedValue: item.input_price_per_million,
-                                          })}
-                                          {tierPreviewLabel ? (
-                                            <div className="text-[11px] tabular-nums text-muted-foreground">
-                                              {tierPreviewLabel}:{" "}
-                                              {formatPriceNumber(
-                                                tierPreview?.input_price_per_million ?? null
-                                              )}
+                                </TableCell>
+                                <TableCell className="hidden px-3 py-2 text-xs text-muted-foreground lg:table-cell">
+                                  <div className="space-y-1">
+                                    <div>{tierRuleThresholdMap.get(override.model) ?? "-"}</div>
+                                    <div>-</div>
+                                  </div>
+                                </TableCell>
+                                {isEditingPrice(override.model) ? (
+                                  <>
+                                    <TableCell
+                                      className="px-3 py-2"
+                                      onClick={(e) => e.stopPropagation()}
+                                    >
+                                      <div className="space-y-2">
+                                        <div className="grid grid-cols-2 gap-x-4 gap-y-1.5">
+                                          {PRICE_FIELDS_SHORT.map(([field, label]) => (
+                                            <div
+                                              key={field}
+                                              className="grid grid-cols-[24px_auto] items-center gap-2"
+                                            >
+                                              <span className="text-[11px] text-muted-foreground">
+                                                {label}
+                                              </span>
+                                              <Input
+                                                value={editDraft[field]}
+                                                onChange={(e) =>
+                                                  setDraftField(field, e.target.value)
+                                                }
+                                                className="h-7 text-xs tabular-nums"
+                                                onKeyDown={editKeyDown}
+                                              />
                                             </div>
-                                          ) : null}
+                                          ))}
+                                        </div>
+                                        <div className="grid grid-cols-[24px_auto] items-center gap-2">
+                                          <span className="text-[11px] text-muted-foreground">
+                                            {t("overrideNote")}
+                                          </span>
+                                          <Input
+                                            value={editDraft.note}
+                                            onChange={(e) => setDraftField("note", e.target.value)}
+                                            className="h-7 text-xs"
+                                            onKeyDown={editKeyDown}
+                                          />
                                         </div>
                                       </div>
-                                      <div className="grid grid-cols-[24px_auto] items-start justify-start gap-2">
-                                        <span className="pt-0.5 text-[11px] text-muted-foreground">
-                                          CR
-                                        </span>
-                                        <div>
-                                          {renderEffectiveNumber({
-                                            effectiveValue: effective.cacheRead,
-                                            syncedValue: item.cache_read_input_price_per_million,
-                                          })}
-                                        </div>
-                                      </div>
-                                      <div className="grid grid-cols-[24px_auto] items-start justify-start gap-2">
-                                        <span className="pt-0.5 text-[11px] text-muted-foreground">
-                                          OUT
-                                        </span>
-                                        <div>
-                                          {renderEffectiveNumber({
-                                            effectiveValue: effective.output,
-                                            syncedValue: item.output_price_per_million,
-                                          })}
-                                          {tierPreviewLabel ? (
-                                            <div className="text-[11px] tabular-nums text-muted-foreground">
-                                              {tierPreviewLabel}:{" "}
-                                              {formatPriceNumber(
-                                                tierPreview?.output_price_per_million ?? null
-                                              )}
-                                            </div>
-                                          ) : null}
-                                        </div>
-                                      </div>
-                                      <div className="grid grid-cols-[24px_auto] items-start justify-start gap-2">
-                                        <span className="pt-0.5 text-[11px] text-muted-foreground">
-                                          CW
-                                        </span>
-                                        <div>
-                                          {renderEffectiveNumber({
-                                            effectiveValue: effective.cacheWrite,
-                                            syncedValue: item.cache_write_input_price_per_million,
-                                          })}
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </TableCell>
-                                  <TableCell className="hidden px-3 py-2 text-xs text-muted-foreground lg:table-cell">
-                                    {new Date(item.synced_at).toLocaleString(locale)}
-                                  </TableCell>
-                                  <TableCell
-                                    className="px-3 py-2"
-                                    onClick={(e) => e.stopPropagation()}
-                                  >
-                                    <div className="flex items-center gap-1">
-                                      {override ? (
+                                    </TableCell>
+                                    <TableCell className="hidden px-3 py-2 lg:table-cell" />
+                                    <TableCell
+                                      className="px-3 py-2"
+                                      onClick={(e) => e.stopPropagation()}
+                                    >
+                                      <div className="flex items-center gap-1">
+                                        <Button
+                                          variant="ghost"
+                                          size="icon"
+                                          className="h-8 w-8 text-green-600 hover:text-green-700"
+                                          onClick={() => void saveEdit()}
+                                          disabled={editIsSaving}
+                                        >
+                                          <Check className="h-4 w-4" />
+                                        </Button>
                                         <Button
                                           variant="ghost"
                                           size="icon"
                                           className="h-8 w-8"
-                                          onClick={() => openResetDialog([item.model])}
+                                          onClick={cancelEditing}
+                                        >
+                                          <X className="h-4 w-4" />
+                                        </Button>
+                                      </div>
+                                    </TableCell>
+                                  </>
+                                ) : (
+                                  <>
+                                    <TableCell
+                                      className="px-3 py-2 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        startEditingPrice(override.model, override);
+                                      }}
+                                    >
+                                      <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+                                        <div className="grid grid-cols-[24px_auto] items-center justify-start gap-2">
+                                          <span className="text-[11px] text-muted-foreground">
+                                            IN
+                                          </span>
+                                          <div>
+                                            <div>{override.input_price_per_million.toFixed(4)}</div>
+                                            {tierPreviewLabel ? (
+                                              <div className="text-[11px] text-muted-foreground">
+                                                {tierPreviewLabel}:{" "}
+                                                {formatPriceNumber(
+                                                  tierPreview?.input_price_per_million ?? null
+                                                )}
+                                              </div>
+                                            ) : null}
+                                          </div>
+                                        </div>
+                                        <div className="grid grid-cols-[24px_auto] items-center justify-start gap-2">
+                                          <span className="text-[11px] text-muted-foreground">
+                                            CR
+                                          </span>
+                                          <div>
+                                            {override.cache_read_input_price_per_million == null
+                                              ? "-"
+                                              : override.cache_read_input_price_per_million.toFixed(
+                                                  4
+                                                )}
+                                          </div>
+                                        </div>
+                                        <div className="grid grid-cols-[24px_auto] items-center justify-start gap-2">
+                                          <span className="text-[11px] text-muted-foreground">
+                                            OUT
+                                          </span>
+                                          <div>
+                                            <div>
+                                              {override.output_price_per_million.toFixed(4)}
+                                            </div>
+                                            {tierPreviewLabel ? (
+                                              <div className="text-[11px] text-muted-foreground">
+                                                {tierPreviewLabel}:{" "}
+                                                {formatPriceNumber(
+                                                  tierPreview?.output_price_per_million ?? null
+                                                )}
+                                              </div>
+                                            ) : null}
+                                          </div>
+                                        </div>
+                                        <div className="grid grid-cols-[24px_auto] items-center justify-start gap-2">
+                                          <span className="text-[11px] text-muted-foreground">
+                                            CW
+                                          </span>
+                                          <div>
+                                            {override.cache_write_input_price_per_million == null
+                                              ? "-"
+                                              : override.cache_write_input_price_per_million.toFixed(
+                                                  4
+                                                )}
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </TableCell>
+                                    <TableCell className="hidden px-3 py-2 text-xs text-muted-foreground lg:table-cell">
+                                      {new Date(override.updated_at).toLocaleString(locale)}
+                                    </TableCell>
+                                    <TableCell
+                                      className="px-3 py-2"
+                                      onClick={(e) => e.stopPropagation()}
+                                    >
+                                      <div className="flex items-center gap-1">
+                                        <Button
+                                          variant="ghost"
+                                          size="icon"
+                                          className="h-8 w-8"
+                                          onClick={() => openResetDialog([override.model])}
                                           disabled={resetOverrides.isPending}
-                                          title={t("priceCatalogResetToOfficial")}
+                                          title={
+                                            override.has_official_price === false
+                                              ? t("priceCatalogDeleteManualPrice")
+                                              : t("priceCatalogResetToOfficial")
+                                          }
                                         >
                                           <RotateCcw className="h-4 w-4" aria-hidden="true" />
                                         </Button>
-                                      ) : (
-                                        <span className="inline-block h-8 w-8" />
-                                      )}
-                                      {hasTiers && (
-                                        <button
-                                          type="button"
-                                          className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-surface-300/60"
-                                          onClick={() => togglePriceRow(item.model)}
-                                          title={t(
-                                            isExpanded
-                                              ? "priceCatalogCollapseTiers"
-                                              : "priceCatalogExpandTiers"
-                                          )}
-                                        >
-                                          <ExpandChevron expanded={isExpanded} />
-                                        </button>
+                                        {hasTiers && (
+                                          <button
+                                            type="button"
+                                            className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-surface-300/60"
+                                            onClick={() => togglePriceRow(override.model)}
+                                            title={t(
+                                              isExpanded
+                                                ? "priceCatalogCollapseTiers"
+                                                : "priceCatalogExpandTiers"
+                                            )}
+                                          >
+                                            <ExpandChevron expanded={isExpanded} />
+                                          </button>
+                                        )}
+                                      </div>
+                                    </TableCell>
+                                  </>
+                                )}
+                              </TableRow>
+                              {isExpanded && (
+                                <TableRow className="bg-surface-300/10">
+                                  <TableCell colSpan={7} className="px-3 py-3">
+                                    <div className="space-y-4">
+                                      {hasTiers && modelTierRules && (
+                                        <div className="space-y-2">
+                                          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                                            {t("tierRulesTitle")} ({modelTierRules.length})
+                                          </p>
+                                          <Table
+                                            className="w-full text-xs"
+                                            frame="none"
+                                            containerClassName="rounded-none border-0 bg-transparent"
+                                          >
+                                            <TableHeader>
+                                              <TableRow className="border-b border-divider/40 text-left text-[11px] uppercase tracking-wide text-muted-foreground hover:bg-transparent">
+                                                <TableHead className="px-2 py-1 h-auto">
+                                                  {t("tierRulesThreshold")}
+                                                </TableHead>
+                                                <TableHead className="px-2 py-1 h-auto">
+                                                  {t("tierRulesSource")}
+                                                </TableHead>
+                                                <TableHead className="px-2 py-1 h-auto">
+                                                  IN
+                                                </TableHead>
+                                                <TableHead className="px-2 py-1 h-auto">
+                                                  OUT
+                                                </TableHead>
+                                                <TableHead className="px-2 py-1 h-auto">
+                                                  CR
+                                                </TableHead>
+                                                <TableHead className="px-2 py-1 h-auto">
+                                                  CW
+                                                </TableHead>
+                                                <TableHead className="px-2 py-1 h-auto">
+                                                  {t("tierRulesActive")}
+                                                </TableHead>
+                                                <TableHead className="w-10 px-2 py-1 h-auto" />
+                                              </TableRow>
+                                            </TableHeader>
+                                            <TableBody>
+                                              {modelTierRules.map((rule) => {
+                                                const isTierEditing =
+                                                  rule.source === "manual"
+                                                    ? isEditingTierRule(rule.id)
+                                                    : isEditingTierOverride(
+                                                        override.model,
+                                                        rule.threshold_input_tokens
+                                                      );
+                                                return (
+                                                  <TableRow
+                                                    key={rule.id}
+                                                    className={cn(
+                                                      "border-b border-divider/30",
+                                                      !rule.is_active && "opacity-50"
+                                                    )}
+                                                  >
+                                                    <TableCell className="px-2 py-1.5 tabular-nums">
+                                                      {t("tierRulesThresholdTokens", {
+                                                        count: rule.threshold_input_tokens / 1000,
+                                                      })}
+                                                    </TableCell>
+                                                    <TableCell className="px-2 py-1.5">
+                                                      <Badge
+                                                        variant={
+                                                          rule.source === "manual"
+                                                            ? "success"
+                                                            : "neutral"
+                                                        }
+                                                      >
+                                                        {rule.source === "manual"
+                                                          ? t("tierRulesSourceManual")
+                                                          : t("tierRulesSourceLitellm")}
+                                                      </Badge>
+                                                    </TableCell>
+                                                    {isTierEditing ? (
+                                                      <>
+                                                        <TableCell className="px-2 py-1.5">
+                                                          <Input
+                                                            value={editDraft.input}
+                                                            onChange={(e) =>
+                                                              setDraftField("input", e.target.value)
+                                                            }
+                                                            className="h-6 w-20 text-xs tabular-nums"
+                                                            onKeyDown={editKeyDown}
+                                                          />
+                                                        </TableCell>
+                                                        <TableCell className="px-2 py-1.5">
+                                                          <Input
+                                                            value={editDraft.output}
+                                                            onChange={(e) =>
+                                                              setDraftField(
+                                                                "output",
+                                                                e.target.value
+                                                              )
+                                                            }
+                                                            className="h-6 w-20 text-xs tabular-nums"
+                                                            onKeyDown={editKeyDown}
+                                                          />
+                                                        </TableCell>
+                                                        <TableCell className="px-2 py-1.5">
+                                                          <Input
+                                                            value={editDraft.cacheRead}
+                                                            onChange={(e) =>
+                                                              setDraftField(
+                                                                "cacheRead",
+                                                                e.target.value
+                                                              )
+                                                            }
+                                                            className="h-6 w-20 text-xs tabular-nums"
+                                                            onKeyDown={editKeyDown}
+                                                          />
+                                                        </TableCell>
+                                                        <TableCell className="px-2 py-1.5">
+                                                          <Input
+                                                            value={editDraft.cacheWrite}
+                                                            onChange={(e) =>
+                                                              setDraftField(
+                                                                "cacheWrite",
+                                                                e.target.value
+                                                              )
+                                                            }
+                                                            className="h-6 w-20 text-xs tabular-nums"
+                                                            onKeyDown={editKeyDown}
+                                                          />
+                                                        </TableCell>
+                                                        <TableCell className="px-2 py-1.5" />
+                                                        <TableCell className="px-2 py-1.5">
+                                                          <div className="flex items-center gap-0.5">
+                                                            <Button
+                                                              variant="ghost"
+                                                              size="icon"
+                                                              className="h-6 w-6 text-green-600 hover:text-green-700"
+                                                              onClick={() => void saveEdit()}
+                                                              disabled={editIsSaving}
+                                                            >
+                                                              <Check className="h-3 w-3" />
+                                                            </Button>
+                                                            <Button
+                                                              variant="ghost"
+                                                              size="icon"
+                                                              className="h-6 w-6"
+                                                              onClick={cancelEditing}
+                                                            >
+                                                              <X className="h-3 w-3" />
+                                                            </Button>
+                                                          </div>
+                                                        </TableCell>
+                                                      </>
+                                                    ) : (
+                                                      <>
+                                                        <TableCell
+                                                          className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
+                                                          onClick={() =>
+                                                            rule.source === "manual"
+                                                              ? startEditingTierRule(rule)
+                                                              : startEditingTierOverride(
+                                                                  override.model,
+                                                                  rule
+                                                                )
+                                                          }
+                                                        >
+                                                          {formatPriceNumber(
+                                                            rule.input_price_per_million
+                                                          )}
+                                                        </TableCell>
+                                                        <TableCell
+                                                          className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
+                                                          onClick={() =>
+                                                            rule.source === "manual"
+                                                              ? startEditingTierRule(rule)
+                                                              : startEditingTierOverride(
+                                                                  override.model,
+                                                                  rule
+                                                                )
+                                                          }
+                                                        >
+                                                          {formatPriceNumber(
+                                                            rule.output_price_per_million
+                                                          )}
+                                                        </TableCell>
+                                                        <TableCell
+                                                          className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
+                                                          onClick={() =>
+                                                            rule.source === "manual"
+                                                              ? startEditingTierRule(rule)
+                                                              : startEditingTierOverride(
+                                                                  override.model,
+                                                                  rule
+                                                                )
+                                                          }
+                                                        >
+                                                          {formatPriceNumber(
+                                                            rule.cache_read_input_price_per_million
+                                                          )}
+                                                        </TableCell>
+                                                        <TableCell
+                                                          className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
+                                                          onClick={() =>
+                                                            rule.source === "manual"
+                                                              ? startEditingTierRule(rule)
+                                                              : startEditingTierOverride(
+                                                                  override.model,
+                                                                  rule
+                                                                )
+                                                          }
+                                                        >
+                                                          {formatPriceNumber(
+                                                            rule.cache_write_input_price_per_million
+                                                          )}
+                                                        </TableCell>
+                                                        <TableCell className="px-2 py-1.5">
+                                                          {rule.source === "manual" ? (
+                                                            <Switch
+                                                              checked={rule.is_active}
+                                                              onCheckedChange={(checked) =>
+                                                                updateTierRule.mutate({
+                                                                  id: rule.id,
+                                                                  data: { is_active: checked },
+                                                                })
+                                                              }
+                                                              disabled={updateTierRule.isPending}
+                                                            />
+                                                          ) : (
+                                                            <span className="text-muted-foreground">
+                                                              -
+                                                            </span>
+                                                          )}
+                                                        </TableCell>
+                                                        <TableCell className="px-2 py-1.5">
+                                                          {rule.source === "manual" && (
+                                                            <Button
+                                                              variant="ghost"
+                                                              size="icon"
+                                                              className="h-6 w-6"
+                                                              onClick={() =>
+                                                                deleteTierRule.mutate(rule.id)
+                                                              }
+                                                              disabled={deleteTierRule.isPending}
+                                                              title={t("tierRulesDelete")}
+                                                            >
+                                                              <Trash2 className="h-3 w-3" />
+                                                            </Button>
+                                                          )}
+                                                        </TableCell>
+                                                      </>
+                                                    )}
+                                                  </TableRow>
+                                                );
+                                              })}
+                                            </TableBody>
+                                          </Table>
+                                        </div>
                                       )}
                                     </div>
                                   </TableCell>
-                                </>
+                                </TableRow>
                               )}
-                            </TableRow>
-                            {isExpanded && (
-                              <TableRow className="bg-surface-300/10">
-                                <TableCell colSpan={7} className="px-3 py-3">
-                                  <div className="space-y-4">
-                                    {hasTiers && modelTierRules && (
-                                      <div className="space-y-2">
-                                        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                                          {t("tierRulesTitle")} ({modelTierRules.length})
-                                        </p>
-                                        <Table className="w-full text-xs">
-                                          <TableHeader>
-                                            <TableRow className="border-b border-divider/40 text-left text-[11px] uppercase tracking-wide text-muted-foreground hover:bg-transparent">
-                                              <TableHead className="px-2 py-1 h-auto">
-                                                {t("tierRulesThreshold")}
-                                              </TableHead>
-                                              <TableHead className="px-2 py-1 h-auto">
-                                                {t("tierRulesSource")}
-                                              </TableHead>
-                                              <TableHead className="px-2 py-1 h-auto">IN</TableHead>
-                                              <TableHead className="px-2 py-1 h-auto">
-                                                OUT
-                                              </TableHead>
-                                              <TableHead className="px-2 py-1 h-auto">CR</TableHead>
-                                              <TableHead className="px-2 py-1 h-auto">CW</TableHead>
-                                              <TableHead className="px-2 py-1 h-auto">
-                                                {t("tierRulesActive")}
-                                              </TableHead>
-                                              <TableHead className="w-10 px-2 py-1 h-auto" />
-                                            </TableRow>
-                                          </TableHeader>
-                                          <TableBody>
-                                            {modelTierRules.map((rule) => {
-                                              const isTierEditing =
-                                                rule.source === "manual"
-                                                  ? isEditingTierRule(rule.id)
-                                                  : isEditingTierOverride(
-                                                      item.model,
-                                                      rule.threshold_input_tokens
-                                                    );
-                                              return (
-                                                <TableRow
-                                                  key={rule.id}
-                                                  className={cn(
-                                                    "border-b border-divider/30",
-                                                    !rule.is_active && "opacity-50"
-                                                  )}
-                                                >
-                                                  <TableCell className="px-2 py-1.5 tabular-nums">
-                                                    {t("tierRulesThresholdTokens", {
-                                                      count: rule.threshold_input_tokens / 1000,
-                                                    })}
-                                                  </TableCell>
-                                                  <TableCell className="px-2 py-1.5">
-                                                    <Badge
-                                                      variant={
-                                                        rule.source === "manual"
-                                                          ? "success"
-                                                          : "neutral"
-                                                      }
-                                                    >
-                                                      {rule.source === "manual"
-                                                        ? t("tierRulesSourceManual")
-                                                        : t("tierRulesSourceLitellm")}
-                                                    </Badge>
-                                                  </TableCell>
-                                                  {isTierEditing ? (
-                                                    <>
-                                                      <TableCell className="px-2 py-1.5">
-                                                        <Input
-                                                          value={editDraft.input}
-                                                          onChange={(e) =>
-                                                            setDraftField("input", e.target.value)
-                                                          }
-                                                          className="h-6 w-20 text-xs tabular-nums"
-                                                          onKeyDown={editKeyDown}
-                                                        />
-                                                      </TableCell>
-                                                      <TableCell className="px-2 py-1.5">
-                                                        <Input
-                                                          value={editDraft.output}
-                                                          onChange={(e) =>
-                                                            setDraftField("output", e.target.value)
-                                                          }
-                                                          className="h-6 w-20 text-xs tabular-nums"
-                                                          onKeyDown={editKeyDown}
-                                                        />
-                                                      </TableCell>
-                                                      <TableCell className="px-2 py-1.5">
-                                                        <Input
-                                                          value={editDraft.cacheRead}
-                                                          onChange={(e) =>
-                                                            setDraftField(
-                                                              "cacheRead",
-                                                              e.target.value
-                                                            )
-                                                          }
-                                                          className="h-6 w-20 text-xs tabular-nums"
-                                                          onKeyDown={editKeyDown}
-                                                        />
-                                                      </TableCell>
-                                                      <TableCell className="px-2 py-1.5">
-                                                        <Input
-                                                          value={editDraft.cacheWrite}
-                                                          onChange={(e) =>
-                                                            setDraftField(
-                                                              "cacheWrite",
-                                                              e.target.value
-                                                            )
-                                                          }
-                                                          className="h-6 w-20 text-xs tabular-nums"
-                                                          onKeyDown={editKeyDown}
-                                                        />
-                                                      </TableCell>
-                                                      <TableCell className="px-2 py-1.5" />
-                                                      <TableCell className="px-2 py-1.5">
-                                                        <div className="flex items-center gap-0.5">
-                                                          <Button
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="h-6 w-6 text-green-600 hover:text-green-700"
-                                                            onClick={() => void saveEdit()}
-                                                            disabled={editIsSaving}
-                                                          >
-                                                            <Check className="h-3 w-3" />
-                                                          </Button>
-                                                          <Button
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="h-6 w-6"
-                                                            onClick={cancelEditing}
-                                                          >
-                                                            <X className="h-3 w-3" />
-                                                          </Button>
-                                                        </div>
-                                                      </TableCell>
-                                                    </>
-                                                  ) : (
-                                                    <>
-                                                      <TableCell
-                                                        className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
-                                                        onClick={() =>
-                                                          rule.source === "manual"
-                                                            ? startEditingTierRule(rule)
-                                                            : startEditingTierOverride(
-                                                                item.model,
-                                                                rule
-                                                              )
-                                                        }
-                                                      >
-                                                        {formatPriceNumber(
-                                                          rule.input_price_per_million
-                                                        )}
-                                                      </TableCell>
-                                                      <TableCell
-                                                        className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
-                                                        onClick={() =>
-                                                          rule.source === "manual"
-                                                            ? startEditingTierRule(rule)
-                                                            : startEditingTierOverride(
-                                                                item.model,
-                                                                rule
-                                                              )
-                                                        }
-                                                      >
-                                                        {formatPriceNumber(
-                                                          rule.output_price_per_million
-                                                        )}
-                                                      </TableCell>
-                                                      <TableCell
-                                                        className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
-                                                        onClick={() =>
-                                                          rule.source === "manual"
-                                                            ? startEditingTierRule(rule)
-                                                            : startEditingTierOverride(
-                                                                item.model,
-                                                                rule
-                                                              )
-                                                        }
-                                                      >
-                                                        {formatPriceNumber(
-                                                          rule.cache_read_input_price_per_million
-                                                        )}
-                                                      </TableCell>
-                                                      <TableCell
-                                                        className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
-                                                        onClick={() =>
-                                                          rule.source === "manual"
-                                                            ? startEditingTierRule(rule)
-                                                            : startEditingTierOverride(
-                                                                item.model,
-                                                                rule
-                                                              )
-                                                        }
-                                                      >
-                                                        {formatPriceNumber(
-                                                          rule.cache_write_input_price_per_million
-                                                        )}
-                                                      </TableCell>
-                                                      <TableCell className="px-2 py-1.5">
-                                                        {rule.source === "manual" ? (
-                                                          <Switch
-                                                            checked={rule.is_active}
-                                                            onCheckedChange={(checked) =>
-                                                              updateTierRule.mutate({
-                                                                id: rule.id,
-                                                                data: { is_active: checked },
-                                                              })
-                                                            }
-                                                            disabled={updateTierRule.isPending}
-                                                          />
-                                                        ) : (
-                                                          <span className="text-muted-foreground">
-                                                            -
-                                                          </span>
-                                                        )}
-                                                      </TableCell>
-                                                      <TableCell className="px-2 py-1.5">
-                                                        {rule.source === "manual" && (
-                                                          <Button
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="h-6 w-6"
-                                                            onClick={() =>
-                                                              deleteTierRule.mutate(rule.id)
-                                                            }
-                                                            disabled={deleteTierRule.isPending}
-                                                            title={t("tierRulesDelete")}
-                                                          >
-                                                            <Trash2 className="h-3 w-3" />
-                                                          </Button>
-                                                        )}
-                                                      </TableCell>
-                                                    </>
-                                                  )}
-                                                </TableRow>
-                                              );
-                                            })}
-                                          </TableBody>
-                                        </Table>
-                                      </div>
+                            </Fragment>
+                          );
+                        })}
+
+                        {priceCatalogTierOnlyModels.map((model) => {
+                          const modelTierRules = allTierRulesMap.get(model);
+                          const isExpanded = expandedPriceRows.has(model);
+                          return (
+                            <Fragment key={model}>
+                              <TableRow
+                                className="cursor-pointer border-b border-divider/60 align-top bg-surface-300/20"
+                                onClick={() => togglePriceRow(model)}
+                              >
+                                <TableCell
+                                  className="px-3 py-2"
+                                  onClick={(e) => e.stopPropagation()}
+                                />
+                                <TableCell className="px-3 py-2 font-mono">
+                                  <span className="block whitespace-normal break-words leading-5">
+                                    {model}
+                                  </span>
+                                </TableCell>
+                                <TableCell className="px-3 py-2 whitespace-nowrap">
+                                  <Badge variant="neutral">{t("tierRulesTitle")}</Badge>
+                                </TableCell>
+                                <TableCell className="hidden px-3 py-2 text-xs text-muted-foreground lg:table-cell">
+                                  <div>{tierRuleThresholdMap.get(model) ?? "-"}</div>
+                                </TableCell>
+                                <TableCell className="px-3 py-2 text-xs text-muted-foreground">
+                                  -
+                                </TableCell>
+                                <TableCell className="hidden px-3 py-2 lg:table-cell" />
+                                <TableCell
+                                  className="px-3 py-2"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  <button
+                                    type="button"
+                                    className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-surface-300/60"
+                                    onClick={() => togglePriceRow(model)}
+                                    title={t(
+                                      isExpanded
+                                        ? "priceCatalogCollapseTiers"
+                                        : "priceCatalogExpandTiers"
                                     )}
-                                  </div>
+                                  >
+                                    <ExpandChevron expanded={isExpanded} />
+                                  </button>
                                 </TableCell>
                               </TableRow>
-                            )}
-                          </Fragment>
-                        );
-                      })}
-                    </TableBody>
-                  </Table>
+                              {isExpanded && modelTierRules && (
+                                <TableRow className="bg-surface-300/10">
+                                  <TableCell colSpan={7} className="px-3 py-3">
+                                    <div className="space-y-2">
+                                      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                                        {t("tierRulesTitle")} ({modelTierRules.length})
+                                      </p>
+                                      <Table
+                                        className="w-full text-xs"
+                                        frame="none"
+                                        containerClassName="rounded-none border-0 bg-transparent"
+                                      >
+                                        <TableHeader>
+                                          <TableRow className="border-b border-divider/40 text-left text-[11px] uppercase tracking-wide text-muted-foreground hover:bg-transparent">
+                                            <TableHead className="px-2 py-1 h-auto">
+                                              {t("tierRulesThreshold")}
+                                            </TableHead>
+                                            <TableHead className="px-2 py-1 h-auto">
+                                              {t("tierRulesSource")}
+                                            </TableHead>
+                                            <TableHead className="px-2 py-1 h-auto">IN</TableHead>
+                                            <TableHead className="px-2 py-1 h-auto">OUT</TableHead>
+                                            <TableHead className="px-2 py-1 h-auto">CR</TableHead>
+                                            <TableHead className="px-2 py-1 h-auto">CW</TableHead>
+                                            <TableHead className="px-2 py-1 h-auto">
+                                              {t("tierRulesActive")}
+                                            </TableHead>
+                                            <TableHead className="w-10 px-2 py-1 h-auto" />
+                                          </TableRow>
+                                        </TableHeader>
+                                        <TableBody>
+                                          {modelTierRules.map((rule) => {
+                                            const isTierEditing =
+                                              rule.source === "manual"
+                                                ? isEditingTierRule(rule.id)
+                                                : isEditingTierOverride(
+                                                    model,
+                                                    rule.threshold_input_tokens
+                                                  );
+                                            return (
+                                              <TableRow
+                                                key={rule.id}
+                                                className={cn(
+                                                  "border-b border-divider/30",
+                                                  !rule.is_active && "opacity-50"
+                                                )}
+                                              >
+                                                <TableCell className="px-2 py-1.5 tabular-nums">
+                                                  {t("tierRulesThresholdTokens", {
+                                                    count: rule.threshold_input_tokens / 1000,
+                                                  })}
+                                                </TableCell>
+                                                <TableCell className="px-2 py-1.5">
+                                                  <Badge
+                                                    variant={
+                                                      rule.source === "manual"
+                                                        ? "success"
+                                                        : "neutral"
+                                                    }
+                                                  >
+                                                    {rule.source === "manual"
+                                                      ? t("tierRulesSourceManual")
+                                                      : t("tierRulesSourceLitellm")}
+                                                  </Badge>
+                                                </TableCell>
+                                                {isTierEditing ? (
+                                                  <>
+                                                    <TableCell className="px-2 py-1.5">
+                                                      <Input
+                                                        value={editDraft.input}
+                                                        onChange={(e) =>
+                                                          setDraftField("input", e.target.value)
+                                                        }
+                                                        className="h-6 w-20 text-xs tabular-nums"
+                                                        onKeyDown={editKeyDown}
+                                                      />
+                                                    </TableCell>
+                                                    <TableCell className="px-2 py-1.5">
+                                                      <Input
+                                                        value={editDraft.output}
+                                                        onChange={(e) =>
+                                                          setDraftField("output", e.target.value)
+                                                        }
+                                                        className="h-6 w-20 text-xs tabular-nums"
+                                                        onKeyDown={editKeyDown}
+                                                      />
+                                                    </TableCell>
+                                                    <TableCell className="px-2 py-1.5">
+                                                      <Input
+                                                        value={editDraft.cacheRead}
+                                                        onChange={(e) =>
+                                                          setDraftField("cacheRead", e.target.value)
+                                                        }
+                                                        className="h-6 w-20 text-xs tabular-nums"
+                                                        onKeyDown={editKeyDown}
+                                                      />
+                                                    </TableCell>
+                                                    <TableCell className="px-2 py-1.5">
+                                                      <Input
+                                                        value={editDraft.cacheWrite}
+                                                        onChange={(e) =>
+                                                          setDraftField(
+                                                            "cacheWrite",
+                                                            e.target.value
+                                                          )
+                                                        }
+                                                        className="h-6 w-20 text-xs tabular-nums"
+                                                        onKeyDown={editKeyDown}
+                                                      />
+                                                    </TableCell>
+                                                    <TableCell className="px-2 py-1.5" />
+                                                    <TableCell className="px-2 py-1.5">
+                                                      <div className="flex items-center gap-0.5">
+                                                        <Button
+                                                          variant="ghost"
+                                                          size="icon"
+                                                          className="h-6 w-6 text-green-600 hover:text-green-700"
+                                                          onClick={() => void saveEdit()}
+                                                          disabled={editIsSaving}
+                                                        >
+                                                          <Check className="h-3 w-3" />
+                                                        </Button>
+                                                        <Button
+                                                          variant="ghost"
+                                                          size="icon"
+                                                          className="h-6 w-6"
+                                                          onClick={cancelEditing}
+                                                        >
+                                                          <X className="h-3 w-3" />
+                                                        </Button>
+                                                      </div>
+                                                    </TableCell>
+                                                  </>
+                                                ) : (
+                                                  <>
+                                                    <TableCell
+                                                      className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
+                                                      onClick={() =>
+                                                        rule.source === "manual"
+                                                          ? startEditingTierRule(rule)
+                                                          : startEditingTierOverride(model, rule)
+                                                      }
+                                                    >
+                                                      {formatPriceNumber(
+                                                        rule.input_price_per_million
+                                                      )}
+                                                    </TableCell>
+                                                    <TableCell
+                                                      className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
+                                                      onClick={() =>
+                                                        rule.source === "manual"
+                                                          ? startEditingTierRule(rule)
+                                                          : startEditingTierOverride(model, rule)
+                                                      }
+                                                    >
+                                                      {formatPriceNumber(
+                                                        rule.output_price_per_million
+                                                      )}
+                                                    </TableCell>
+                                                    <TableCell
+                                                      className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
+                                                      onClick={() =>
+                                                        rule.source === "manual"
+                                                          ? startEditingTierRule(rule)
+                                                          : startEditingTierOverride(model, rule)
+                                                      }
+                                                    >
+                                                      {formatPriceNumber(
+                                                        rule.cache_read_input_price_per_million
+                                                      )}
+                                                    </TableCell>
+                                                    <TableCell
+                                                      className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
+                                                      onClick={() =>
+                                                        rule.source === "manual"
+                                                          ? startEditingTierRule(rule)
+                                                          : startEditingTierOverride(model, rule)
+                                                      }
+                                                    >
+                                                      {formatPriceNumber(
+                                                        rule.cache_write_input_price_per_million
+                                                      )}
+                                                    </TableCell>
+                                                    <TableCell className="px-2 py-1.5">
+                                                      {rule.source === "manual" ? (
+                                                        <Switch
+                                                          checked={rule.is_active}
+                                                          onCheckedChange={(checked) =>
+                                                            updateTierRule.mutate({
+                                                              id: rule.id,
+                                                              data: { is_active: checked },
+                                                            })
+                                                          }
+                                                          disabled={updateTierRule.isPending}
+                                                        />
+                                                      ) : (
+                                                        <span className="text-muted-foreground">
+                                                          -
+                                                        </span>
+                                                      )}
+                                                    </TableCell>
+                                                    <TableCell className="px-2 py-1.5">
+                                                      {rule.source === "manual" && (
+                                                        <Button
+                                                          variant="ghost"
+                                                          size="icon"
+                                                          className="h-6 w-6"
+                                                          onClick={() =>
+                                                            deleteTierRule.mutate(rule.id)
+                                                          }
+                                                          disabled={deleteTierRule.isPending}
+                                                          title={t("tierRulesDelete")}
+                                                        >
+                                                          <Trash2 className="h-3 w-3" />
+                                                        </Button>
+                                                      )}
+                                                    </TableCell>
+                                                  </>
+                                                )}
+                                              </TableRow>
+                                            );
+                                          })}
+                                        </TableBody>
+                                      </Table>
+                                    </div>
+                                  </TableCell>
+                                </TableRow>
+                              )}
+                            </Fragment>
+                          );
+                        })}
+
+                        {priceCatalogVisibleSyncedItems.map((item: BillingModelPrice) => {
+                          const override = manualOverrideMap.get(item.model);
+                          const tierPreview = tierRulePreviewMap.get(item.model);
+                          const tierPreviewLabel = tierPreview
+                            ? `>${t("tierRulesThresholdTokens", {
+                                count: tierPreview.threshold_input_tokens / 1000,
+                              })}`
+                            : null;
+                          const effective = override
+                            ? {
+                                input: override.input_price_per_million,
+                                output: override.output_price_per_million,
+                                cacheRead: override.cache_read_input_price_per_million,
+                                cacheWrite: override.cache_write_input_price_per_million,
+                                source: "manual" as const,
+                              }
+                            : {
+                                input: item.input_price_per_million,
+                                output: item.output_price_per_million,
+                                cacheRead: item.cache_read_input_price_per_million,
+                                cacheWrite: item.cache_write_input_price_per_million,
+                                source: "litellm" as const,
+                              };
+                          const modelTierRules = allTierRulesMap.get(item.model);
+                          const hasTiers = !!modelTierRules && modelTierRules.length > 0;
+                          const isExpanded = expandedPriceRows.has(item.model);
+
+                          const renderEffectiveNumber = (options: {
+                            effectiveValue: number | null;
+                            syncedValue: number | null;
+                          }) => {
+                            const { effectiveValue, syncedValue } = options;
+                            if (effectiveValue == null) {
+                              return <span className="text-muted-foreground">-</span>;
+                            }
+
+                            if (!override) {
+                              return (
+                                <span className="tabular-nums">{effectiveValue.toFixed(4)}</span>
+                              );
+                            }
+
+                            const syncedLabel =
+                              syncedValue == null ? "-" : (syncedValue as number).toFixed(4);
+                            return (
+                              <div className="space-y-0.5">
+                                <div className="tabular-nums font-medium text-foreground">
+                                  {effectiveValue.toFixed(4)}
+                                </div>
+                                <div className="text-[11px] tabular-nums text-muted-foreground">
+                                  litellm: {syncedLabel}
+                                </div>
+                              </div>
+                            );
+                          };
+
+                          return (
+                            <Fragment key={item.id}>
+                              <TableRow
+                                className={cn(
+                                  "border-b border-divider/60 align-top",
+                                  hasTiers && "cursor-pointer",
+                                  recentlySavedModel === item.model && "bg-amber-500/10"
+                                )}
+                                onClick={hasTiers ? () => togglePriceRow(item.model) : undefined}
+                              >
+                                <TableCell
+                                  className="px-3 py-2"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  {override ? (
+                                    <Checkbox
+                                      checked={selectedResetModels.includes(item.model)}
+                                      onCheckedChange={(value) =>
+                                        toggleSelectedResetModel(item.model, value === true)
+                                      }
+                                      aria-label={t("priceCatalogSelectModel", {
+                                        model: item.model,
+                                      })}
+                                    />
+                                  ) : (
+                                    <span className="sr-only">-</span>
+                                  )}
+                                </TableCell>
+                                <TableCell className="px-3 py-2 font-mono">
+                                  <span className="block whitespace-normal break-words leading-5">
+                                    {item.model}
+                                  </span>
+                                </TableCell>
+                                <TableCell className="px-3 py-2 whitespace-nowrap">
+                                  <div className="space-y-1">
+                                    <Badge variant={override ? "success" : "neutral"}>
+                                      {override
+                                        ? t("priceCatalogEffectiveManual")
+                                        : t("priceCatalogEffectiveSynced")}
+                                    </Badge>
+                                    <p className="text-[11px] text-muted-foreground">
+                                      {item.source}
+                                    </p>
+                                  </div>
+                                </TableCell>
+                                <TableCell className="hidden px-3 py-2 text-xs text-muted-foreground lg:table-cell">
+                                  <div className="space-y-1">
+                                    <div>{tierRuleThresholdMap.get(item.model) ?? "-"}</div>
+                                    <div>
+                                      {item.max_input_tokens != null
+                                        ? item.max_input_tokens.toLocaleString()
+                                        : "-"}{" "}
+                                      /{" "}
+                                      {item.max_output_tokens != null
+                                        ? item.max_output_tokens.toLocaleString()
+                                        : "-"}
+                                    </div>
+                                  </div>
+                                </TableCell>
+                                {isEditingPrice(item.model) ? (
+                                  <>
+                                    <TableCell
+                                      className="px-3 py-2"
+                                      onClick={(e) => e.stopPropagation()}
+                                    >
+                                      <div className="space-y-2">
+                                        <div className="grid grid-cols-2 gap-x-4 gap-y-1.5">
+                                          {PRICE_FIELDS_SHORT.map(([field, label]) => (
+                                            <div
+                                              key={field}
+                                              className="grid grid-cols-[24px_auto] items-center gap-2"
+                                            >
+                                              <span className="text-[11px] text-muted-foreground">
+                                                {label}
+                                              </span>
+                                              <Input
+                                                value={editDraft[field]}
+                                                onChange={(e) =>
+                                                  setDraftField(field, e.target.value)
+                                                }
+                                                className="h-7 text-xs tabular-nums"
+                                                onKeyDown={editKeyDown}
+                                              />
+                                            </div>
+                                          ))}
+                                        </div>
+                                        <div className="grid grid-cols-[24px_auto] items-center gap-2">
+                                          <span className="text-[11px] text-muted-foreground">
+                                            {t("overrideNote")}
+                                          </span>
+                                          <Input
+                                            value={editDraft.note}
+                                            onChange={(e) => setDraftField("note", e.target.value)}
+                                            className="h-7 text-xs"
+                                            onKeyDown={editKeyDown}
+                                          />
+                                        </div>
+                                      </div>
+                                    </TableCell>
+                                    <TableCell className="hidden px-3 py-2 lg:table-cell" />
+                                    <TableCell
+                                      className="px-3 py-2"
+                                      onClick={(e) => e.stopPropagation()}
+                                    >
+                                      <div className="flex items-center gap-1">
+                                        <Button
+                                          variant="ghost"
+                                          size="icon"
+                                          className="h-8 w-8 text-green-600 hover:text-green-700"
+                                          onClick={() => void saveEdit()}
+                                          disabled={editIsSaving}
+                                        >
+                                          <Check className="h-4 w-4" />
+                                        </Button>
+                                        <Button
+                                          variant="ghost"
+                                          size="icon"
+                                          className="h-8 w-8"
+                                          onClick={cancelEditing}
+                                        >
+                                          <X className="h-4 w-4" />
+                                        </Button>
+                                      </div>
+                                    </TableCell>
+                                  </>
+                                ) : (
+                                  <>
+                                    <TableCell
+                                      className="px-3 py-2 cursor-pointer hover:bg-surface-300/40 transition-colors"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        startEditingPrice(item.model, override);
+                                      }}
+                                    >
+                                      <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+                                        <div className="grid grid-cols-[24px_auto] items-start justify-start gap-2">
+                                          <span className="pt-0.5 text-[11px] text-muted-foreground">
+                                            IN
+                                          </span>
+                                          <div>
+                                            {renderEffectiveNumber({
+                                              effectiveValue: effective.input,
+                                              syncedValue: item.input_price_per_million,
+                                            })}
+                                            {tierPreviewLabel ? (
+                                              <div className="text-[11px] tabular-nums text-muted-foreground">
+                                                {tierPreviewLabel}:{" "}
+                                                {formatPriceNumber(
+                                                  tierPreview?.input_price_per_million ?? null
+                                                )}
+                                              </div>
+                                            ) : null}
+                                          </div>
+                                        </div>
+                                        <div className="grid grid-cols-[24px_auto] items-start justify-start gap-2">
+                                          <span className="pt-0.5 text-[11px] text-muted-foreground">
+                                            CR
+                                          </span>
+                                          <div>
+                                            {renderEffectiveNumber({
+                                              effectiveValue: effective.cacheRead,
+                                              syncedValue: item.cache_read_input_price_per_million,
+                                            })}
+                                          </div>
+                                        </div>
+                                        <div className="grid grid-cols-[24px_auto] items-start justify-start gap-2">
+                                          <span className="pt-0.5 text-[11px] text-muted-foreground">
+                                            OUT
+                                          </span>
+                                          <div>
+                                            {renderEffectiveNumber({
+                                              effectiveValue: effective.output,
+                                              syncedValue: item.output_price_per_million,
+                                            })}
+                                            {tierPreviewLabel ? (
+                                              <div className="text-[11px] tabular-nums text-muted-foreground">
+                                                {tierPreviewLabel}:{" "}
+                                                {formatPriceNumber(
+                                                  tierPreview?.output_price_per_million ?? null
+                                                )}
+                                              </div>
+                                            ) : null}
+                                          </div>
+                                        </div>
+                                        <div className="grid grid-cols-[24px_auto] items-start justify-start gap-2">
+                                          <span className="pt-0.5 text-[11px] text-muted-foreground">
+                                            CW
+                                          </span>
+                                          <div>
+                                            {renderEffectiveNumber({
+                                              effectiveValue: effective.cacheWrite,
+                                              syncedValue: item.cache_write_input_price_per_million,
+                                            })}
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </TableCell>
+                                    <TableCell className="hidden px-3 py-2 text-xs text-muted-foreground lg:table-cell">
+                                      {new Date(item.synced_at).toLocaleString(locale)}
+                                    </TableCell>
+                                    <TableCell
+                                      className="px-3 py-2"
+                                      onClick={(e) => e.stopPropagation()}
+                                    >
+                                      <div className="flex items-center gap-1">
+                                        {override ? (
+                                          <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            className="h-8 w-8"
+                                            onClick={() => openResetDialog([item.model])}
+                                            disabled={resetOverrides.isPending}
+                                            title={t("priceCatalogResetToOfficial")}
+                                          >
+                                            <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                                          </Button>
+                                        ) : (
+                                          <span className="inline-block h-8 w-8" />
+                                        )}
+                                        {hasTiers && (
+                                          <button
+                                            type="button"
+                                            className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-surface-300/60"
+                                            onClick={() => togglePriceRow(item.model)}
+                                            title={t(
+                                              isExpanded
+                                                ? "priceCatalogCollapseTiers"
+                                                : "priceCatalogExpandTiers"
+                                            )}
+                                          >
+                                            <ExpandChevron expanded={isExpanded} />
+                                          </button>
+                                        )}
+                                      </div>
+                                    </TableCell>
+                                  </>
+                                )}
+                              </TableRow>
+                              {isExpanded && (
+                                <TableRow className="bg-surface-300/10">
+                                  <TableCell colSpan={7} className="px-3 py-3">
+                                    <div className="space-y-4">
+                                      {hasTiers && modelTierRules && (
+                                        <div className="space-y-2">
+                                          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                                            {t("tierRulesTitle")} ({modelTierRules.length})
+                                          </p>
+                                          <Table
+                                            className="w-full text-xs"
+                                            frame="none"
+                                            containerClassName="rounded-none border-0 bg-transparent"
+                                          >
+                                            <TableHeader>
+                                              <TableRow className="border-b border-divider/40 text-left text-[11px] uppercase tracking-wide text-muted-foreground hover:bg-transparent">
+                                                <TableHead className="px-2 py-1 h-auto">
+                                                  {t("tierRulesThreshold")}
+                                                </TableHead>
+                                                <TableHead className="px-2 py-1 h-auto">
+                                                  {t("tierRulesSource")}
+                                                </TableHead>
+                                                <TableHead className="px-2 py-1 h-auto">
+                                                  IN
+                                                </TableHead>
+                                                <TableHead className="px-2 py-1 h-auto">
+                                                  OUT
+                                                </TableHead>
+                                                <TableHead className="px-2 py-1 h-auto">
+                                                  CR
+                                                </TableHead>
+                                                <TableHead className="px-2 py-1 h-auto">
+                                                  CW
+                                                </TableHead>
+                                                <TableHead className="px-2 py-1 h-auto">
+                                                  {t("tierRulesActive")}
+                                                </TableHead>
+                                                <TableHead className="w-10 px-2 py-1 h-auto" />
+                                              </TableRow>
+                                            </TableHeader>
+                                            <TableBody>
+                                              {modelTierRules.map((rule) => {
+                                                const isTierEditing =
+                                                  rule.source === "manual"
+                                                    ? isEditingTierRule(rule.id)
+                                                    : isEditingTierOverride(
+                                                        item.model,
+                                                        rule.threshold_input_tokens
+                                                      );
+                                                return (
+                                                  <TableRow
+                                                    key={rule.id}
+                                                    className={cn(
+                                                      "border-b border-divider/30",
+                                                      !rule.is_active && "opacity-50"
+                                                    )}
+                                                  >
+                                                    <TableCell className="px-2 py-1.5 tabular-nums">
+                                                      {t("tierRulesThresholdTokens", {
+                                                        count: rule.threshold_input_tokens / 1000,
+                                                      })}
+                                                    </TableCell>
+                                                    <TableCell className="px-2 py-1.5">
+                                                      <Badge
+                                                        variant={
+                                                          rule.source === "manual"
+                                                            ? "success"
+                                                            : "neutral"
+                                                        }
+                                                      >
+                                                        {rule.source === "manual"
+                                                          ? t("tierRulesSourceManual")
+                                                          : t("tierRulesSourceLitellm")}
+                                                      </Badge>
+                                                    </TableCell>
+                                                    {isTierEditing ? (
+                                                      <>
+                                                        <TableCell className="px-2 py-1.5">
+                                                          <Input
+                                                            value={editDraft.input}
+                                                            onChange={(e) =>
+                                                              setDraftField("input", e.target.value)
+                                                            }
+                                                            className="h-6 w-20 text-xs tabular-nums"
+                                                            onKeyDown={editKeyDown}
+                                                          />
+                                                        </TableCell>
+                                                        <TableCell className="px-2 py-1.5">
+                                                          <Input
+                                                            value={editDraft.output}
+                                                            onChange={(e) =>
+                                                              setDraftField(
+                                                                "output",
+                                                                e.target.value
+                                                              )
+                                                            }
+                                                            className="h-6 w-20 text-xs tabular-nums"
+                                                            onKeyDown={editKeyDown}
+                                                          />
+                                                        </TableCell>
+                                                        <TableCell className="px-2 py-1.5">
+                                                          <Input
+                                                            value={editDraft.cacheRead}
+                                                            onChange={(e) =>
+                                                              setDraftField(
+                                                                "cacheRead",
+                                                                e.target.value
+                                                              )
+                                                            }
+                                                            className="h-6 w-20 text-xs tabular-nums"
+                                                            onKeyDown={editKeyDown}
+                                                          />
+                                                        </TableCell>
+                                                        <TableCell className="px-2 py-1.5">
+                                                          <Input
+                                                            value={editDraft.cacheWrite}
+                                                            onChange={(e) =>
+                                                              setDraftField(
+                                                                "cacheWrite",
+                                                                e.target.value
+                                                              )
+                                                            }
+                                                            className="h-6 w-20 text-xs tabular-nums"
+                                                            onKeyDown={editKeyDown}
+                                                          />
+                                                        </TableCell>
+                                                        <TableCell className="px-2 py-1.5" />
+                                                        <TableCell className="px-2 py-1.5">
+                                                          <div className="flex items-center gap-0.5">
+                                                            <Button
+                                                              variant="ghost"
+                                                              size="icon"
+                                                              className="h-6 w-6 text-green-600 hover:text-green-700"
+                                                              onClick={() => void saveEdit()}
+                                                              disabled={editIsSaving}
+                                                            >
+                                                              <Check className="h-3 w-3" />
+                                                            </Button>
+                                                            <Button
+                                                              variant="ghost"
+                                                              size="icon"
+                                                              className="h-6 w-6"
+                                                              onClick={cancelEditing}
+                                                            >
+                                                              <X className="h-3 w-3" />
+                                                            </Button>
+                                                          </div>
+                                                        </TableCell>
+                                                      </>
+                                                    ) : (
+                                                      <>
+                                                        <TableCell
+                                                          className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
+                                                          onClick={() =>
+                                                            rule.source === "manual"
+                                                              ? startEditingTierRule(rule)
+                                                              : startEditingTierOverride(
+                                                                  item.model,
+                                                                  rule
+                                                                )
+                                                          }
+                                                        >
+                                                          {formatPriceNumber(
+                                                            rule.input_price_per_million
+                                                          )}
+                                                        </TableCell>
+                                                        <TableCell
+                                                          className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
+                                                          onClick={() =>
+                                                            rule.source === "manual"
+                                                              ? startEditingTierRule(rule)
+                                                              : startEditingTierOverride(
+                                                                  item.model,
+                                                                  rule
+                                                                )
+                                                          }
+                                                        >
+                                                          {formatPriceNumber(
+                                                            rule.output_price_per_million
+                                                          )}
+                                                        </TableCell>
+                                                        <TableCell
+                                                          className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
+                                                          onClick={() =>
+                                                            rule.source === "manual"
+                                                              ? startEditingTierRule(rule)
+                                                              : startEditingTierOverride(
+                                                                  item.model,
+                                                                  rule
+                                                                )
+                                                          }
+                                                        >
+                                                          {formatPriceNumber(
+                                                            rule.cache_read_input_price_per_million
+                                                          )}
+                                                        </TableCell>
+                                                        <TableCell
+                                                          className="px-2 py-1.5 tabular-nums cursor-pointer hover:bg-surface-300/40 transition-colors"
+                                                          onClick={() =>
+                                                            rule.source === "manual"
+                                                              ? startEditingTierRule(rule)
+                                                              : startEditingTierOverride(
+                                                                  item.model,
+                                                                  rule
+                                                                )
+                                                          }
+                                                        >
+                                                          {formatPriceNumber(
+                                                            rule.cache_write_input_price_per_million
+                                                          )}
+                                                        </TableCell>
+                                                        <TableCell className="px-2 py-1.5">
+                                                          {rule.source === "manual" ? (
+                                                            <Switch
+                                                              checked={rule.is_active}
+                                                              onCheckedChange={(checked) =>
+                                                                updateTierRule.mutate({
+                                                                  id: rule.id,
+                                                                  data: { is_active: checked },
+                                                                })
+                                                              }
+                                                              disabled={updateTierRule.isPending}
+                                                            />
+                                                          ) : (
+                                                            <span className="text-muted-foreground">
+                                                              -
+                                                            </span>
+                                                          )}
+                                                        </TableCell>
+                                                        <TableCell className="px-2 py-1.5">
+                                                          {rule.source === "manual" && (
+                                                            <Button
+                                                              variant="ghost"
+                                                              size="icon"
+                                                              className="h-6 w-6"
+                                                              onClick={() =>
+                                                                deleteTierRule.mutate(rule.id)
+                                                              }
+                                                              disabled={deleteTierRule.isPending}
+                                                              title={t("tierRulesDelete")}
+                                                            >
+                                                              <Trash2 className="h-3 w-3" />
+                                                            </Button>
+                                                          )}
+                                                        </TableCell>
+                                                      </>
+                                                    )}
+                                                  </TableRow>
+                                                );
+                                              })}
+                                            </TableBody>
+                                          </Table>
+                                        </div>
+                                      )}
+                                    </div>
+                                  </TableCell>
+                                </TableRow>
+                              )}
+                            </Fragment>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
+                  </div>
                 </div>
 
                 {modelPrices.data && modelPrices.data.total_pages > 1 && (
-                  <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="mt-3 flex flex-col gap-3 border-t border-divider/70 bg-surface-200/45 pt-3 sm:flex-row sm:items-center sm:justify-between">
                     <div className="type-body-small text-muted-foreground">
                       {tCommon("items")}{" "}
                       <span className="font-semibold text-foreground">

--- a/src/app/[locale]/(dashboard)/upstreams/page.tsx
+++ b/src/app/[locale]/(dashboard)/upstreams/page.tsx
@@ -31,7 +31,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { Badge } from "@/components/ui/badge";
 import {
   useAllUpstreams,
   useUpstreams,
@@ -252,10 +251,10 @@ export default function UpstreamsPage() {
     <>
       <Topbar title={t("pageTitle")} />
 
-      <div className="min-w-0 space-y-6 px-4 py-5 sm:px-6 lg:px-8 lg:py-7 xl:px-10">
+      <div className="min-w-0 max-w-full space-y-6 overflow-x-hidden px-3 py-5 sm:px-6 lg:px-8 lg:py-7 xl:px-10">
         <Card
           variant="outlined"
-          className="border-surface-400/65 bg-surface-300/38 shadow-[var(--vr-shadow-sm)] backdrop-blur supports-[backdrop-filter]:bg-surface-300/32"
+          className="w-full max-w-full overflow-hidden border-surface-400/65 bg-surface-300/38 shadow-[var(--vr-shadow-sm)] backdrop-blur supports-[backdrop-filter]:bg-surface-300/32"
         >
           <CardContent className="space-y-4 p-4 sm:p-5 lg:p-6">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
@@ -277,7 +276,7 @@ export default function UpstreamsPage() {
               </Button>
             </div>
 
-            <div className="rounded-cf-md border border-surface-400/65 bg-surface-400/28 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] sm:p-4">
+            <div className="border-t border-divider/70 pt-4">
               <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
                 <div className="relative flex-1">
                   <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -290,7 +289,7 @@ export default function UpstreamsPage() {
                   />
                 </div>
 
-                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:w-[460px]">
+                <div className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2 lg:w-[460px]">
                   <Select
                     value={statusFilter}
                     onValueChange={(value) => setStatusFilter(value as UpstreamStatusFilter)}
@@ -354,39 +353,31 @@ export default function UpstreamsPage() {
               </div>
 
               <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
-                <div className="flex flex-wrap items-center gap-2 rounded-cf-sm border border-divider/80 bg-surface-300/42 px-2.5 py-1.5">
-                  <Badge
-                    variant="outline"
-                    className="border-surface-400/70 bg-surface-200/45 text-muted-foreground"
-                  >
+                <div className="flex min-w-0 max-w-full flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                  <span className="whitespace-nowrap">
                     {t("overviewTotal", { count: overview.total })}
-                  </Badge>
-                  <Badge
-                    variant="outline"
-                    className="border-surface-400/70 bg-surface-200/45 text-muted-foreground"
-                  >
+                  </span>
+                  <span className="h-3 w-px bg-divider/70" aria-hidden="true" />
+                  <span className="whitespace-nowrap">
                     {t("overviewHealthy", { count: overview.healthy })}
-                  </Badge>
-                  <Badge
-                    variant="outline"
+                  </span>
+                  <span className="h-3 w-px bg-divider/70" aria-hidden="true" />
+                  <span
                     className={cn(
-                      "border-surface-400/70 bg-surface-200/45 text-muted-foreground",
-                      overview.fullConcurrency > 0 &&
-                        "border-status-warning/45 bg-status-warning-muted text-status-warning"
+                      "whitespace-nowrap",
+                      overview.fullConcurrency > 0 && "text-status-warning"
                     )}
                   >
                     {t("overviewConcurrencyFull", { count: overview.fullConcurrency })}
-                  </Badge>
-                  <Badge
-                    variant="outline"
-                    className="border-surface-400/70 bg-surface-200/45 text-muted-foreground"
-                  >
+                  </span>
+                  <span className="h-3 w-px bg-divider/70" aria-hidden="true" />
+                  <span className="whitespace-nowrap">
                     {t("overviewFiltered", { count: overview.filtered })}
-                  </Badge>
+                  </span>
                 </div>
 
-                <div className="flex flex-wrap items-center justify-end gap-3">
-                  <div className="inline-flex items-center rounded-cf-sm border border-surface-400/70 bg-surface-200/70 p-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+                <div className="flex min-w-0 max-w-full flex-wrap items-center justify-end gap-3">
+                  <div className="inline-flex max-w-full items-center rounded-cf-sm border border-surface-400/70 bg-surface-200/70 p-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
                     <span className="px-2 text-[11px] text-muted-foreground">
                       {t("densityLabel")}
                     </span>

--- a/src/components/admin/logs-table.tsx
+++ b/src/components/admin/logs-table.tsx
@@ -3402,10 +3402,7 @@ export function LogsTable({ logs, isLive = false }: LogsTableProps) {
               </div>
             </TooltipProvider>
           ) : (
-            <div
-              ref={setDesktopTableContainerElement}
-              className="overflow-x-auto rounded-cf-md border border-divider bg-card"
-            >
+            <div ref={setDesktopTableContainerElement} className="overflow-x-auto bg-card">
               <TooltipProvider>
                 {desktopSections.map((section, sectionIndex) => (
                   <Fragment key={section.key}>

--- a/src/components/admin/route-capability-badges.tsx
+++ b/src/components/admin/route-capability-badges.tsx
@@ -209,7 +209,7 @@ export function RouteCapabilityBadges({
   }
 
   return (
-    <div className={cn("flex min-w-0 max-w-full flex-nowrap gap-1.5 overflow-hidden", className)}>
+    <div className={cn("flex min-w-0 max-w-full flex-wrap gap-1.5 overflow-visible", className)}>
       {capabilities.map((capability) => (
         <RouteCapabilityBadge key={capability} capability={capability} className={badgeClassName} />
       ))}

--- a/src/components/admin/upstreams-table.tsx
+++ b/src/components/admin/upstreams-table.tsx
@@ -413,7 +413,7 @@ export function UpstreamsTable({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="w-full max-w-full space-y-4 overflow-hidden">
       {tieredData.map((tier) => {
         const isCollapsed = collapsedTiers.has(tier.priority);
         const isClosing = closingTiers.has(tier.priority);
@@ -431,7 +431,7 @@ export function UpstreamsTable({
         return (
           <section
             key={`tier-${tier.priority}`}
-            className="rounded-cf-md border border-surface-400/55 bg-surface-400/40 shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]"
+            className="w-full max-w-full overflow-hidden rounded-cf-md border border-surface-400/55 bg-surface-300/24"
           >
             <button
               type="button"
@@ -492,16 +492,16 @@ export function UpstreamsTable({
               <div
                 data-state={isClosing ? "closed" : "open"}
                 className={cn(
-                  "origin-top overflow-hidden motion-reduce:transition-none",
+                  "origin-top motion-reduce:transition-none",
                   "transition-[max-height,opacity,transform] duration-[260ms] ease-cf-standard",
                   isClosing || isOpening
                     ? "max-h-0 -translate-y-1 opacity-0"
-                    : "max-h-[2400px] translate-y-0 opacity-100"
+                    : "max-h-none overflow-visible translate-y-0 opacity-100"
                 )}
               >
                 <div
                   className={cn(
-                    "grid gap-3 rounded-b-cf-md bg-surface-200/62 ring-1 ring-inset ring-surface-100/35",
+                    "grid min-w-0 gap-3 bg-transparent [&>*]:min-w-0",
                     isCompactDensity
                       ? "p-3 sm:p-3.5 md:grid-cols-2 2xl:grid-cols-3"
                       : "p-3 sm:p-4 xl:grid-cols-2"
@@ -567,7 +567,7 @@ export function UpstreamsTable({
                       <article
                         key={upstream.id}
                         className={cn(
-                          "rounded-cf-md border bg-card shadow-[var(--vr-shadow-sm)]",
+                          "w-full min-w-0 max-w-full overflow-hidden rounded-cf-md border bg-card shadow-[var(--vr-shadow-sm)]",
                           "transition-[transform,box-shadow,border-color,opacity,filter] duration-300 ease-cf-standard",
                           isCompactDensity ? "p-2.5 sm:p-3" : "p-3 sm:p-4",
                           upstream.is_active
@@ -587,7 +587,7 @@ export function UpstreamsTable({
                               isCompactDensity ? "space-y-1.5" : "space-y-2"
                             )}
                           >
-                            <div className="flex flex-wrap items-center gap-2">
+                            <div className="flex min-w-0 max-w-full flex-wrap items-center gap-2">
                               <Badge
                                 variant="outline"
                                 className={cn(
@@ -638,7 +638,7 @@ export function UpstreamsTable({
                             <RouteCapabilityBadges
                               capabilities={upstream.route_capabilities}
                               className={cn(
-                                "max-w-full items-start gap-1.5",
+                                "max-w-full flex-wrap items-start gap-1.5 overflow-visible",
                                 !upstream.is_active && "opacity-75"
                               )}
                               badgeClassName={cn(
@@ -722,7 +722,7 @@ export function UpstreamsTable({
                         >
                           <section
                             className={cn(
-                              "rounded-cf-sm border border-divider bg-surface-300/45",
+                              "min-w-0 overflow-hidden rounded-cf-sm bg-surface-300/35",
                               isCompactDensity ? "p-2.5" : "p-3"
                             )}
                           >
@@ -761,7 +761,7 @@ export function UpstreamsTable({
 
                           <section
                             className={cn(
-                              "rounded-cf-sm border border-divider bg-surface-300/45",
+                              "min-w-0 overflow-hidden rounded-cf-sm bg-surface-300/35",
                               isCompactDensity ? "p-2.5" : "p-3"
                             )}
                           >
@@ -806,7 +806,7 @@ export function UpstreamsTable({
                             {!concurrency.unlimited && (
                               <div
                                 className={cn(
-                                  "mt-2 flex items-center justify-between gap-2 rounded-cf-sm border border-divider bg-surface-200 px-2",
+                                  "mt-2 flex items-center justify-between gap-2 rounded-cf-sm bg-surface-200/75 px-2",
                                   isCompactDensity ? "py-1" : "py-1.5"
                                 )}
                               >
@@ -838,7 +838,7 @@ export function UpstreamsTable({
 
                         <section
                           className={cn(
-                            "rounded-cf-sm border border-divider bg-surface-300/45",
+                            "min-w-0 overflow-hidden rounded-cf-sm bg-surface-300/35",
                             isCompactDensity ? "mt-2.5 p-2.5" : "mt-3 p-3"
                           )}
                         >

--- a/src/components/dashboard/leaderboard-section.tsx
+++ b/src/components/dashboard/leaderboard-section.tsx
@@ -47,7 +47,7 @@ function formatCost(usd: number): string {
 }
 
 const RANK_ROW_BASE =
-  "flex items-center gap-3 rounded-cf-sm border-l-2 px-2.5 py-1.5 transition-colors border border-divider-subtle/60 bg-surface-300/50 hover:bg-surface-400/60";
+  "flex items-center gap-3 rounded-cf-sm border-l-2 px-2.5 py-1.5 transition-colors bg-surface-300/42 hover:bg-surface-400/55";
 
 function getRankRowClass(index: number): string {
   if (index < RANK_LEFT_BORDERS.length) {

--- a/src/components/dashboard/usage-chart.tsx
+++ b/src/components/dashboard/usage-chart.tsx
@@ -441,7 +441,7 @@ export function UsageChart({
           </div>
         </div>
 
-        <div className="rounded-cf-md border border-divider/75 bg-surface-200/25 px-3 py-2.5">
+        <div className="border-y border-divider/60 bg-surface-200/20 py-2.5">
           <div className="flex flex-wrap items-center gap-3 lg:gap-4">
             <div className="inline-flex w-fit lg:shrink-0">
               <button

--- a/tests/components/route-capability-badges.test.tsx
+++ b/tests/components/route-capability-badges.test.tsx
@@ -31,6 +31,25 @@ describe("RouteCapabilityBadges", () => {
     const { container } = render(<RouteCapabilityBadges capabilities={[]} />);
     expect(container.firstChild).toBeNull();
   });
+
+  it("allows capability badges to wrap instead of clipping on narrow screens", () => {
+    const { container } = render(
+      <RouteCapabilityBadges
+        capabilities={[
+          "openai_chat_compatible",
+          "codex_cli_responses",
+          "openai_responses",
+          "anthropic_messages",
+        ]}
+      />
+    );
+
+    const badgeList = container.firstChild as HTMLElement;
+    expect(badgeList.className).toContain("flex-wrap");
+    expect(badgeList.className).toContain("overflow-visible");
+    expect(badgeList.className).not.toContain("flex-nowrap");
+    expect(badgeList.className).not.toContain("overflow-hidden");
+  });
 });
 
 describe("RouteCapabilityMultiSelect", () => {

--- a/tests/components/upstreams-table.test.tsx
+++ b/tests/components/upstreams-table.test.tsx
@@ -286,6 +286,24 @@ describe("UpstreamsTable", () => {
     expect(screen.getByText("OpenAI Main")).toBeInTheDocument();
   });
 
+  it("keeps expanded tier content unconstrained so long mobile lists are not clipped", () => {
+    const { container } = render(
+      <UpstreamsTable
+        upstreams={[baseUpstream]}
+        onEdit={onEdit}
+        onDelete={onDelete}
+        onTest={onTest}
+      />
+    );
+
+    const expandedTier = container.querySelector('[data-state="open"]');
+
+    expect(expandedTier).toBeInTheDocument();
+    expect(expandedTier?.className).toContain("max-h-none");
+    expect(expandedTier?.className).toContain("overflow-visible");
+    expect(expandedTier?.className).not.toContain("max-h-[2400px]");
+  });
+
   it("calls toggle mutation when active switch changes", async () => {
     mockToggleUpstreamActive.mockResolvedValueOnce(undefined);
 


### PR DESCRIPTION
## Summary

Fix admin UI layout clipping and nested card framing issues across the dashboard, with emphasis on mobile upstream cards and the billing model price catalog.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (code improvement without changing functionality)
- [x] Tests (adding or updating tests)
- [ ] Build/CI (changes to build system or CI configuration)

## Changes

- Reduced nested card framing across keys, logs, dashboard, upstream, and billing admin surfaces.
- Added an independent scroll region for the billing model price catalog so pagination remains reachable when the catalog is long.
- Fixed mobile upstream card clipping by allowing capability badges to wrap and expanded tier content to grow without a fixed max-height cap.
- Added regression coverage for capability badge wrapping and unconstrained upstream tier expansion.

## Test Plan

- [x] Local tests pass (`pnpm test:run`)
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`)
- [x] Manual testing completed

Additional verification performed:

- `pnpm exec prettier --check "src/components/admin/upstreams-table.tsx" "src/components/admin/route-capability-badges.tsx" "tests/components/upstreams-table.test.tsx" "tests/components/route-capability-badges.test.tsx"`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm test:run -- tests/components/upstreams-table.test.tsx tests/components/route-capability-badges.test.tsx`
- `pnpm lint`
- `pnpm build`
- `pnpm test:run`
- Playwright mobile checks for `/zh-CN/upstreams` and `/zh-CN/system/billing` at 390px.

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

No screenshots attached. Manual Playwright checks verified the mobile layout at 390px for the affected pages.

## Additional Notes

Remote CI is passing on PR #145, including Quality, Production Build, Migration Consistency, Proxy Stability, Playwright E2E, CodeQL, and Codecov checks.
