### PR TITLE
feat: preview upstream model catalog refresh

### DIFF
--- a/src/app/api/admin/upstreams/[id]/catalog/preview/route.ts
+++ b/src/app/api/admin/upstreams/[id]/catalog/preview/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { ROUTE_CAPABILITY_VALUES, normalizeRouteCapabilities } from "@/lib/route-capabilities";
+import {
+  previewUpstreamCatalog,
+  UpstreamNotFoundError,
+  type UpstreamCatalogPreviewInput,
+} from "@/lib/services/upstream-service";
+import { errorResponse } from "@/lib/utils/api-auth";
+import { validateAdminAuth } from "@/lib/utils/auth";
+import { createLogger } from "@/lib/utils/logger";
+
+const log = createLogger("admin-upstream-catalog-preview");
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+const modelDiscoverySchema = z.object({
+  mode: z.enum([
+    "openai_compatible",
+    "anthropic_native",
+    "gemini_native",
+    "gemini_openai_compatible",
+    "custom",
+    "litellm",
+  ]),
+  custom_endpoint: z.string().trim().min(1).nullable().optional(),
+  enable_lite_llm_fallback: z.boolean().default(false),
+  auto_refresh_enabled: z.boolean().default(false),
+});
+
+const previewCatalogSchema = z.object({
+  base_url: z.string().url(),
+  api_key: z.string().optional(),
+  route_capabilities: z.array(z.enum(ROUTE_CAPABILITY_VALUES)).nullable().optional(),
+  model_discovery: modelDiscoverySchema.nullable().optional(),
+});
+
+/**
+ * Preview the model catalog for an upstream using the current editor values.
+ */
+export async function POST(request: NextRequest, context: RouteContext) {
+  const authHeader = request.headers.get("authorization");
+  if (!validateAdminAuth(authHeader)) {
+    return errorResponse("Unauthorized", 401);
+  }
+
+  try {
+    const { id } = await context.params;
+    const body = await request.json();
+    const validated = previewCatalogSchema.parse(body);
+    const input: UpstreamCatalogPreviewInput = {
+      baseUrl: validated.base_url,
+      apiKey: validated.api_key,
+      routeCapabilities:
+        validated.route_capabilities !== undefined
+          ? normalizeRouteCapabilities(validated.route_capabilities ?? [])
+          : undefined,
+      modelDiscovery:
+        validated.model_discovery === undefined
+          ? undefined
+          : validated.model_discovery
+            ? {
+                mode: validated.model_discovery.mode,
+                customEndpoint: validated.model_discovery.custom_endpoint ?? null,
+                enableLiteLlmFallback: validated.model_discovery.enable_lite_llm_fallback,
+                autoRefreshEnabled: validated.model_discovery.auto_refresh_enabled,
+              }
+            : null,
+    };
+
+    const preview = await previewUpstreamCatalog(id, input);
+
+    return NextResponse.json({
+      model_discovery: preview.modelDiscovery
+        ? {
+            mode: preview.modelDiscovery.mode,
+            custom_endpoint: preview.modelDiscovery.customEndpoint,
+            enable_lite_llm_fallback: preview.modelDiscovery.enableLiteLlmFallback,
+            auto_refresh_enabled: preview.modelDiscovery.autoRefreshEnabled,
+          }
+        : null,
+      model_catalog: preview.modelCatalog,
+      model_catalog_updated_at: preview.modelCatalogUpdatedAt?.toISOString() ?? null,
+      model_catalog_last_status: preview.modelCatalogLastStatus,
+      model_catalog_last_error: preview.modelCatalogLastError,
+      model_catalog_last_failed_at: preview.modelCatalogLastFailedAt?.toISOString() ?? null,
+    });
+  } catch (error) {
+    if (error instanceof UpstreamNotFoundError) {
+      return errorResponse("Upstream not found", 404);
+    }
+
+    if (error instanceof z.ZodError) {
+      return errorResponse(
+        `Validation error: ${error.issues.map((issue) => issue.message).join(", ")}`,
+        400
+      );
+    }
+
+    log.error({ err: error }, "failed to preview upstream catalog");
+    return errorResponse(error instanceof Error ? error.message : "Internal server error", 500);
+  }
+}

