### PR TITLE
Refine admin pagination and sensitive inputs

### DIFF
--- a/src/app/[locale]/(auth)/login/page.tsx
+++ b/src/app/[locale]/(auth)/login/page.tsx
@@ -8,7 +8,7 @@ import { ArrowRight, Cpu, KeyRound, Shield, Terminal } from "lucide-react";
 
 import { LanguageSwitcher } from "@/components/language-switcher";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
 import { createApiClient } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { useRouter } from "@/i18n/navigation";
@@ -231,9 +231,10 @@ export default function LoginPage() {
                       className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
                       aria-hidden="true"
                     />
-                    <Input
+                    <PasswordInput
                       id="admin-token"
-                      type="password"
+                      allowPasswordManager
+                      autoComplete="current-password"
                       placeholder={t("tokenPlaceholder")}
                       value={inputValue}
                       onChange={(e) => setInputValue(e.target.value)}

--- a/src/app/[locale]/(dashboard)/keys/page.tsx
+++ b/src/app/[locale]/(dashboard)/keys/page.tsx
@@ -2,15 +2,15 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { ChevronLeft, ChevronRight, Key } from "lucide-react";
+import { Key } from "lucide-react";
 
 import { CreateKeyDialog } from "@/components/admin/create-key-dialog";
 import { EditKeyDialog } from "@/components/admin/edit-key-dialog";
 import { KeysTable } from "@/components/admin/keys-table";
+import { PaginationControls } from "@/components/admin/pagination-controls";
 import { RevokeKeyDialog } from "@/components/admin/revoke-key-dialog";
 import { Topbar } from "@/components/admin/topbar";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { useAPIKeys } from "@/hooks/use-api-keys";
 import type { APIKey } from "@/types/api";
 
@@ -86,38 +86,13 @@ export default function KeysPage() {
 
             {data && data.total_pages > 1 && (
               <Card variant="filled" className="border border-divider">
-                <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="type-body-small text-muted-foreground">
-                    {tCommon("items")}{" "}
-                    <span className="font-semibold text-foreground">{data.total}</span> ·{" "}
-                    {tCommon("page")}{" "}
-                    <span className="font-semibold text-foreground">{data.page}</span>{" "}
-                    {tCommon("of")}{" "}
-                    <span className="font-semibold text-foreground">{data.total_pages}</span>
-                  </div>
-                  <div className="flex gap-2">
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => setPage(page - 1)}
-                      disabled={page === 1}
-                      className="gap-1"
-                    >
-                      <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-                      {tCommon("previous")}
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => setPage(page + 1)}
-                      disabled={page === data.total_pages}
-                      className="gap-1"
-                    >
-                      {tCommon("next")}
-                      <ChevronRight className="h-4 w-4" aria-hidden="true" />
-                    </Button>
-                  </div>
-                </CardContent>
+                <PaginationControls
+                  total={data.total}
+                  page={page}
+                  totalPages={data.total_pages}
+                  onPageChange={setPage}
+                  className="p-4"
+                />
               </Card>
             )}
           </>

--- a/src/app/[locale]/(dashboard)/logs/page.tsx
+++ b/src/app/[locale]/(dashboard)/logs/page.tsx
@@ -2,13 +2,13 @@
 
 import { useState, useCallback } from "react";
 import { useTranslations } from "next-intl";
-import { ChevronLeft, ChevronRight, ScrollText } from "lucide-react";
+import { ScrollText } from "lucide-react";
 
 import { LogsTable } from "@/components/admin/logs-table";
