### PR TITLE
fix(billing): 防止 snapshot 在 api_key/upstream 被删后写入失败

### DIFF
--- a/src/lib/services/billing-cost-service.ts
+++ b/src/lib/services/billing-cost-service.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import { db, requestBillingSnapshots, upstreams } from "@/lib/db";
+import { db, requestBillingSnapshots, requestLogs, upstreams } from "@/lib/db";
 import {
   resolveBillingModelPrice,
   type BillingPriceSource,
@@ -277,11 +277,29 @@ function calculateCost(
 }
 
 /**
+ * 以 request_logs 行为准重写 api_key_id / upstream_id，避免引用已删除主表行导致 FK 违例。
+ * request_logs 两列都带 `ON DELETE SET NULL`，行内值已是 FK 安全的最终态。
+ */
+async function reconcileFkColumnsWithRequestLog(
+  input: PersistRequestBillingInput
+): Promise<PersistRequestBillingInput> {
+  const logRow = await db.query.requestLogs.findFirst({
+    where: eq(requestLogs.id, input.requestLogId),
+    columns: { apiKeyId: true, upstreamId: true },
+  });
+  if (!logRow) {
+    return { ...input, apiKeyId: null, upstreamId: null };
+  }
+  return { ...input, apiKeyId: logRow.apiKeyId, upstreamId: logRow.upstreamId };
+}
+
+/**
  * Calculate and persist an immutable request billing snapshot.
  */
 export async function calculateAndPersistRequestBillingSnapshot(
-  input: PersistRequestBillingInput
+  rawInput: PersistRequestBillingInput
 ): Promise<PersistedRequestBillingResult> {
+  const input = await reconcileFkColumnsWithRequestLog(rawInput);
   const model = input.model?.trim() ?? "";
   if (!model) {
     return upsertUnbilledSnapshot(input, "model_missing");

--- a/tests/unit/services/billing-cost-service.test.ts
+++ b/tests/unit/services/billing-cost-service.test.ts
@@ -5,6 +5,7 @@ const valuesMock = vi.fn(() => ({ onConflictDoUpdate: onConflictDoUpdateMock }))
 const insertMock = vi.fn(() => ({ values: valuesMock }));
 const upstreamFindFirstMock = vi.fn();
 const snapshotFindFirstMock = vi.fn();
+const requestLogsFindFirstMock = vi.fn();
 
 vi.mock("drizzle-orm", async (importOriginal) => {
   const actual = await importOriginal<typeof import("drizzle-orm")>();
@@ -23,11 +24,17 @@ vi.mock("@/lib/db", () => ({
       requestBillingSnapshots: {
         findFirst: snapshotFindFirstMock,
       },
+      requestLogs: {
+        findFirst: requestLogsFindFirstMock,
+      },
     },
     insert: insertMock,
   },
   requestBillingSnapshots: {
     requestLogId: "request_log_id",
+  },
+  requestLogs: {
+    id: "id",
   },
   upstreams: {
     id: "id",
@@ -50,6 +57,7 @@ describe("billing-cost-service", () => {
     vi.clearAllMocks();
     upstreamFindFirstMock.mockResolvedValue(null);
     snapshotFindFirstMock.mockResolvedValue(null);
+    requestLogsFindFirstMock.mockResolvedValue({ apiKeyId: "key-1", upstreamId: "up-1" });
     onConflictDoUpdateMock.mockResolvedValue(undefined);
   });
 
@@ -448,6 +456,55 @@ describe("billing-cost-service", () => {
         appliedTierThreshold: 128000,
         modelMaxInputTokens: 200000,
         modelMaxOutputTokens: 8192,
+      })
+    );
+  });
+
+  it("writes null FK columns when request_logs row was cascade-nulled after key/upstream deletion", async () => {
+    // 模拟生产环境观察到的 race：冒烟测试发完请求后立刻删除了 api_key 和 upstream，
+    // request_logs 行已被 cascade SET NULL；调用方仍然带着内存里的旧 id 进来，
+    // 此时 snapshot 必须按 request_logs 的最终值写入 NULL，避免 FK 违例。
+    requestLogsFindFirstMock.mockResolvedValueOnce({ apiKeyId: null, upstreamId: null });
+
+    const { calculateAndPersistRequestBillingSnapshot } =
+      await import("../../../src/lib/services/billing-cost-service");
+
+    const result = await calculateAndPersistRequestBillingSnapshot({
+      requestLogId: "log-fk-race",
+      apiKeyId: "stale-key-id",
+      upstreamId: "stale-upstream-id",
+      model: "gpt-4.1-smoke",
+      usage: { promptTokens: 6, completionTokens: 3, totalTokens: 9 },
+    });
+
+    expect(result.status).toBe("unbilled");
+    expect(result.unbillableReason).toBe("price_not_found");
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKeyId: null,
+        upstreamId: null,
+      })
+    );
+  });
+
+  it("falls back to null FK columns when request_logs row is missing", async () => {
+    requestLogsFindFirstMock.mockResolvedValueOnce(undefined);
+
+    const { calculateAndPersistRequestBillingSnapshot } =
+      await import("../../../src/lib/services/billing-cost-service");
+
+    await calculateAndPersistRequestBillingSnapshot({
+      requestLogId: "log-missing",
+      apiKeyId: "stale-key-id",
+      upstreamId: "stale-upstream-id",
+      model: null,
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    });
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKeyId: null,
+        upstreamId: null,
       })
     );
   });


