### PR TITLE
ci: generate grouped release notes with git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,25 +158,28 @@ jobs:
             fi
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
+
       - name: Generate release notes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
-          NOTES_ARGS=(
-            -f tag_name="${GITHUB_REF_NAME}"
-            -f target_commitish="${{ steps.validate.outputs.release_commit }}"
-          )
+          CLIFF_RANGE="${GITHUB_REF_NAME}"
 
           if [ -n "${{ steps.notes_baseline.outputs.previous_tag }}" ]; then
-            NOTES_ARGS+=(-f previous_tag_name="${{ steps.notes_baseline.outputs.previous_tag }}")
+            CLIFF_RANGE="${{ steps.notes_baseline.outputs.previous_tag }}..${GITHUB_REF_NAME}"
           fi
 
-          gh api \
-            "repos/${{ github.repository }}/releases/generate-notes" \
-            "${NOTES_ARGS[@]}" \
-            --jq .body > generated-release-notes.md
+          git-cliff \
+            --config cliff.toml \
+            --output generated-release-notes.md \
+            --github-repo "${{ github.repository }}" \
+            "${CLIFF_RANGE}"
 
       - name: Build release body and metadata
         shell: bash
@@ -198,6 +201,14 @@ jobs:
 
           EOF
           cat generated-release-notes.md >> release-body.md
+          if [ -n "${{ steps.notes_baseline.outputs.previous_tag }}" ]; then
+            cat >> release-body.md <<EOF
+
+          ## Changelog
+
+          Full Changelog: ${{ github.server_url }}/${{ github.repository }}/compare/${{ steps.notes_baseline.outputs.compare_range }}
+          EOF
+          fi
 
           cat > release-metadata.json <<EOF
           {

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,50 @@
+# git-cliff configuration for GitHub Release notes.
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+body = """
+{%- macro remote_url() -%}
+https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+
+{% if commits | length == 0 -%}
+No notable changes.
+{% else -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+## {{ group }}
+
+{% for commit in commits -%}
+{% if commit.remote.pr_title -%}
+{%- set commit_message = commit.remote.pr_title -%}
+{%- else -%}
+{%- set commit_message = commit.message -%}
+{%- endif -%}
+- {{ commit_message | split(pat="\n") | first | trim }}{% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }})){% endif %}
+{% endfor %}
+{% endfor %}
+{% endif -%}
+
+"""
+trim = true
+postprocessors = [
+  { pattern = "(?m)^- (feat|fix|docs?|security|perf|refactor|test|ci|build|chore)(\\([^)]+\\))?!?:\\s*", replace = "- " },
+]
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+filter_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "oldest"
+
+commit_parsers = [
+  { message = "^feat", group = "New Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^security", group = "Security" },
+  { message = "^docs?", group = "Documentation" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Maintenance" },
+  { message = "^test", group = "Tests" },
+  { message = "^(ci|build|chore)", group = "Maintenance" },
+  { message = ".*", group = "Other Changes" },
+]


### PR DESCRIPTION
## Summary

- Replace GitHub generated release notes with git-cliff grouped release notes.
- Add `cliff.toml` for semantic commit based release categories.
- Preserve existing release metadata, image digest, and compare range behavior.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (code improvement without changing functionality)
- [ ] Tests (adding or updating tests)
- [x] Build/CI (changes to build system or CI configuration)

## Changes

- Install `git-cliff` in the Release workflow before release note generation.
- Replace GitHub `releases/generate-notes` with `git-cliff`.
- Keep the existing release body metadata and `release-metadata.json` generation.
- Append `Full Changelog` from the existing `notes_baseline.compare_range`.

## Test Plan

- [ ] Local tests pass (`pnpm test:run`)
- [ ] Type check passes (`pnpm exec tsc --noEmit`)
- [ ] Lint passes (`pnpm lint`)
- [x] Manual testing completed

Manual validation:
- `pnpm dlx git-cliff --config cliff.toml --output "C:/Users/admin/AppData/Local/Temp/opencode/autorouter-release-notes.md" --github-repo "g1331/AutoRouter" "v0.2.1..v0.2.2-alpha.1"`
- `pnpm exec prettier --check ".github/workflows/release.yml"`
- `pnpm dlx js-yaml ".github/workflows/release.yml"`

## Checklist

- [x] Code follows the project's coding standards
- [ ] Tests have been added where necessary
- [ ] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

N/A

## Additional Notes

This PR does not change the release artifact publishing flow. It only changes the source and formatting of generated release notes.