+import { PaginationControls } from "@/components/admin/pagination-controls";
 import { RefreshIntervalSelect } from "@/components/admin/refresh-interval-select";
 import { Topbar } from "@/components/admin/topbar";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -220,38 +220,13 @@ export default function LogsPage() {
                 className={cn("border border-divider", LOGS_SECTION_ENTER_CLASS)}
                 style={{ animationDelay: "140ms" }}
               >
-                <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="type-body-small text-muted-foreground">
-                    {tCommon("items")}{" "}
-                    <span className="font-semibold text-foreground">{data.total}</span> ·{" "}
-                    {tCommon("page")}{" "}
-                    <span className="font-semibold text-foreground">{data.page}</span>{" "}
-                    {tCommon("of")}{" "}
-                    <span className="font-semibold text-foreground">{data.total_pages}</span>
-                  </div>
-                  <div className="flex gap-2">
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => setPage(page - 1)}
-                      disabled={page === 1}
-                      className="gap-1"
-                    >
-                      <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-                      {tCommon("previous")}
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => setPage(page + 1)}
-                      disabled={page === data.total_pages}
-                      className="gap-1"
-                    >
-                      {tCommon("next")}
-                      <ChevronRight className="h-4 w-4" aria-hidden="true" />
-                    </Button>
-                  </div>
-                </CardContent>
+                <PaginationControls
+                  total={data.total}
+                  page={page}
+                  totalPages={data.total_pages}
+                  onPageChange={setPage}
+                  className="p-4"
+                />
               </Card>
             )}
           </>

--- a/src/app/[locale]/(dashboard)/system/billing/page.tsx
+++ b/src/app/[locale]/(dashboard)/system/billing/page.tsx
@@ -2,20 +2,11 @@
 
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations, useLocale } from "next-intl";
-import {
-  Check,
-  ChevronDown,
-  ChevronLeft,
-  ChevronRight,
-  Plus,
-  RotateCcw,
-  Trash2,
-  Wallet,
-  X,
-} from "lucide-react";
+import { Check, ChevronDown, Plus, RotateCcw, Trash2, Wallet, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
+import { PaginationControls } from "@/components/admin/pagination-controls";
 import { Topbar } from "@/components/admin/topbar";
 import {
   AlertDialog,
@@ -3613,21 +3604,18 @@ export default function BillingPage() {
                 </div>
 
                 {modelPrices.data && modelPrices.data.total_pages > 1 && (
-                  <div className="mt-3 flex flex-col gap-3 border-t border-divider/70 bg-surface-200/45 pt-3 sm:flex-row sm:items-center sm:justify-between">
-                    <div className="type-body-small text-muted-foreground">
-                      {tCommon("items")}{" "}
-                      <span className="font-semibold text-foreground">
-                        {modelPrices.data.total}
-                      </span>{" "}
-                      · {tCommon("page")}{" "}
-                      <span className="font-semibold text-foreground">{modelPrices.data.page}</span>{" "}
-                      {tCommon("of")}{" "}
-                      <span className="font-semibold text-foreground">
-                        {modelPrices.data.total_pages}
-                      </span>
-                    </div>
-                    <div className="flex gap-2">
-                      <div className="flex items-center gap-2">
+                  <PaginationControls
+                    total={modelPrices.data.total}
+                    page={modelPricePage}
+                    totalPages={modelPrices.data.total_pages}
+                    onPageChange={(nextPage) => {
+                      setModelPricePage(nextPage);
+                      setExpandedPriceRows(new Set());
+                      if (editTarget) setEditTarget(null);
+                    }}
+                    className="mt-3 border-t border-divider/70 bg-surface-200/45 pt-3"
+                    actionPrefix={
+                      <div className="flex items-center gap-2 pr-0 sm:pr-1">
                         <span className="text-xs text-muted-foreground">
                           {t("priceCatalogPageSize")}
                         </span>
@@ -3658,38 +3646,8 @@ export default function BillingPage() {
                           </SelectContent>
                         </Select>
                       </div>
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => {
-                          setModelPricePage((prev) => Math.max(1, prev - 1));
-                          setExpandedPriceRows(new Set());
-                          if (editTarget) setEditTarget(null);
-                        }}
-                        disabled={modelPricePage === 1}
-                        className="gap-1"
-                      >
-                        <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-                        {tCommon("previous")}
-                      </Button>
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => {
-                          setModelPricePage((prev) =>
-                            Math.min(modelPrices.data?.total_pages ?? prev, prev + 1)
-                          );
-                          setExpandedPriceRows(new Set());
-                          if (editTarget) setEditTarget(null);
-                        }}
-                        disabled={modelPricePage === modelPrices.data.total_pages}
-                        className="gap-1"
-                      >
-                        {tCommon("next")}
-                        <ChevronRight className="h-4 w-4" aria-hidden="true" />
-                      </Button>
-                    </div>
-                  </div>
+                    }
+                  />
                 )}
               </div>
             )}

