### PR TITLE
ci: skip merge commits in release notes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -38,6 +38,8 @@ tag_pattern = "v[0-9].*"
 sort_commits = "oldest"
 
 commit_parsers = [
+  { message = "^Merge pull request", skip = true },
+  { message = "^Merge branch", skip = true },
   { message = "^feat", group = "New Features" },
   { message = "^fix", group = "Bug Fixes" },
   { message = "^security", group = "Security" },


### PR DESCRIPTION
## Summary

- Skip GitHub merge commits in `git-cliff` release notes.
- Keep release notes focused on semantic commits from merged branches.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (code improvement without changing functionality)
- [ ] Tests (adding or updating tests)
- [x] Build/CI (changes to build system or CI configuration)

## Changes

- Add `git-cliff` skip parsers for `Merge pull request` and `Merge branch` commit messages.

## Test Plan

- [ ] Local tests pass (`pnpm test:run`)
- [ ] Type check passes (`pnpm exec tsc --noEmit`)
- [ ] Lint passes (`pnpm lint`)
- [x] Manual testing completed

Manual validation:
- `pnpm dlx git-cliff --config cliff.toml --output "C:/Users/admin/AppData/Local/Temp/opencode/autorouter-release-notes-alpha2-fixed.md" --github-repo "g1331/AutoRouter" "v0.2.2-alpha.1..v0.2.2-alpha.2"`

## Checklist

- [x] Code follows the project's coding standards
- [ ] Tests have been added where necessary
- [ ] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

N/A

## Additional Notes

This PR fixes a release-note generation edge case found during the `v0.2.2-alpha.2` test release.