### PR DESCRIPTION
## Summary

修复生产环境中 `request_billing_snapshots` 写入时出现的 FK 违例：

```
insert or update on table "request_billing_snapshots" violates foreign key constraint
"request_billing_snapshots_api_key_id_api_keys_id_fk"
```

### 根因

snapshot 持久化是请求主流程的"最后一公里"——尤其在 SSE 流式响应结束后才在 `.then(...)` 里异步触发。如果调用方（`route.ts` 里 8 处 `persistBillingSnapshotSafely`）持有的内存版 `validApiKey.id` 在此期间已被外部删除（典型场景：部署冒烟测试创建临时 key、发请求、收响应后立刻删 key），INSERT 时这个 UUID 不再存在于 `api_keys` 表，FK 约束失败。

`onDelete: SET NULL` 只在"先存在、后被删"时由 DB 触发；救不了"INSERT 时引用已不存在的行"。

### 生产证据

数据库反查同一条 `request_logs` 行：

| 字段 | 值 |
|---|---|
| `api_key_id` | `NULL`（cascade SET NULL 已触发）|
| `upstream_id` | `NULL`（同上）|
| `api_key_name` | `deploy-smoke-26296857443-key` |
| `model` | `gpt-4.1-smoke` |
| `created_at` → snapshot `billed_at` 时差 | 198 ms |

冒烟测试在 198 ms 窗口内删 key + 删 upstream，snapshot 异步写入时撞 FK。

### 修复

- 在 `calculateAndPersistRequestBillingSnapshot` 入口新增 `reconcileFkColumnsWithRequestLog`：根据 `requestLogId` 反查 `request_logs` 行，用其 `api_key_id` / `upstream_id` 覆盖 input。
- `request_logs` 两列都带 `ON DELETE SET NULL`，行内值已是 DB 最终态，天然 FK 安全。
- 单点收敛于 billing service 入口，**8 处调用点零改动自动受益**。

### 影响

- 行为变化：snapshot 的 `api_key_id` / `upstream_id` 始终与 `request_logs` 行保持一致（即使调用方传入旧 id）。这本就是预期语义，过去因为没显式 reconcile 才会撞 FK。
- 性能：每次 snapshot 写入新增 1 次主键索引 SELECT。snapshot 不在请求关键路径上（响应已发出后异步写），开销可接受。

## Test plan

- [x] `pnpm test:run tests/unit/services/billing-cost-service.test.ts` —— 13/13 通过（原有 11 + 新增 2）
- [x] `pnpm test:run tests/unit/services/` —— 1112/1112 全量单元测试通过，无回归
- [x] `pnpm exec tsc --noEmit` 通过
- [x] `pnpm lint` 通过
- [x] `pnpm build` 通过
- [x] 新增用例 `writes null FK columns when request_logs row was cascade-nulled after key/upstream deletion` 直接复现并验证生产 race 场景
- [x] 新增用例 `falls back to null FK columns when request_logs row is missing` 覆盖 request_logs 行不存在的兜底分支
- [ ] 上线后观察 `failed to persist billing snapshot` 日志频次回落到 0

## 后续可选改进

- 冒烟测试的 teardown 加短暂等待，避免后续异步落库逻辑（不止 billing，也包含 quota tracker 等）撞上删除窗口。这是系统性问题，billing snapshot 只是第一个被发现的症状。