--- a/src/app/[locale]/(dashboard)/upstreams/page.tsx
+++ b/src/app/[locale]/(dashboard)/upstreams/page.tsx
@@ -3,8 +3,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import {
-  ChevronLeft,
-  ChevronRight,
   Filter,
   LayoutGrid,
   Plus,
@@ -16,6 +14,7 @@ import {
 } from "lucide-react";
 
 import { DeleteUpstreamDialog } from "@/components/admin/delete-upstream-dialog";
+import { PaginationControls } from "@/components/admin/pagination-controls";
 import { TestUpstreamDialog } from "@/components/admin/test-upstream-dialog";
 import { Topbar } from "@/components/admin/topbar";
 import { UpstreamFormDialog } from "@/components/admin/upstream-form-dialog";
@@ -449,40 +448,13 @@ export default function UpstreamsPage() {
                 variant="filled"
                 className="border border-surface-400/65 bg-surface-300/35 shadow-[var(--vr-shadow-xs)]"
               >
-                <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="type-body-small text-muted-foreground">
-                    {tCommon("items")}{" "}
-                    <span className="font-semibold text-foreground">{upstreamsData.total}</span> ·{" "}
-                    {tCommon("page")}{" "}
-                    <span className="font-semibold text-foreground">{upstreamsData.page}</span>{" "}
-                    {tCommon("of")}{" "}
-                    <span className="font-semibold text-foreground">
-                      {upstreamsData.total_pages}
-                    </span>
-                  </div>
-                  <div className="flex gap-2">
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => setUpstreamPage(upstreamPage - 1)}
-                      disabled={upstreamPage === 1}
-                      className="gap-1"
-                    >
-                      <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-                      {tCommon("previous")}
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => setUpstreamPage(upstreamPage + 1)}
-                      disabled={upstreamPage === upstreamsData.total_pages}
-                      className="gap-1"
-                    >
-                      {tCommon("next")}
-                      <ChevronRight className="h-4 w-4" aria-hidden="true" />
-                    </Button>
-                  </div>
-                </CardContent>
+                <PaginationControls
+                  total={upstreamsData.total}
+                  page={upstreamPage}
+                  totalPages={upstreamsData.total_pages}
+                  onPageChange={setUpstreamPage}
+                  className="p-4"
+                />
               </Card>
             )}
           </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -515,6 +515,11 @@ html.theme-switching::before {
     font: inherit;
     color: inherit;
   }
