### PR TITLE
Improve upstream form usability

### DIFF
--- a/src/components/admin/upstream-form-dialog.tsx
+++ b/src/components/admin/upstream-form-dialog.tsx
@@ -113,6 +113,7 @@ import {
   resolveRouteCapabilities,
 } from "@/lib/route-capabilities";
 import { RouteCapabilityMultiSelect } from "@/components/admin/route-capability-badges";
+import { DEFAULT_CIRCUIT_BREAKER_CONFIG } from "@/lib/circuit-breaker-defaults";
 import { inferDefaultModelDiscoveryConfig } from "@/lib/services/upstream-model-types";
 import { cn } from "@/lib/utils";
 
@@ -989,7 +990,12 @@ export function UpstreamFormDialog({
   const probeModelListId = useId();
   const t = useTranslations("upstreams");
   const tCommon = useTranslations("common");
-  const circuitBreakerUseDefaultPlaceholder = t("circuitBreakerUseDefaultPlaceholder");
+  const circuitBreakerDefaults = {
+    failureThreshold: DEFAULT_CIRCUIT_BREAKER_CONFIG.failureThreshold,
+    successThreshold: DEFAULT_CIRCUIT_BREAKER_CONFIG.successThreshold,
+    openDuration: Math.round(DEFAULT_CIRCUIT_BREAKER_CONFIG.openDuration / 1000),
+    probeInterval: Math.round(DEFAULT_CIRCUIT_BREAKER_CONFIG.probeInterval / 1000),
+  };
   const [configSearchQuery, setConfigSearchQuery] = useState("");
   const [activeSectionId, setActiveSectionId] = useState<ConfigSectionId>("basic-name");
   const [highlightedSectionId, setHighlightedSectionId] = useState<ConfigSectionId | null>(null);
@@ -2564,7 +2570,7 @@ export function UpstreamFormDialog({
                           </div>
                         </div>
 
-                        <div className="grid gap-4 xl:h-[min(62vh,720px)] xl:grid-cols-[minmax(0,1.02fr)_minmax(340px,0.98fr)]">
+                        <div className="grid gap-4 xl:h-[min(76vh,860px)] xl:grid-cols-[minmax(0,1.02fr)_minmax(340px,0.98fr)]">
                           <div className="flex min-h-0 flex-col gap-4 xl:border-r xl:border-divider/70 xl:pr-5">
                             <section className="space-y-3">
                               <div className="flex flex-wrap items-start justify-between gap-3">
@@ -3509,7 +3515,9 @@ export function UpstreamFormDialog({
                             type="number"
                             min={1}
                             max={100}
-                            placeholder={circuitBreakerUseDefaultPlaceholder}
+                            placeholder={t("circuitBreakerUseDefaultPlaceholder", {
+                              value: circuitBreakerDefaults.failureThreshold,
+                            })}
                             value={circuitBreakerConfig?.failure_threshold ?? ""}
                             onChange={(e) => {
                               const val = e.target.value ? parseInt(e.target.value, 10) : undefined;
@@ -3534,7 +3542,9 @@ export function UpstreamFormDialog({
                             type="number"
                             min={1}
                             max={100}
-                            placeholder={circuitBreakerUseDefaultPlaceholder}
+                            placeholder={t("circuitBreakerUseDefaultPlaceholder", {
+                              value: circuitBreakerDefaults.successThreshold,
+                            })}
                             value={circuitBreakerConfig?.success_threshold ?? ""}
                             onChange={(e) => {
                               const val = e.target.value ? parseInt(e.target.value, 10) : undefined;
@@ -3560,7 +3570,9 @@ export function UpstreamFormDialog({
                             min={1}
                             max={300}
                             step={1}
-                            placeholder={circuitBreakerUseDefaultPlaceholder}
+                            placeholder={t("circuitBreakerUseDefaultPlaceholder", {
+                              value: circuitBreakerDefaults.openDuration,
+                            })}
                             value={circuitBreakerConfig?.open_duration ?? ""}
                             onChange={(e) => {
                               const val = e.target.value ? parseInt(e.target.value, 10) : undefined;
@@ -3582,7 +3594,9 @@ export function UpstreamFormDialog({
                             min={1}
                             max={60}
                             step={1}
-                            placeholder={circuitBreakerUseDefaultPlaceholder}
+                            placeholder={t("circuitBreakerUseDefaultPlaceholder", {
+                              value: circuitBreakerDefaults.probeInterval,
+                            })}
                             value={circuitBreakerConfig?.probe_interval ?? ""}
                             onChange={(e) => {
                               const val = e.target.value ? parseInt(e.target.value, 10) : undefined;

--- a/src/lib/circuit-breaker-defaults.ts
+++ b/src/lib/circuit-breaker-defaults.ts
@@ -1,0 +1,13 @@
+export interface CircuitBreakerConfig {
+  failureThreshold: number;
+  successThreshold: number;
+  openDuration: number;
+  probeInterval: number;
+}
+
+export const DEFAULT_CIRCUIT_BREAKER_CONFIG: CircuitBreakerConfig = {
+  failureThreshold: 5,
+  successThreshold: 2,
+  openDuration: 5 * 60_000,
+  probeInterval: 30_000,
+};

--- a/src/lib/services/circuit-breaker.ts
+++ b/src/lib/services/circuit-breaker.ts
@@ -1,5 +1,11 @@
 import { eq } from "drizzle-orm";
 import { db, circuitBreakerStates, type CircuitBreakerState } from "../db";
+import {
+  DEFAULT_CIRCUIT_BREAKER_CONFIG,
+  type CircuitBreakerConfig,
+} from "../circuit-breaker-defaults";
+
+export type { CircuitBreakerConfig };
 
 /**
  * Circuit breaker states
@@ -11,24 +17,9 @@ export enum CircuitBreakerStateEnum {
 }
 
 /**
- * Circuit breaker configuration
- */
-export interface CircuitBreakerConfig {
-  failureThreshold: number;
-  successThreshold: number;
-  openDuration: number; // milliseconds
-  probeInterval: number; // milliseconds
-}
-
-/**
  * Default circuit breaker configuration
  */
-export const DEFAULT_CONFIG: CircuitBreakerConfig = {
-  failureThreshold: 5,
-  successThreshold: 2,
-  openDuration: 5 * 60_000,
-  probeInterval: 30_000,
-};
+export const DEFAULT_CONFIG: CircuitBreakerConfig = DEFAULT_CIRCUIT_BREAKER_CONFIG;
 
 /**
  * Error thrown when circuit breaker is open

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -884,7 +884,7 @@
     "targetModel": "Target Model",
     "modelRedirectsDescription": "Map requested model names to upstream-supported model names",
     "circuitBreakerConfig": "Circuit Breaker Configuration",
-    "circuitBreakerUseDefaultPlaceholder": "Leave empty to use system default",
+    "circuitBreakerUseDefaultPlaceholder": "Default: {value}",
     "failureThreshold": "Failure Threshold",
     "failureThresholdDesc": "Consecutive failures to trigger circuit open (1-100)",
     "successThreshold": "Success Threshold",

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -889,7 +889,7 @@
     "targetModel": "目标模型",
     "modelRedirectsDescription": "将请求中的模型名称映射为上游支持的模型名称",
     "circuitBreakerConfig": "熔断器配置",
-    "circuitBreakerUseDefaultPlaceholder": "留空使用系统默认",
+    "circuitBreakerUseDefaultPlaceholder": "默认值：{value}",
     "failureThreshold": "失败阈值",
     "failureThresholdDesc": "触发熔断的连续失败次数 (1-100)",
     "successThreshold": "成功阈值",

--- a/tests/components/upstream-form-dialog.test.tsx
+++ b/tests/components/upstream-form-dialog.test.tsx
@@ -6,7 +6,10 @@ import type { Upstream, UpstreamProbeResponse } from "@/types/api";
 
 // Mock next-intl
 vi.mock("next-intl", () => ({
-  useTranslations: () => (key: string) => key,
+  useTranslations: () => (key: string, values?: Record<string, string | number>) =>
+    key === "circuitBreakerUseDefaultPlaceholder" && values
+      ? `circuitBreakerUseDefaultPlaceholder:${values.value}`
+      : key,
 }));
 
 // Mock hooks
@@ -1032,6 +1035,7 @@ describe("UpstreamFormDialog", () => {
 
       expect(workspaceContainer).toBeTruthy();
       expect(workspaceContainer?.className).toContain("grid");
+      expect(workspaceContainer?.className).toContain("xl:h-[min(76vh,860px)]");
     });
 
     it("imports selected catalog entries and echoes returned model rules", async () => {
@@ -1355,6 +1359,27 @@ describe("UpstreamFormDialog", () => {
       ensureAdvancedConfigExpanded();
       const priorityInput = screen.getByPlaceholderText("priorityPlaceholder");
       expect(priorityInput).toHaveValue(3);
+    });
+
+    it("shows concrete circuit breaker defaults in empty override inputs", () => {
+      render(<UpstreamFormDialog open={true} onOpenChange={mockOnOpenChange} />, {
+        wrapper: Wrapper,
+      });
+
+      ensureAdvancedConfigExpanded();
+
+      expect(
+        screen.getByPlaceholderText("circuitBreakerUseDefaultPlaceholder:5")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("circuitBreakerUseDefaultPlaceholder:2")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("circuitBreakerUseDefaultPlaceholder:300")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("circuitBreakerUseDefaultPlaceholder:30")
+      ).toBeInTheDocument();
     });
 
     it("submits edited upstream with updated priority", async () => {


### PR DESCRIPTION
## Summary

- Show concrete circuit breaker defaults in upstream form inputs.
- Share circuit breaker defaults through a client-safe constants module.
- Increase the desktop model routing workspace height for better 1080p usability.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (code improvement without changing functionality)
- [x] Tests (adding or updating tests)
- [ ] Build/CI (changes to build system or CI configuration)

## Changes

- Added `src/lib/circuit-breaker-defaults.ts` so UI and service code read the same default values without importing server-side database dependencies into client code.
- Updated upstream form placeholders to display the actual default circuit breaker values.
- Increased the model discovery/rules desktop workspace from `62vh` to `76vh` with a higher max height for the rules area.
- Added component regression coverage for the default value placeholders and desktop workspace height.

## Test Plan

- [x] Local tests pass (`pnpm test:run`)
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`)
- [ ] Manual testing completed

Additional validation performed:

- `pnpm test:run tests/components/upstream-form-dialog.test.tsx`
- `pnpm test:run tests/unit/services/circuit-breaker.test.ts`
- `pnpm build`
- `pnpm format:check`
- `lsp_diagnostics` on modified TypeScript files
- Oracle read-only review passed

Note: `pnpm lint` reports 0 errors and 37 existing `jsdoc/require-jsdoc` warnings outside this change.

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

UI change is layout/placeholder-only. No screenshot attached.

## Additional Notes

The branch contains three atomic commits and keeps `master` aligned with `origin/master`.