--- a/src/components/admin/upstream-form-dialog.tsx
+++ b/src/components/admin/upstream-form-dialog.tsx
@@ -84,8 +84,7 @@ import { Textarea } from "@/components/ui/textarea";
 import {
   useCreateUpstream,
   useExecuteUpstreamProbe,
-  useImportUpstreamCatalogModels,
-  useRefreshUpstreamCatalog,
+  usePreviewUpstreamCatalog,
   useUpstreamProbes,
   useUpdateUpstream,
 } from "@/hooks/use-upstreams";
@@ -101,6 +100,7 @@ import type {
   UpstreamModelRule,
   UpstreamModelRuleSource,
   UpstreamModelRuleType,
+  UpstreamCatalogPreviewResponse,
   UpstreamProbeClientProfile,
   UpstreamProbeResponse,
 } from "@/types/api";
@@ -508,6 +508,65 @@ function buildCatalogWorkspaceState(upstream?: Upstream | null): CatalogWorkspac
     modelCatalogLastError: upstream?.model_catalog_last_error ?? null,
     modelCatalogLastFailedAt: upstream?.model_catalog_last_failed_at ?? null,
   };
+}
+
+function applyCatalogPreviewToUpstream(
+  upstream: Upstream,
+  preview: UpstreamCatalogPreviewResponse
+): Upstream {
+  return {
+    ...upstream,
+    model_discovery: preview.model_discovery,
+    model_catalog: preview.model_catalog,
+    model_catalog_updated_at: preview.model_catalog_updated_at,
+    model_catalog_last_status: preview.model_catalog_last_status,
+    model_catalog_last_error: preview.model_catalog_last_error,
+    model_catalog_last_failed_at: preview.model_catalog_last_failed_at,
+  };
+}
+
+function areCatalogWorkspaceStatesEqual(
+  left: CatalogWorkspaceState,
+  right: CatalogWorkspaceState
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function importCatalogModelsIntoRules(
+  catalog: UpstreamModelCatalogEntry[],
+  selectedModels: string[],
+  currentRules: UpstreamFormValues["model_rules"]
+): UpstreamFormValues["model_rules"] {
+  const catalogByModel = new Map(catalog.map((entry) => [entry.model, entry]));
+  const nextRules = [...currentRules];
+
+  for (const model of selectedModels) {
+    const catalogEntry = catalogByModel.get(model);
+    if (!catalogEntry) {
+      continue;
+    }
+
+    const importedRule: UpstreamFormValues["model_rules"][number] = {
+      type: "exact",
+      value: catalogEntry.model,
+      target_model: null,
+      source: catalogEntry.source,
+      display_label: null,
+    };
+    const alreadyPresent = nextRules.some(
+      (rule) =>
+        rule.type === importedRule.type &&
+        rule.value === importedRule.value &&
+        (rule.target_model ?? null) === importedRule.target_model &&
+        rule.source === importedRule.source
+    );
+
+    if (!alreadyPresent) {
+      nextRules.push(importedRule);
+    }
+  }
+
+  return nextRules;
 }
 
 function buildUpstreamFormDefaults(upstream?: Upstream | null): UpstreamFormValues {
@@ -981,8 +1040,7 @@ export function UpstreamFormDialog({
   const isEdit = !!upstream;
   const activeSchema = isEdit ? editUpstreamFormSchema : createUpstreamFormSchema;
   const createMutation = useCreateUpstream();
-  const refreshCatalogMutation = useRefreshUpstreamCatalog();
-  const importCatalogMutation = useImportUpstreamCatalogModels();
+  const previewCatalogMutation = usePreviewUpstreamCatalog();
   const updateMutation = useUpdateUpstream();
   const executeProbeMutation = useExecuteUpstreamProbe();
   const resetExecuteProbeMutation = executeProbeMutation.reset;
@@ -1105,6 +1163,16 @@ export function UpstreamFormDialog({
   const catalogState = useMemo(
     () => buildCatalogWorkspaceState(workspaceUpstream ?? upstream),
     [upstream, workspaceUpstream]
+  );
+  const catalogWorkspaceDirty = useMemo(
+    () =>
+      isEdit &&
+      !!upstream &&
+      !areCatalogWorkspaceStatesEqual(
+        buildCatalogWorkspaceState(upstream),
+        buildCatalogWorkspaceState(workspaceUpstream ?? upstream)
+      ),
+    [isEdit, upstream, workspaceUpstream]
   );
   const configSections = useMemo<ConfigSectionEntry[]>(
     () => [
@@ -1337,7 +1405,10 @@ export function UpstreamFormDialog({
     const currentValues = normalizeUpstreamFormValuesForDirtyCheck(form.getValues());
     const normalizedDefaultValues = normalizeUpstreamFormValuesForDirtyCheck(defaultValues);
 
-    return JSON.stringify(currentValues) !== JSON.stringify(normalizedDefaultValues);
+    return (
+      catalogWorkspaceDirty ||
+      JSON.stringify(currentValues) !== JSON.stringify(normalizedDefaultValues)
+    );
   };
 
   const mutationProbe =
@@ -1570,13 +1641,29 @@ export function UpstreamFormDialog({
   };
 
   const handleRefreshCatalog = async () => {
-    if (!upstream || catalogRefreshDependencyDirty) {
+    if (!upstream) {
       return;
     }
 
     try {
-      const refreshedUpstream = await refreshCatalogMutation.mutateAsync(upstream.id);
-      syncWorkspaceFromRemoteUpstream(refreshedUpstream);
+      const preview = await previewCatalogMutation.mutateAsync({
+        id: upstream.id,
+        data: {
+          base_url: watchedBaseUrl ?? "",
+          ...(watchedApiKey?.trim() ? { api_key: watchedApiKey.trim() } : {}),
+          route_capabilities: watchedRouteCapabilities ?? [],
+          model_discovery: watchedModelDiscovery
+            ? toApiModelDiscoveryValue(watchedModelDiscovery)
+            : null,
+        },
+      });
+      setWorkspaceUpstream((current) =>
+        applyCatalogPreviewToUpstream(current ?? upstream, preview)
+      );
+      const refreshedModelSet = new Set((preview.model_catalog ?? []).map((entry) => entry.model));
+      setSelectedCatalogModels((current) =>
+        current.filter((model) => refreshedModelSet.has(model))
+      );
     } catch {
       // Refresh errors are surfaced by the mutation toast.
     }
@@ -1610,20 +1697,17 @@ export function UpstreamFormDialog({
   };
 
   const handleImportCatalog = async () => {
-    if (!upstream || selectedCatalogModels.length === 0) {
+    if (selectedCatalogModels.length === 0) {
       return;
     }
 
-    try {
-      const updatedUpstream = await importCatalogMutation.mutateAsync({
-        id: upstream.id,
-        models: selectedCatalogModels,
-      });
-      syncWorkspaceFromRemoteUpstream(updatedUpstream, { replaceRules: true });
-      setSelectedCatalogModels([]);
-    } catch {
-      // Import errors are surfaced by the mutation toast.
-    }
+    const nextRules = importCatalogModelsIntoRules(
+      catalogState.modelCatalog,
+      selectedCatalogModels,
+      form.getValues("model_rules")
+    );
+    replaceModelRules(nextRules);
+    setSelectedCatalogModels([]);
   };
 
   const onSubmit = async (values: UpstreamFormValues) => {
@@ -1659,6 +1743,11 @@ export function UpstreamFormDialog({
             | null;
           route_capabilities?: RouteCapability[] | null;
           model_discovery?: UpstreamModelDiscoveryConfig | null;
+          model_catalog?: UpstreamModelCatalogEntry[] | null;
+          model_catalog_updated_at?: string | null;
+          model_catalog_last_status?: UpstreamModelCatalogStatus | null;
+          model_catalog_last_error?: string | null;
+          model_catalog_last_failed_at?: string | null;
           model_rules?: UpstreamModelRule[] | null;
           circuit_breaker_config?: {
             failure_threshold?: number;
@@ -1697,6 +1786,13 @@ export function UpstreamFormDialog({
         }
         if (data.api_key) {
           updateData.api_key = data.api_key;
+        }
+        if (workspaceUpstream) {
+          updateData.model_catalog = workspaceUpstream.model_catalog;
+          updateData.model_catalog_updated_at = workspaceUpstream.model_catalog_updated_at;
+          updateData.model_catalog_last_status = workspaceUpstream.model_catalog_last_status;
+          updateData.model_catalog_last_error = workspaceUpstream.model_catalog_last_error;
+          updateData.model_catalog_last_failed_at = workspaceUpstream.model_catalog_last_failed_at;
         }
         await updateMutation.mutateAsync({
           id: upstream.id,
@@ -1844,8 +1940,8 @@ export function UpstreamFormDialog({
   const catalogUpdatedAtLabel = formatCatalogTimestamp(catalogState.modelCatalogUpdatedAt);
   const catalogFailedAtLabel = formatCatalogTimestamp(catalogState.modelCatalogLastFailedAt);
   const catalogHasEntries = catalogState.modelCatalog.length > 0;
-  const catalogIsRefreshing = refreshCatalogMutation.isPending;
-  const catalogRefreshBlocked = !isEdit || catalogRefreshDependencyDirty;
+  const catalogIsRefreshing = previewCatalogMutation.isPending;
+  const catalogRefreshBlocked = !isEdit || !watchedBaseUrl?.trim();
   const currentRuleCount = watchedModelRules?.length ?? 0;
   const selectedModelRuleIdSet = new Set(
     selectedModelRuleIds.filter((id) => modelRuleFields.some((field) => field.id === id))
@@ -3087,16 +3183,9 @@ export function UpstreamFormDialog({
                                       onClick={() => {
                                         void handleImportCatalog();
                                       }}
-                                      disabled={
-                                        importCatalogMutation.isPending ||
-                                        selectedCatalogModels.length === 0
-                                      }
+                                      disabled={selectedCatalogModels.length === 0}
                                     >
-                                      {importCatalogMutation.isPending ? (
-                                        <Loader2 className="h-4 w-4 animate-spin" />
-                                      ) : (
-                                        <ArrowDownToLine className="h-4 w-4" />
-                                      )}
+                                      <ArrowDownToLine className="h-4 w-4" />
                                       {t("catalogImportScope", {
                                         count: selectedCatalogModels.length,
                                       })}

--- a/src/hooks/use-upstreams.ts
+++ b/src/hooks/use-upstreams.ts
@@ -12,6 +12,8 @@ import type {
   UpstreamProbeResponse,
   ExecuteUpstreamProbeRequest,
   UpstreamQuotaStatusResponse,
+  UpstreamCatalogPreviewRequest,
+  UpstreamCatalogPreviewResponse,
 } from "@/types/api";
 import { toast } from "sonner";
 
@@ -127,6 +129,27 @@ export function useRefreshUpstreamCatalog() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["upstreams"] });
       toast.success("模型目录已刷新");
+    },
+    onError: (error: Error) => {
+      toast.error(`刷新目录失败: ${error.message}`);
+    },
+  });
+}
+
+/**
+ * Preview upstream model catalog with unsaved form values.
+ */
+export function usePreviewUpstreamCatalog() {
+  const { apiClient } = useAuth();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpstreamCatalogPreviewRequest }) =>
+      apiClient.post<UpstreamCatalogPreviewResponse>(
+        `/admin/upstreams/${id}/catalog/preview`,
+        data
+      ),
+    onSuccess: () => {
+      toast.success("Model catalog refreshed");
     },
     onError: (error: Error) => {
       toast.error(`刷新目录失败: ${error.message}`);

--- a/src/hooks/use-upstreams.ts
+++ b/src/hooks/use-upstreams.ts
@@ -149,7 +149,7 @@ export function usePreviewUpstreamCatalog() {
         data
       ),
     onSuccess: () => {
-      toast.success("Model catalog refreshed");
+      toast.success("模型目录已刷新");
     },
     onError: (error: Error) => {
       toast.error(`刷新目录失败: ${error.message}`);

--- a/src/lib/services/upstream-crud.ts
+++ b/src/lib/services/upstream-crud.ts
@@ -158,6 +158,13 @@ export interface UpstreamUpdateInput {
     | null;
 }
 
+export interface UpstreamCatalogPreviewInput {
+  baseUrl: string;
+  apiKey?: string | null;
+  routeCapabilities?: RouteCapability[] | null;
+  modelDiscovery?: UpstreamModelDiscoveryConfig | null;
+}
+
 export interface UpstreamResponse {
   id: string;
   name: string;
@@ -821,6 +828,34 @@ export async function refreshUpstreamCatalog(upstreamId: string): Promise<Upstre
     modelCatalogLastStatus: refreshed.modelCatalogLastStatus,
     modelCatalogLastError: refreshed.modelCatalogLastError,
     modelCatalogLastFailedAt: refreshed.modelCatalogLastFailedAt,
+  });
+}
+
+/**
+ * Preview an upstream model catalog using unsaved form values without updating the record.
+ */
+export async function previewUpstreamCatalog(
+  upstreamId: string,
+  input: UpstreamCatalogPreviewInput
+) {
+  const existing = await db.query.upstreams.findFirst({
+    where: eq(upstreams.id, upstreamId),
+  });
+
+  if (!existing) {
+    throw new UpstreamNotFoundError(`Upstream not found: ${upstreamId}`);
+  }
+
+  const apiKey = input.apiKey?.trim() || decrypt(existing.apiKeyEncrypted);
+
+  return refreshUpstreamModelCatalogData({
+    baseUrl: input.baseUrl,
+    apiKey,
+    routeCapabilities: input.routeCapabilities ?? existing.routeCapabilities,
+    modelDiscovery: input.modelDiscovery ?? existing.modelDiscovery,
+    previousCatalog: existing.modelCatalog,
+    previousCatalogUpdatedAt: existing.modelCatalogUpdatedAt,
+    timeoutMs: existing.timeout * 1000,
   });
 }
 

--- a/src/lib/services/upstream-service.ts
+++ b/src/lib/services/upstream-service.ts
@@ -21,6 +21,7 @@ export {
   listUpstreams,
   getUpstreamById,
   refreshUpstreamCatalog,
+  previewUpstreamCatalog,
   importUpstreamCatalogModels,
   loadActiveUpstreams,
   getDefaultUpstream,
@@ -30,6 +31,7 @@ export {
   // Upstream types
   type UpstreamCreateInput,
   type UpstreamUpdateInput,
+  type UpstreamCatalogPreviewInput,
   type UpstreamResponse,
   type PaginatedUpstreams,
 } from "./upstream-crud";

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -763,7 +763,7 @@
     "catalogUpdatedAtLabel": "Updated {time}",
     "catalogNeverRefreshed": "Not refreshed yet",
     "catalogStatusBarHint": "Import only. Existing rules stay.",
-    "catalogSavedConfigHint": "Unsaved changes. Save before refresh.",
+    "catalogSavedConfigHint": "Refresh uses current form values and applies after save.",
     "refreshCatalog": "Refresh",
     "clearLiteLlmCatalogEntries": "Clear LiteLLM",
     "modelDiscoverySectionTitle": "Discovery",

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -768,7 +768,7 @@
     "catalogUpdatedAtLabel": "更新：{time}",
     "catalogNeverRefreshed": "尚未刷新",
     "catalogStatusBarHint": "仅导入，不覆盖规则。",
-    "catalogSavedConfigHint": "有未保存改动，先保存后刷新。",
+    "catalogSavedConfigHint": "本次刷新将使用当前表单配置，保存后生效。",
     "refreshCatalog": "刷新",
     "clearLiteLlmCatalogEntries": "清理 LiteLLM",
     "modelDiscoverySectionTitle": "模型发现",

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -312,6 +312,22 @@ export interface UpstreamUpdate {
     | null;
 }
 
+export interface UpstreamCatalogPreviewRequest {
+  base_url: string;
+  api_key?: string;
+  route_capabilities?: RouteCapability[] | null;
+  model_discovery?: UpstreamModelDiscoveryConfig | null;
+}
+
+export interface UpstreamCatalogPreviewResponse {
+  model_discovery: UpstreamModelDiscoveryConfig | null;
+  model_catalog: UpstreamModelCatalogEntry[] | null;
+  model_catalog_updated_at: string | null;
+  model_catalog_last_status: UpstreamModelCatalogStatus;
+  model_catalog_last_error: string | null;
+  model_catalog_last_failed_at: string | null;
+}
+
 export interface UpstreamResponse {
   id: string; // UUID
   name: string;

--- a/tests/components/upstream-form-dialog.test.tsx
+++ b/tests/components/upstream-form-dialog.test.tsx
@@ -15,15 +15,13 @@ vi.mock("next-intl", () => ({
 // Mock hooks
 const mockCreateMutateAsync = vi.fn();
 const mockUpdateMutateAsync = vi.fn();
-const mockRefreshCatalogMutateAsync = vi.fn();
-const mockImportCatalogMutateAsync = vi.fn();
+const mockPreviewCatalogMutateAsync = vi.fn();
 const mockExecuteProbeMutateAsync = vi.fn();
 const mockExecuteProbeReset = vi.fn();
 const upstreamHookState = {
   createPending: false,
   updatePending: false,
   refreshPending: false,
-  importPending: false,
   probePending: false,
   probeData: null as unknown,
   probeMutationData: null as UpstreamProbeResponse | null,
@@ -48,13 +46,9 @@ vi.mock("@/hooks/use-upstreams", () => ({
     mutateAsync: mockUpdateMutateAsync,
     isPending: upstreamHookState.updatePending,
   }),
-  useRefreshUpstreamCatalog: () => ({
-    mutateAsync: mockRefreshCatalogMutateAsync,
+  usePreviewUpstreamCatalog: () => ({
+    mutateAsync: mockPreviewCatalogMutateAsync,
     isPending: upstreamHookState.refreshPending,
-  }),
-  useImportUpstreamCatalogModels: () => ({
-    mutateAsync: mockImportCatalogMutateAsync,
-    isPending: upstreamHookState.importPending,
   }),
   useUpstreamProbes: () => ({
     data: upstreamHookState.probeData,
@@ -146,8 +140,7 @@ describe("UpstreamFormDialog", () => {
     });
     mockCreateMutateAsync.mockReset();
     mockUpdateMutateAsync.mockReset();
-    mockRefreshCatalogMutateAsync.mockReset();
-    mockImportCatalogMutateAsync.mockReset();
+    mockPreviewCatalogMutateAsync.mockReset();
     mockExecuteProbeMutateAsync.mockReset();
     mockExecuteProbeReset.mockReset();
     mockOnOpenChange.mockReset();
@@ -155,7 +148,6 @@ describe("UpstreamFormDialog", () => {
     upstreamHookState.createPending = false;
     upstreamHookState.updatePending = false;
     upstreamHookState.refreshPending = false;
-    upstreamHookState.importPending = false;
     upstreamHookState.probePending = false;
     upstreamHookState.probeData = { data: [], total: 0 };
     upstreamHookState.probeMutationData = null;
@@ -793,7 +785,21 @@ describe("UpstreamFormDialog", () => {
       expect(screen.getByText("runProbe")).toBeDisabled();
     });
 
-    it("blocks catalog refresh when discovery dependencies are edited but not saved", () => {
+    it("previews catalog refresh with unsaved discovery dependencies", async () => {
+      mockPreviewCatalogMutateAsync.mockResolvedValueOnce({
+        model_discovery: {
+          mode: "openai_compatible",
+          custom_endpoint: null,
+          enable_lite_llm_fallback: false,
+          auto_refresh_enabled: false,
+        },
+        model_catalog: [{ model: "codex-mini-latest", source: "native" }],
+        model_catalog_updated_at: new Date("2026-05-14T12:00:00.000Z").toISOString(),
+        model_catalog_last_status: "success",
+        model_catalog_last_error: null,
+        model_catalog_last_failed_at: null,
+      });
+
       render(
         <UpstreamFormDialog upstream={mockUpstream} open={true} onOpenChange={mockOnOpenChange} />,
         { wrapper: Wrapper }
@@ -804,7 +810,69 @@ describe("UpstreamFormDialog", () => {
       });
 
       expect(screen.getByText("catalogSavedConfigHint")).toBeInTheDocument();
-      expect(screen.getByText("refreshCatalog")).toBeDisabled();
+      fireEvent.click(screen.getByText("refreshCatalog"));
+
+      await waitFor(() => {
+        expect(mockPreviewCatalogMutateAsync).toHaveBeenCalledWith({
+          id: "upstream-1",
+          data: {
+            base_url: "https://gateway.example.com/codex/v1",
+            route_capabilities: [],
+            model_discovery: {
+              mode: "openai_compatible",
+              custom_endpoint: null,
+              enable_lite_llm_fallback: false,
+              auto_refresh_enabled: false,
+            },
+          },
+        });
+      });
+      expect(screen.getByText("codex-mini-latest")).toBeInTheDocument();
+    });
+
+    it("saves previewed catalog entries with the form update", async () => {
+      const previewedAt = new Date("2026-05-14T12:00:00.000Z").toISOString();
+      mockPreviewCatalogMutateAsync.mockResolvedValueOnce({
+        model_discovery: {
+          mode: "openai_compatible",
+          custom_endpoint: null,
+          enable_lite_llm_fallback: false,
+          auto_refresh_enabled: false,
+        },
+        model_catalog: [{ model: "codex-mini-latest", source: "native" }],
+        model_catalog_updated_at: previewedAt,
+        model_catalog_last_status: "success",
+        model_catalog_last_error: null,
+        model_catalog_last_failed_at: null,
+      });
+      mockUpdateMutateAsync.mockResolvedValueOnce({});
+
+      render(
+        <UpstreamFormDialog upstream={mockUpstream} open={true} onOpenChange={mockOnOpenChange} />,
+        { wrapper: Wrapper }
+      );
+
+      fireEvent.click(screen.getByText("refreshCatalog"));
+      await waitFor(() => {
+        expect(screen.getByText("codex-mini-latest")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText("save"));
+
+      await waitFor(() => {
+        expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: "upstream-1",
+            data: expect.objectContaining({
+              model_catalog: [{ model: "codex-mini-latest", source: "native" }],
+              model_catalog_updated_at: previewedAt,
+              model_catalog_last_status: "success",
+              model_catalog_last_error: null,
+              model_catalog_last_failed_at: null,
+            }),
+          })
+        );
+      });
     });
 
     it("shows catalog loading state without hiding the rules workspace", () => {
@@ -1038,27 +1106,7 @@ describe("UpstreamFormDialog", () => {
       expect(workspaceContainer?.className).toContain("xl:h-[min(76vh,860px)]");
     });
 
-    it("imports selected catalog entries and echoes returned model rules", async () => {
-      mockImportCatalogMutateAsync.mockResolvedValueOnce({
-        ...mockUpstream,
-        model_rules: [
-          {
-            type: "exact",
-            value: "gpt-4.1",
-            target_model: null,
-            source: "native",
-            display_label: "精确匹配",
-          },
-          {
-            type: "exact",
-            value: "gpt-4.1-mini",
-            target_model: null,
-            source: "inferred",
-            display_label: "精确匹配",
-          },
-        ],
-      });
-
+    it("imports selected catalog entries into local model rules", () => {
       render(
         <UpstreamFormDialog upstream={mockUpstream} open={true} onOpenChange={mockOnOpenChange} />,
         { wrapper: Wrapper }
@@ -1067,13 +1115,7 @@ describe("UpstreamFormDialog", () => {
       fireEvent.click(screen.getByText("gpt-4.1-mini"));
       fireEvent.click(screen.getByText("catalogImportScope"));
 
-      await waitFor(() => {
-        expect(mockImportCatalogMutateAsync).toHaveBeenCalledWith({
-          id: "upstream-1",
-          models: ["gpt-4.1-mini"],
-        });
-      });
-
+      expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
       expect(screen.getAllByDisplayValue("gpt-4.1-mini").length).toBeGreaterThanOrEqual(1);
     });
 

--- a/tests/unit/api/admin/upstreams/catalog.test.ts
+++ b/tests/unit/api/admin/upstreams/catalog.test.ts
@@ -20,10 +20,12 @@ vi.mock("@/lib/utils/auth", () => ({
 
 const mockRefreshUpstreamCatalog = vi.fn();
 const mockImportUpstreamCatalogModels = vi.fn();
+const mockPreviewUpstreamCatalog = vi.fn();
 
 vi.mock("@/lib/services/upstream-service", () => ({
   refreshUpstreamCatalog: (...args: unknown[]) => mockRefreshUpstreamCatalog(...args),
   importUpstreamCatalogModels: (...args: unknown[]) => mockImportUpstreamCatalogModels(...args),
+  previewUpstreamCatalog: (...args: unknown[]) => mockPreviewUpstreamCatalog(...args),
   UpstreamNotFoundError: class UpstreamNotFoundError extends Error {},
 }));
 
@@ -149,5 +151,77 @@ describe("Admin Upstream Catalog API", () => {
       "gpt-4.1",
       "gpt-4.1-mini",
     ]);
+  });
+
+  it("should preview an upstream catalog without saving it", async () => {
+    const { POST } = await import("@/app/api/admin/upstreams/[id]/catalog/preview/route");
+    mockPreviewUpstreamCatalog.mockResolvedValueOnce({
+      modelDiscovery: {
+        mode: "openai_compatible",
+        customEndpoint: null,
+        enableLiteLlmFallback: false,
+        autoRefreshEnabled: false,
+      },
+      modelCatalog: [{ model: "codex-mini-latest", source: "native" }],
+      modelCatalogUpdatedAt: new Date("2026-05-14T12:00:00.000Z"),
+      modelCatalogLastStatus: "success",
+      modelCatalogLastError: null,
+      modelCatalogLastFailedAt: null,
+    });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/admin/upstreams/upstream-1/catalog/preview",
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-admin-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          base_url: "https://gateway.example.com/codex/v1",
+          api_key: "sk-new-key",
+          route_capabilities: ["openai_chat_compatible"],
+          model_discovery: {
+            mode: "openai_compatible",
+            custom_endpoint: null,
+            enable_lite_llm_fallback: false,
+            auto_refresh_enabled: false,
+          },
+        }),
+      }
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ id: "upstream-1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      model_discovery: {
+        mode: "openai_compatible",
+        custom_endpoint: null,
+        enable_lite_llm_fallback: false,
+        auto_refresh_enabled: false,
+      },
+      model_catalog: [{ model: "codex-mini-latest", source: "native" }],
+      model_catalog_updated_at: "2026-05-14T12:00:00.000Z",
+      model_catalog_last_status: "success",
+      model_catalog_last_error: null,
+      model_catalog_last_failed_at: null,
+    });
+    expect(mockPreviewUpstreamCatalog).toHaveBeenCalledWith("upstream-1", {
+      baseUrl: "https://gateway.example.com/codex/v1",
+      apiKey: "sk-new-key",
+      routeCapabilities: ["openai_chat_compatible"],
+      modelDiscovery: {
+        mode: "openai_compatible",
+        customEndpoint: null,
+        enableLiteLlmFallback: false,
+        autoRefreshEnabled: false,
+      },
+    });
+    expect(mockRefreshUpstreamCatalog).not.toHaveBeenCalled();
+    expect(mockImportUpstreamCatalogModels).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/hooks/use-upstreams.test.ts
+++ b/tests/unit/hooks/use-upstreams.test.ts
@@ -579,6 +579,49 @@ describe("catalog mutations", () => {
       models: ["gpt-4.1", "gpt-4.1-mini"],
     });
   });
+
+  it("previews upstream catalog with unsaved form values", async () => {
+    const preview = {
+      model_discovery: {
+        mode: "openai_compatible",
+        custom_endpoint: null,
+        enable_lite_llm_fallback: false,
+        auto_refresh_enabled: false,
+      },
+      model_catalog: [{ model: "codex-mini-latest", source: "native" }],
+      model_catalog_updated_at: "2026-05-14T12:00:00.000Z",
+      model_catalog_last_status: "success",
+      model_catalog_last_error: null,
+      model_catalog_last_failed_at: null,
+    };
+    mockPost.mockResolvedValueOnce(preview);
+
+    const { usePreviewUpstreamCatalog } = await import("@/hooks/use-upstreams");
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePreviewUpstreamCatalog(), { wrapper });
+
+    result.current.mutate({
+      id: "upstream-1",
+      data: {
+        base_url: "https://gateway.example.com/codex/v1",
+        api_key: "sk-new-key",
+        route_capabilities: ["openai_chat_compatible"],
+        model_discovery: preview.model_discovery,
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockPost).toHaveBeenCalledWith("/admin/upstreams/upstream-1/catalog/preview", {
+      base_url: "https://gateway.example.com/codex/v1",
+      api_key: "sk-new-key",
+      route_capabilities: ["openai_chat_compatible"],
+      model_discovery: preview.model_discovery,
+    });
+  });
 });
 
 describe("useToggleUpstreamActive", () => {


### PR DESCRIPTION
## Summary

Adds an upstream model catalog preview refresh flow so the edit dialog can refresh models from current form values before saving.

## Related Issue

Closes #161

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (code improvement without changing functionality)
- [x] Tests (adding or updating tests)
- [ ] Build/CI (changes to build system or CI configuration)

## Changes

- Added `POST /api/admin/upstreams/[id]/catalog/preview` to refresh a model catalog from editor values without updating the upstream record.
- Updated the upstream edit dialog so refresh uses unsaved `base_url`, `api_key`, route capabilities, and discovery settings.
- Changed catalog import in the edit dialog to update local model rules first, then persist catalog and rules together when saving.
- Updated catalog refresh copy and added component, hook, and API coverage.

## Test Plan

- [x] Local tests pass (`pnpm test:run`)
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`)
- [ ] Manual testing completed

Commands run:

```bash
pnpm test:run tests/components/upstream-form-dialog.test.tsx tests/unit/api/admin/upstreams/catalog.test.ts tests/unit/hooks/use-upstreams.test.ts
pnpm exec tsc --noEmit --pretty false
pnpm format:check
pnpm lint
git diff --check
```

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [ ] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

Not captured.

## Additional Notes

`pnpm lint` passes with existing JSDoc warnings and no errors.
