### PR TITLE
ci: order release notes sections

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,11 +175,17 @@ jobs:
             CLIFF_RANGE="${{ steps.notes_baseline.outputs.previous_tag }}..${GITHUB_REF_NAME}"
           fi
 
-          git-cliff \
-            --config cliff.toml \
-            --output generated-release-notes.md \
-            --github-repo "${{ github.repository }}" \
-            "${CLIFF_RANGE}"
+          CLIFF_ARGS=(
+            --config cliff.toml
+            --output generated-release-notes.md
+            --github-repo "${{ github.repository }}"
+          )
+
+          if [[ ! "${GITHUB_REF_NAME}" =~ - ]]; then
+            CLIFF_ARGS+=(--ignore-tags '.*-(alpha|beta)\.[0-9]+$')
+          fi
+
+          git-cliff "${CLIFF_ARGS[@]}" "${CLIFF_RANGE}"
 
       - name: Build release body and metadata
         shell: bash

--- a/cliff.toml
+++ b/cliff.toml
@@ -10,10 +10,13 @@ https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
 {% if commits | length == 0 -%}
 No notable changes.
 {% else -%}
-{% for group, commits in commits | group_by(attribute="group") %}
+{% set ordered_groups = ["New Features", "Bug Fixes", "Security", "Performance", "Documentation", "Tests", "Maintenance", "Other Changes"] %}
+{% set grouped_commits = commits | group_by(attribute="group") %}
+{% for group in ordered_groups -%}
+{% if group in grouped_commits -%}
 ## {{ group }}
 
-{% for commit in commits -%}
+{% for commit in grouped_commits[group] -%}
 {% if commit.remote.pr_title -%}
 {%- set commit_message = commit.remote.pr_title -%}
 {%- else -%}
@@ -21,6 +24,7 @@ No notable changes.
 {%- endif -%}
 - {{ commit_message | split(pat="\n") | first | trim }}{% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }})){% endif %}
 {% endfor %}
+{% endif -%}
 {% endfor %}
 {% endif -%}
 
@@ -43,10 +47,10 @@ commit_parsers = [
   { message = "^feat", group = "New Features" },
   { message = "^fix", group = "Bug Fixes" },
   { message = "^security", group = "Security" },
-  { message = "^docs?", group = "Documentation" },
   { message = "^perf", group = "Performance" },
-  { message = "^refactor", group = "Maintenance" },
+  { message = "^docs?", group = "Documentation" },
   { message = "^test", group = "Tests" },
+  { message = "^refactor", group = "Maintenance" },
   { message = "^(ci|build|chore)", group = "Maintenance" },
   { message = ".*", group = "Other Changes" },
 ]


### PR DESCRIPTION
## Summary

Fixes release note section rendering so stable releases show each category once, in a reader-friendly order.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (code improvement without changing functionality)
- [ ] Tests (adding or updating tests)
- [x] Build/CI (changes to build system or CI configuration)

## Changes

- Orders git-cliff release note groups with an explicit template list.
- Prevents duplicate headings when commits from the same group are separated by other commits.
- Ignores intermediate alpha and beta tags for stable release note generation so stable notes stay in one generated section.

## Test Plan

- [ ] Local tests pass (`pnpm test:run`)
- [ ] Type check passes (`pnpm exec tsc --noEmit`)
- [ ] Lint passes (`pnpm lint`)
- [x] Manual testing completed

Manual validation:
- Ran `git diff --check`.
- Ran `git-cliff` locally for `v0.2.1..v0.2.2` with prerelease tags ignored and confirmed headings render once in the expected order.
- Verified `.github/workflows/release.yml` with YAML diagnostics.
- Verified `cliff.toml` through `git-cliff` parsing and pre-commit `check toml`.

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

N/A

## Additional Notes

The already published `v0.2.2` GitHub Release body was updated manually to use the corrected section order.