+
+  .password-input__field::-ms-reveal,
+  .password-input__field::-ms-clear {
+    display: none;
+  }
 }
 
 @layer utilities {

--- a/src/components/admin/pagination-controls.tsx
+++ b/src/components/admin/pagination-controls.tsx
@@ -71,7 +71,11 @@ export function PaginationControls({
         {tCommon("of")} <span className="font-semibold text-foreground">{totalPages}</span>
       </div>
 
-      <form className="flex flex-wrap items-center gap-2 sm:justify-end" onSubmit={handleSubmit}>
+      <form
+        className="flex flex-wrap items-center gap-2 sm:justify-end"
+        onSubmit={handleSubmit}
+        noValidate
+      >
         {actionPrefix}
 
         <div className="flex items-center gap-2">

--- a/src/components/admin/pagination-controls.tsx
+++ b/src/components/admin/pagination-controls.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { type FormEvent, type ReactNode, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+interface PaginationControlsProps {
+  total: number;
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  actionPrefix?: ReactNode;
+  className?: string;
+}
+
+function clampPage(value: number, totalPages: number) {
+  return Math.min(Math.max(Math.trunc(value), 1), totalPages);
+}
+
+export function PaginationControls({
+  total,
+  page,
+  totalPages,
+  onPageChange,
+  actionPrefix,
+  className,
+}: PaginationControlsProps) {
+  const tCommon = useTranslations("common");
+  const currentPage = clampPage(page, totalPages);
+  const [pageDraft, setPageDraft] = useState(String(currentPage));
+
+  useEffect(() => {
+    setPageDraft(String(currentPage));
+  }, [currentPage]);
+
+  const parsedDraft = Number(pageDraft);
+  const canSubmit = Number.isFinite(parsedDraft) && pageDraft.trim() !== "";
+  const normalizedDraftPage = canSubmit ? clampPage(parsedDraft, totalPages) : currentPage;
+
+  const changePage = (nextPage: number) => {
+    const normalizedPage = clampPage(nextPage, totalPages);
+    setPageDraft(String(normalizedPage));
+    if (normalizedPage !== page) {
+      onPageChange(normalizedPage);
+    }
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSubmit) {
+      setPageDraft(String(currentPage));
+      return;
+    }
+    changePage(normalizedDraftPage);
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between",
+        className
+      )}
+    >
+      <div className="type-body-small text-muted-foreground">
+        {tCommon("items")} <span className="font-semibold text-foreground">{total}</span> ·{" "}
+        {tCommon("page")} <span className="font-semibold text-foreground">{currentPage}</span>{" "}
+        {tCommon("of")} <span className="font-semibold text-foreground">{totalPages}</span>
+      </div>
+
+      <form className="flex flex-wrap items-center gap-2 sm:justify-end" onSubmit={handleSubmit}>
+        {actionPrefix}
+
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">{tCommon("jumpToPage")}</span>
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={1}
+            max={totalPages}
+            value={pageDraft}
+            onChange={(event) => setPageDraft(event.target.value)}
+            onBlur={() => {
+              if (!canSubmit) {
+                setPageDraft(String(currentPage));
+              }
+            }}
+            className="h-9 w-20 px-2 text-center"
+            aria-label={tCommon("jumpToPageAria")}
+          />
+          {tCommon("pageSuffix") && (
+            <span className="text-xs text-muted-foreground">{tCommon("pageSuffix")}</span>
+          )}
+          <Button
+            type="submit"
+            variant="secondary"
+            size="sm"
+            disabled={!canSubmit || normalizedDraftPage === currentPage}
+          >
+            {tCommon("goToPage")}
+          </Button>
+        </div>
+
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={() => changePage(currentPage - 1)}
+          disabled={currentPage === 1}
+          className="gap-1"
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+          {tCommon("previousPage")}
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={() => changePage(currentPage + 1)}
+          disabled={currentPage === totalPages}
+          className="gap-1"
+        >
+          {tCommon("nextPage")}
+          <ChevronRight className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/admin/upstream-form-dialog.tsx
+++ b/src/components/admin/upstream-form-dialog.tsx
@@ -77,6 +77,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
 import { Textarea } from "@/components/ui/textarea";
 import {
   useCreateUpstream,
@@ -1942,9 +1943,8 @@ export function UpstreamFormDialog({
                           <FormItem>
                             <FormLabel>{t("apiKey")} *</FormLabel>
                             <FormControl>
-                              <Input
+                              <PasswordInput
                                 {...field}
-                                type="password"
                                 autoComplete="new-password"
                                 autoCapitalize="none"
                                 autoCorrect="off"

--- a/src/components/ui/password-input.tsx
+++ b/src/components/ui/password-input.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import * as React from "react";
+import { useTranslations } from "next-intl";
+import { Eye, EyeOff } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn, warnIfForbiddenVisualStyle } from "@/lib/utils";
+
+type PasswordInputProps = Omit<React.ComponentPropsWithoutRef<typeof Input>, "type"> & {
+  allowPasswordManager?: boolean;
+  containerClassName?: string;
+};
+
+const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
+  (
+    {
+      allowPasswordManager = false,
+      className,
+      containerClassName,
+      disabled,
+      autoComplete,
+      ...props
+    },
+    ref
+  ) => {
+    const tCommon = useTranslations("common");
+    const [isVisible, setIsVisible] = React.useState(false);
+    const [supportsTextSecurity, setSupportsTextSecurity] = React.useState(true);
+    const shouldUseTextSecurity = !isVisible && supportsTextSecurity && !allowPasswordManager;
+
+    React.useEffect(() => {
+      setSupportsTextSecurity(
+        typeof CSS !== "undefined" &&
+          typeof CSS.supports === "function" &&
+          CSS.supports("-webkit-text-security", "disc")
+      );
+    }, []);
+
+    warnIfForbiddenVisualStyle("PasswordInput", containerClassName);
+
+    return (
+      <div className={cn("relative", containerClassName)}>
+        <Input
+          ref={ref}
+          type={isVisible || shouldUseTextSecurity ? "text" : "password"}
+          disabled={disabled}
+          autoComplete={autoComplete ?? (allowPasswordManager ? "current-password" : "off")}
+          data-1p-ignore={allowPasswordManager ? undefined : "true"}
+          data-lpignore={allowPasswordManager ? undefined : "true"}
+          data-form-type={allowPasswordManager ? undefined : "other"}
+          className={cn(
+            "password-input__field pr-12",
+            shouldUseTextSecurity &&
+              "font-mono text-[16px] leading-none tracking-[0.22em] [-webkit-text-security:disc]",
+            className
+          )}
+          {...props}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="absolute right-1.5 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          onClick={() => setIsVisible((value) => !value)}
+          disabled={disabled}
+          aria-label={isVisible ? tCommon("hideSensitiveInput") : tCommon("showSensitiveInput")}
+        >
+          {isVisible ? (
+            <EyeOff className="h-4 w-4" aria-hidden="true" />
+          ) : (
+            <Eye className="h-4 w-4" aria-hidden="true" />
+          )}
+        </Button>
+      </div>
+    );
+  }
+);
+PasswordInput.displayName = "PasswordInput";
+
+export { PasswordInput };

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -22,6 +22,12 @@
     "back": "Back",
     "next": "Next",
     "previous": "Previous",
+    "nextPage": "Next page",
+    "previousPage": "Previous page",
+    "jumpToPage": "Go to page",
+    "jumpToPageAria": "Go to a specific page",
+    "pageSuffix": "",
+    "goToPage": "Go",
     "page": "Page",
     "of": "of",
     "items": "items",
@@ -38,6 +44,8 @@
     "sysOk": "SYS::OK",
     "expand": "Expand",
     "collapse": "Collapse",
+    "showSensitiveInput": "Show input value",
+    "hideSensitiveInput": "Hide input value",
     "logout": "Sign out of your account"
   },
   "nav": {

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -22,6 +22,12 @@
     "back": "返回",
     "next": "下一步",
     "previous": "上一步",
+    "nextPage": "下一页",
+    "previousPage": "上一页",
+    "jumpToPage": "跳转到第",
+    "jumpToPageAria": "跳转到指定页数",
+    "pageSuffix": "页",
+    "goToPage": "跳转",
     "page": "页",
     "of": "/",
     "items": "条",
@@ -38,6 +44,8 @@
     "sysOk": "SYS::OK",
     "expand": "展开",
     "collapse": "收起",
+    "showSensitiveInput": "显示输入内容",
+    "hideSensitiveInput": "隐藏输入内容",
     "logout": "退出当前账户"
   },
   "nav": {

--- a/tests/components/pagination-controls.test.tsx
+++ b/tests/components/pagination-controls.test.tsx
@@ -1,0 +1,131 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PaginationControls } from "@/components/admin/pagination-controls";
+
+const translations: Record<string, string> = {};
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => translations[key] ?? key,
+}));
+
+afterEach(() => {
+  Object.keys(translations).forEach((key) => delete translations[key]);
+});
+
+describe("PaginationControls", () => {
+  it("renders pagination copy, action content, and moves to adjacent pages", () => {
+    const onPageChange = vi.fn();
+
+    const { container } = render(
+      <PaginationControls
+        total={42}
+        page={2}
+        totalPages={5}
+        onPageChange={onPageChange}
+        actionPrefix={<button type="button">refresh</button>}
+      />
+    );
+
+    expect(container).toHaveTextContent("items 42");
+    expect(container).toHaveTextContent("page 2 of 5");
+    expect(screen.getByRole("button", { name: "refresh" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "previousPage" }));
+    fireEvent.click(screen.getByRole("button", { name: "nextPage" }));
+
+    expect(onPageChange).toHaveBeenNthCalledWith(1, 1);
+    expect(onPageChange).toHaveBeenNthCalledWith(2, 3);
+  });
+
+  it("submits a direct page jump", async () => {
+    const user = userEvent.setup();
+    const onPageChange = vi.fn();
+
+    render(<PaginationControls total={42} page={2} totalPages={5} onPageChange={onPageChange} />);
+
+    const input = screen.getByRole("spinbutton", { name: "jumpToPageAria" });
+    await user.clear(input);
+    await user.type(input, "4");
+    await user.click(screen.getByRole("button", { name: "goToPage" }));
+
+    expect(onPageChange).toHaveBeenCalledWith(4);
+    expect(input).toHaveValue(4);
+  });
+
+  it("clamps submitted page jumps to the available range", async () => {
+    const user = userEvent.setup();
+    const onPageChange = vi.fn();
+
+    render(<PaginationControls total={42} page={2} totalPages={5} onPageChange={onPageChange} />);
+
+    const input = screen.getByRole("spinbutton", { name: "jumpToPageAria" });
+    await user.clear(input);
+    await user.type(input, "99");
+    await user.click(screen.getByRole("button", { name: "goToPage" }));
+
+    expect(onPageChange).toHaveBeenCalledWith(5);
+    expect(input).toHaveValue(5);
+  });
+
+  it("resets invalid page drafts on blur and submit", async () => {
+    const user = userEvent.setup();
+    const onPageChange = vi.fn();
+
+    render(<PaginationControls total={42} page={3} totalPages={5} onPageChange={onPageChange} />);
+
+    const input = screen.getByRole("spinbutton", { name: "jumpToPageAria" });
+    await user.clear(input);
+    expect(screen.getByRole("button", { name: "goToPage" })).toBeDisabled();
+
+    fireEvent.blur(input);
+    expect(input).toHaveValue(3);
+
+    await user.clear(input);
+    fireEvent.submit(input.closest("form")!);
+
+    expect(input).toHaveValue(3);
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+
+  it("does not call onPageChange when a direct jump resolves to the current page", async () => {
+    const user = userEvent.setup();
+    const onPageChange = vi.fn();
+
+    render(<PaginationControls total={42} page={2} totalPages={5} onPageChange={onPageChange} />);
+
+    const input = screen.getByRole("spinbutton", { name: "jumpToPageAria" });
+    await user.clear(input);
+    await user.type(input, "2.9");
+    fireEvent.submit(input.closest("form")!);
+
+    expect(input).toHaveValue(2);
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+
+  it("updates the page draft when the current page changes and disables edge buttons", () => {
+    const onPageChange = vi.fn();
+    const { rerender } = render(
+      <PaginationControls total={42} page={1} totalPages={3} onPageChange={onPageChange} />
+    );
+
+    expect(screen.getByRole("button", { name: "previousPage" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "nextPage" })).toBeEnabled();
+    expect(screen.getByRole("spinbutton", { name: "jumpToPageAria" })).toHaveValue(1);
+
+    rerender(<PaginationControls total={42} page={3} totalPages={3} onPageChange={onPageChange} />);
+
+    expect(screen.getByRole("button", { name: "previousPage" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "nextPage" })).toBeDisabled();
+    expect(screen.getByRole("spinbutton", { name: "jumpToPageAria" })).toHaveValue(3);
+  });
+
+  it("omits the page suffix when the translation is empty", () => {
+    translations.pageSuffix = "";
+
+    render(<PaginationControls total={42} page={2} totalPages={5} onPageChange={vi.fn()} />);
+
+    expect(screen.queryByText("pageSuffix")).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/password-input.test.tsx
+++ b/tests/components/password-input.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PasswordInput } from "@/components/ui/password-input";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const originalCSS = globalThis.CSS;
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "CSS", {
+    configurable: true,
+    value: originalCSS,
+  });
+});
+
+describe("PasswordInput", () => {
+  it("keeps a right-side visibility toggle and switches input visibility", async () => {
+    Object.defineProperty(globalThis, "CSS", {
+      configurable: true,
+      value: {
+        supports: vi.fn(() => true),
+      },
+    });
+
+    render(<PasswordInput placeholder="secret value" />);
+
+    const input = screen.getByPlaceholderText("secret value");
+    await waitFor(() => {
+      expect(input).toHaveAttribute("type", "text");
+    });
+    expect(input.className).toContain("[-webkit-text-security:disc]");
+    expect(input.className).toContain("tracking-[0.22em]");
+    expect(input).toHaveAttribute("autocomplete", "off");
+    expect(input).toHaveAttribute("data-1p-ignore", "true");
+    expect(input).toHaveAttribute("data-lpignore", "true");
+    expect(input).toHaveAttribute("data-form-type", "other");
+
+    const showButton = screen.getByRole("button", { name: "showSensitiveInput" });
+    expect(showButton.className).toContain("right-1.5");
+
+    fireEvent.click(showButton);
+    expect(input).toHaveAttribute("type", "text");
+    expect(input.className).not.toContain("[-webkit-text-security:disc]");
+    expect(screen.getByRole("button", { name: "hideSensitiveInput" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "hideSensitiveInput" }));
+    await waitFor(() => {
+      expect(input).toHaveAttribute("type", "text");
+    });
+    expect(input.className).toContain("[-webkit-text-security:disc]");
+  });
+
+  it("falls back to native password type when text security is unavailable", async () => {
+    Object.defineProperty(globalThis, "CSS", {
+      configurable: true,
+      value: {
+        supports: vi.fn(() => false),
+      },
+    });
+
+    render(<PasswordInput placeholder="legacy browser" autoComplete="new-password" />);
+
+    const input = screen.getByPlaceholderText("legacy browser");
+    await waitFor(() => {
+      expect(input).toHaveAttribute("type", "password");
+    });
+    expect(input.className).not.toContain("[-webkit-text-security:disc]");
+    expect(input).toHaveAttribute("autocomplete", "new-password");
+  });
+
+  it("allows browser password managers when requested", async () => {
+    Object.defineProperty(globalThis, "CSS", {
+      configurable: true,
+      value: {
+        supports: vi.fn(() => true),
+      },
+    });
+
+    render(<PasswordInput placeholder="saved secret" allowPasswordManager />);
+
+    const input = screen.getByPlaceholderText("saved secret");
+    expect(input).toHaveAttribute("type", "password");
+    expect(input).toHaveAttribute("autocomplete", "current-password");
+    expect(input.className).not.toContain("[-webkit-text-security:disc]");
+    expect(input).not.toHaveAttribute("data-1p-ignore");
+    expect(input).not.toHaveAttribute("data-lpignore");
+    expect(input).not.toHaveAttribute("data-form-type");
+  });
+});


### PR DESCRIPTION
## Summary

Refines admin pagination controls and sensitive input behavior across the dashboard.

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (code improvement without changing functionality)
- [x] Tests (adding or updating tests)
- [ ] Build/CI (changes to build system or CI configuration)

## Changes

- Add a shared `PaginationControls` component with previous/next page labels and direct page jump support.
- Replace duplicated pagination controls in Keys, Upstreams, Logs, and Billing price catalog.
- Add coverage for `PaginationControls` rendering, adjacent navigation, direct page jumps, invalid input reset, boundary states, and empty page suffix behavior.
- Disable native form validation in `PaginationControls` so out-of-range direct jumps are handled by the component's own page clamping.
- Add a shared `PasswordInput` component with a fixed right-side visibility toggle.
- Keep login Admin Token compatible with browser saved-password quick fill through `allowPasswordManager`.
- Keep upstream API Key input protected from accidental browser autofill.
- Hide native Edge password reveal controls so only the project eye button is shown.
- Add English and Simplified Chinese common labels for pagination and sensitive input visibility.
- Add component coverage for `PasswordInput` visibility, password-manager mode, and fallback behavior.

## Test Plan

- [x] Local tests pass (`pnpm test:run`)
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`)
- [x] Manual testing completed

Additional checks completed:

- [x] Component tests pass (`pnpm test:run tests/components/pagination-controls.test.tsx tests/components/password-input.test.tsx`)
- [x] Coverage run passes (`pnpm test:run --coverage`): 121 files passed, 2222 tests passed, 1 skipped; statements 85.03%, branches 76.78%, functions 82.48%, lines 85.84%.
- [x] Format check passes (`pnpm format:check`)
- [x] Remote PR checks passed before the latest coverage commit: Quality, Production Build, Migration Consistency, Proxy Stability, Playwright E2E, CodeQL, Codecov project/patch

Note: `pnpm lint` completes successfully with the repository's existing `jsdoc/require-jsdoc` warnings.

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

UI-related change. Screenshots were provided during review of the login sensitive input behavior; no new image assets are included in this PR.

## Additional Notes

Branch: `admin-pagination-password-controls`
Commits: `11c42b8 feat: refine admin pagination and sensitive inputs`, `f8d07cc test:cover-admin-pagination-controls`
Latest remote checks are currently running for `f8d07cc`.
