### PR TITLE
fix(billing): snapshot 写入加 FK 违例捕获重试，闭环 PR #168 残留的 race

### DIFF
--- a/src/lib/services/billing-cost-service.ts
+++ b/src/lib/services/billing-cost-service.ts
@@ -8,6 +8,73 @@ import {
 import { getProviderTypeForModel } from "@/lib/services/model-router";
 import { quotaTracker } from "@/lib/services/upstream-quota-tracker";
 import { apiKeyQuotaTracker } from "@/lib/services/api-key-quota-tracker";
+import { createLogger } from "@/lib/utils/logger";
+
+const log = createLogger("billing-cost-service");
+
+type BillingSnapshotInsertValues = typeof requestBillingSnapshots.$inferInsert;
+type BillingSnapshotUpdateSet = Partial<BillingSnapshotInsertValues>;
+
+function isPgForeignKeyViolation(
+  error: unknown
+): error is { code: string; constraint_name?: string } {
+  return (
+    typeof error === "object" && error !== null && (error as { code?: unknown }).code === "23503"
+  );
+}
+
+function resolveViolatedFkColumn(
+  constraintName: string | undefined
+): "apiKeyId" | "upstreamId" | null {
+  if (!constraintName) return null;
+  if (constraintName.includes("api_key_id")) return "apiKeyId";
+  if (constraintName.includes("upstream_id")) return "upstreamId";
+  return null;
+}
+
+/**
+ * 写 snapshot 时若 api_key_id / upstream_id 违反 FK 约束（典型场景：caller 持有的
+ * id 在请求处理与异步 snapshot 写入之间被并发删除——reconcile 也无法消除这一
+ * TOCTOU 窗口），把违反的那一列置 NULL 后单次重试。
+ *
+ * 返回实际写入数据库的两列值，供 applyQuotaDeltaAfterSnapshotUpsert 使用，
+ * 防止"INSERT 已置 NULL 但内存配额仍按原 id 累加"导致 DB/memory 状态错位。
+ */
+async function upsertBillingSnapshotWithFkRetry(
+  values: BillingSnapshotInsertValues,
+  updateSet: BillingSnapshotUpdateSet,
+  requestLogId: string
+): Promise<{ apiKeyId: string | null; upstreamId: string | null }> {
+  try {
+    await db
+      .insert(requestBillingSnapshots)
+      .values(values)
+      .onConflictDoUpdate({ target: requestBillingSnapshots.requestLogId, set: updateSet });
+    return { apiKeyId: values.apiKeyId ?? null, upstreamId: values.upstreamId ?? null };
+  } catch (error) {
+    if (!isPgForeignKeyViolation(error)) throw error;
+    const column = resolveViolatedFkColumn(error.constraint_name);
+    if (!column) throw error;
+
+    const patchedValues: BillingSnapshotInsertValues = { ...values, [column]: null };
+    const patchedSet: BillingSnapshotUpdateSet = { ...updateSet, [column]: null };
+
+    await db.insert(requestBillingSnapshots).values(patchedValues).onConflictDoUpdate({
+      target: requestBillingSnapshots.requestLogId,
+      set: patchedSet,
+    });
+
+    log.warn(
+      { requestLogId, nulledColumn: column, constraint: error.constraint_name },
+      "billing snapshot FK violation retried with NULL"
+    );
+
+    return {
+      apiKeyId: patchedValues.apiKeyId ?? null,
+      upstreamId: patchedValues.upstreamId ?? null,
+    };
+  }
+}
 
 export type UnbillableReason =
   | "model_missing"
@@ -142,9 +209,8 @@ async function upsertUnbilledSnapshot(
     },
   });
 
-  await db
-    .insert(requestBillingSnapshots)
-    .values({
+  const writtenIds = await upsertBillingSnapshotWithFkRetry(
+    {
       requestLogId: input.requestLogId,
       apiKeyId: input.apiKeyId,
       upstreamId: input.upstreamId,
@@ -174,45 +240,44 @@ async function upsertUnbilledSnapshot(
       currency: "USD",
       billedAt: now,
       createdAt: now,
-    })
-    .onConflictDoUpdate({
-      target: requestBillingSnapshots.requestLogId,
-      set: {
-        apiKeyId: input.apiKeyId,
-        upstreamId: input.upstreamId,
-        model: input.model,
-        billingStatus: "unbilled",
-        unbillableReason: reason,
-        priceSource: null,
-        baseInputPricePerMillion: null,
-        baseOutputPricePerMillion: null,
-        baseCacheReadInputPricePerMillion: null,
-        baseCacheWriteInputPricePerMillion: null,
-        matchedRuleType: null,
-        matchedRuleDisplayLabel: null,
-        appliedTierThreshold: null,
-        modelMaxInputTokens: null,
-        modelMaxOutputTokens: null,
-        inputMultiplier: null,
-        outputMultiplier: null,
-        promptTokens: usage.promptTokens,
-        completionTokens: usage.completionTokens,
-        totalTokens: usage.totalTokens,
-        cacheReadTokens: usage.cacheReadTokens,
-        cacheWriteTokens: usage.cacheWriteTokens,
-        cacheReadCost: null,
-        cacheWriteCost: null,
-        finalCost: null,
-        currency: "USD",
-        billedAt: now,
-      },
-    });
+    },
+    {
+      apiKeyId: input.apiKeyId,
+      upstreamId: input.upstreamId,
+      model: input.model,
+      billingStatus: "unbilled",
+      unbillableReason: reason,
+      priceSource: null,
+      baseInputPricePerMillion: null,
+      baseOutputPricePerMillion: null,
+      baseCacheReadInputPricePerMillion: null,
+      baseCacheWriteInputPricePerMillion: null,
+      matchedRuleType: null,
+      matchedRuleDisplayLabel: null,
+      appliedTierThreshold: null,
+      modelMaxInputTokens: null,
+      modelMaxOutputTokens: null,
+      inputMultiplier: null,
+      outputMultiplier: null,
+      promptTokens: usage.promptTokens,
+      completionTokens: usage.completionTokens,
+      totalTokens: usage.totalTokens,
+      cacheReadTokens: usage.cacheReadTokens,
+      cacheWriteTokens: usage.cacheWriteTokens,
+      cacheReadCost: null,
+      cacheWriteCost: null,
+      finalCost: null,
+      currency: "USD",
+      billedAt: now,
+    },
+    input.requestLogId
+  );
 
   applyQuotaDeltaAfterSnapshotUpsert(
     previousSnapshot ?? null,
     "unbilled",
-    input.apiKeyId,
-    input.upstreamId,
+    writtenIds.apiKeyId,
+    writtenIds.upstreamId,
     null
   );
 
@@ -347,9 +412,8 @@ export async function calculateAndPersistRequestBillingSnapshot(
     },
   });
 
-  await db
-    .insert(requestBillingSnapshots)
-    .values({
+  const writtenIds = await upsertBillingSnapshotWithFkRetry(
+    {
       requestLogId: input.requestLogId,
       apiKeyId: input.apiKeyId,
       upstreamId: input.upstreamId,
@@ -379,45 +443,44 @@ export async function calculateAndPersistRequestBillingSnapshot(
       currency: "USD",
       billedAt: now,
       createdAt: now,
-    })
-    .onConflictDoUpdate({
-      target: requestBillingSnapshots.requestLogId,
-      set: {
-        apiKeyId: input.apiKeyId,
-        upstreamId: input.upstreamId,
-        model,
-        billingStatus: "billed",
-        unbillableReason: null,
-        priceSource: resolvedPrice.source,
-        baseInputPricePerMillion: resolvedPrice.inputPricePerMillion,
-        baseOutputPricePerMillion: resolvedPrice.outputPricePerMillion,
-        baseCacheReadInputPricePerMillion: resolvedPrice.cacheReadInputPricePerMillion,
-        baseCacheWriteInputPricePerMillion: resolvedPrice.cacheWriteInputPricePerMillion,
-        matchedRuleType: resolvedPrice.matchedRuleType,
-        matchedRuleDisplayLabel: resolvedPrice.matchedRuleDisplayLabel,
-        appliedTierThreshold: resolvedPrice.appliedTierThreshold,
-        modelMaxInputTokens: resolvedPrice.modelMaxInputTokens,
-        modelMaxOutputTokens: resolvedPrice.modelMaxOutputTokens,
-        inputMultiplier,
-        outputMultiplier,
-        promptTokens: cost.billedInputTokens,
-        completionTokens: usage.completionTokens,
-        totalTokens: usage.totalTokens,
-        cacheReadTokens: usage.cacheReadTokens,
-        cacheWriteTokens: usage.cacheWriteTokens,
-        cacheReadCost: cost.cacheReadCost,
-        cacheWriteCost: cost.cacheWriteCost,
-        finalCost: cost.finalCost,
-        currency: "USD",
-        billedAt: now,
-      },
-    });
+    },
+    {
+      apiKeyId: input.apiKeyId,
+      upstreamId: input.upstreamId,
+      model,
+      billingStatus: "billed",
+      unbillableReason: null,
+      priceSource: resolvedPrice.source,
+      baseInputPricePerMillion: resolvedPrice.inputPricePerMillion,
+      baseOutputPricePerMillion: resolvedPrice.outputPricePerMillion,
+      baseCacheReadInputPricePerMillion: resolvedPrice.cacheReadInputPricePerMillion,
+      baseCacheWriteInputPricePerMillion: resolvedPrice.cacheWriteInputPricePerMillion,
+      matchedRuleType: resolvedPrice.matchedRuleType,
+      matchedRuleDisplayLabel: resolvedPrice.matchedRuleDisplayLabel,
+      appliedTierThreshold: resolvedPrice.appliedTierThreshold,
+      modelMaxInputTokens: resolvedPrice.modelMaxInputTokens,
+      modelMaxOutputTokens: resolvedPrice.modelMaxOutputTokens,
+      inputMultiplier,
+      outputMultiplier,
+      promptTokens: cost.billedInputTokens,
+      completionTokens: usage.completionTokens,
+      totalTokens: usage.totalTokens,
+      cacheReadTokens: usage.cacheReadTokens,
+      cacheWriteTokens: usage.cacheWriteTokens,
+      cacheReadCost: cost.cacheReadCost,
+      cacheWriteCost: cost.cacheWriteCost,
+      finalCost: cost.finalCost,
+      currency: "USD",
+      billedAt: now,
+    },
+    input.requestLogId
+  );
 
   applyQuotaDeltaAfterSnapshotUpsert(
     previousSnapshot ?? null,
     "billed",
-    input.apiKeyId,
-    input.upstreamId,
+    writtenIds.apiKeyId,
+    writtenIds.upstreamId,
     cost.finalCost
   );
 

--- a/tests/unit/services/billing-cost-service.test.ts
+++ b/tests/unit/services/billing-cost-service.test.ts
@@ -52,6 +52,16 @@ vi.mock("@/lib/services/upstream-quota-tracker", () => ({
   },
 }));
 
+const loggerWarnMock = vi.fn();
+vi.mock("@/lib/utils/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: loggerWarnMock,
+    error: vi.fn(),
+  }),
+}));
+
 describe("billing-cost-service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -507,5 +517,171 @@ describe("billing-cost-service", () => {
         upstreamId: null,
       })
     );
+  });
+
+  it("retries with null api_key_id when INSERT hits api_keys FK violation", async () => {
+    // 真实生产 race：reconcile 读到的 api_key_id 在 reconcile→INSERT 之间被并发删除，
+    // INSERT 撞 FK；helper 应当捕获 PG 23503 + 对应约束名后单次重试，把 apiKeyId 置 NULL。
+    // reconcile 此时还能读到旧 id（cascade 尚未触发），下一刻 INSERT 才撞 FK。
+    requestLogsFindFirstMock.mockResolvedValueOnce({
+      apiKeyId: "doomed-key-id",
+      upstreamId: "still-valid-upstream",
+    });
+    const fkError = Object.assign(new Error("FK violation"), {
+      code: "23503",
+      constraint_name: "request_billing_snapshots_api_key_id_api_keys_id_fk",
+      table_name: "request_billing_snapshots",
+    });
+    onConflictDoUpdateMock.mockRejectedValueOnce(fkError).mockResolvedValueOnce(undefined);
+
+    const { calculateAndPersistRequestBillingSnapshot } =
+      await import("../../../src/lib/services/billing-cost-service");
+
+    await calculateAndPersistRequestBillingSnapshot({
+      requestLogId: "log-fk-retry",
+      apiKeyId: "doomed-key-id",
+      upstreamId: "still-valid-upstream",
+      model: "gpt-4.1-smoke",
+      usage: { promptTokens: 6, completionTokens: 3, totalTokens: 9 },
+    });
+
+    expect(onConflictDoUpdateMock).toHaveBeenCalledTimes(2);
+    expect(valuesMock).toHaveBeenCalledTimes(2);
+    expect(valuesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        apiKeyId: null,
+        upstreamId: "still-valid-upstream",
+      })
+    );
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nulledColumn: "apiKeyId",
+        constraint: "request_billing_snapshots_api_key_id_api_keys_id_fk",
+      }),
+      expect.stringContaining("FK violation retried")
+    );
+  });
+
+  it("retries with null upstream_id when INSERT hits upstreams FK violation", async () => {
+    requestLogsFindFirstMock.mockResolvedValueOnce({
+      apiKeyId: "still-valid-key",
+      upstreamId: "doomed-upstream-id",
+    });
+    const fkError = Object.assign(new Error("FK violation"), {
+      code: "23503",
+      constraint_name: "request_billing_snapshots_upstream_id_upstreams_id_fk",
+    });
+    onConflictDoUpdateMock.mockRejectedValueOnce(fkError).mockResolvedValueOnce(undefined);
+
+    const { calculateAndPersistRequestBillingSnapshot } =
+      await import("../../../src/lib/services/billing-cost-service");
+
+    await calculateAndPersistRequestBillingSnapshot({
+      requestLogId: "log-upstream-retry",
+      apiKeyId: "still-valid-key",
+      upstreamId: "doomed-upstream-id",
+      model: "gpt-4.1-smoke",
+      usage: { promptTokens: 6, completionTokens: 3, totalTokens: 9 },
+    });
+
+    expect(valuesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        apiKeyId: "still-valid-key",
+        upstreamId: null,
+      })
+    );
+  });
+
+  it("skips quota delta for FK-retried column to avoid db/memory state drift", async () => {
+    // 重试时 upstream_id 被置 NULL，配额累加必须基于实际写入值（NULL），
+    // 否则数据库快照已无 upstream 维度但内存配额仍按旧 id 累加，造成幽灵配额。
+    const { resolveBillingModelPrice } =
+      await import("../../../src/lib/services/billing-price-service");
+    vi.mocked(resolveBillingModelPrice).mockResolvedValueOnce({
+      model: "gpt-4.1",
+      source: "litellm",
+      inputPricePerMillion: 10,
+      outputPricePerMillion: 30,
+      cacheReadInputPricePerMillion: null,
+      cacheWriteInputPricePerMillion: null,
+      matchedRuleType: "flat",
+      matchedRuleDisplayLabel: null,
+      appliedTierThreshold: null,
+      modelMaxInputTokens: 200000,
+      modelMaxOutputTokens: 8192,
+    });
+    upstreamFindFirstMock.mockResolvedValueOnce({
+      billingInputMultiplier: 1,
+      billingOutputMultiplier: 1,
+    });
+    requestLogsFindFirstMock.mockResolvedValueOnce({
+      apiKeyId: "key-1",
+      upstreamId: "doomed-upstream-id",
+    });
+
+    const fkError = Object.assign(new Error("FK violation"), {
+      code: "23503",
+      constraint_name: "request_billing_snapshots_upstream_id_upstreams_id_fk",
+    });
+    onConflictDoUpdateMock.mockRejectedValueOnce(fkError).mockResolvedValueOnce(undefined);
+
+    const { calculateAndPersistRequestBillingSnapshot } =
+      await import("../../../src/lib/services/billing-cost-service");
+
+    await calculateAndPersistRequestBillingSnapshot({
+      requestLogId: "log-quota-retry-null",
+      apiKeyId: "key-1",
+      upstreamId: "doomed-upstream-id",
+      model: "gpt-4.1",
+      usage: { promptTokens: 1000, completionTokens: 500, totalTokens: 1500 },
+    });
+
+    const upstreamCalls = mockAdjustSpending.mock.calls.filter(
+      ([id]) => id === "doomed-upstream-id"
+    );
+    expect(upstreamCalls).toHaveLength(0);
+  });
+
+  it("rethrows non-FK errors without retry", async () => {
+    const otherError = Object.assign(new Error("unique violation"), { code: "23505" });
+    onConflictDoUpdateMock.mockRejectedValueOnce(otherError);
+
+    const { calculateAndPersistRequestBillingSnapshot } =
+      await import("../../../src/lib/services/billing-cost-service");
+
+    await expect(
+      calculateAndPersistRequestBillingSnapshot({
+        requestLogId: "log-other-err",
+        apiKeyId: "key-1",
+        upstreamId: "up-1",
+        model: null,
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      })
+    ).rejects.toBe(otherError);
+
+    expect(onConflictDoUpdateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows FK violation when constraint name is not recognized", async () => {
+    const fkError = Object.assign(new Error("FK violation"), {
+      code: "23503",
+      constraint_name: "some_unrelated_constraint",
+    });
+    onConflictDoUpdateMock.mockRejectedValueOnce(fkError);
+
+    const { calculateAndPersistRequestBillingSnapshot } =
+      await import("../../../src/lib/services/billing-cost-service");
+
+    await expect(
+      calculateAndPersistRequestBillingSnapshot({
+        requestLogId: "log-unknown-fk",
+        apiKeyId: "key-1",
+        upstreamId: "up-1",
+        model: null,
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      })
+    ).rejects.toBe(fkError);
+
+    expect(onConflictDoUpdateMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

PR #168 上线（v0.3.0-alpha.3）后，部署 smoke test 再次复现 `request_billing_snapshots` 的 FK 违例。原因：上次引入的 `reconcileFkColumnsWithRequestLog` 只是把 race 窗口从 198ms 缩到几毫秒，没有消除——reconcile SELECT 与 INSERT 之间，cascade `SET NULL` 仍可能在 caller 持有的 id 上触发。

### 生产时序坐实

同一个 `requestId: 1ab55a08`：

```
T+0       SSE 流请求开始
T+5ms     上游 SSE 响应到来
T+139ms   smoke test 删除 api_key（cascade 把 request_logs.api_key_id 置 NULL）
T+142ms   snapshot INSERT 用 reconcile 拿到的旧 id 撞 FK
```

reconcile 必然发生在 T+139ms 之前（否则会读到 NULL 走对路径），INSERT 在 T+139ms 之后。TOCTOU 窗口客观存在，单纯"读一下再写"消除不掉。

### 修复

在 INSERT 处加 **catch-FK-and-retry-with-NULL**：

- 捕获 PG 错误码 `23503`
- 解析 `err.constraint_name`，命中 `..._api_key_id_..._fk` / `..._upstream_id_..._fk` 任一约束 → 把违反的那列置 NULL
- 单次重试 INSERT
- 仍失败 / 非 FK 错误 / 未识别的约束 → 透传

`reconcileFkColumnsWithRequestLog` 保留——它仍能让"事前已删"的常见路径直接走 NULL 路径，不会产生重试日志噪音。两层叠加：reconcile 是常见路径清场，catch-retry 是事中 race 兜底。

### 三处不可分割的细节

1. **配额联动**：helper 返回实际写入数据库的 `apiKeyId` / `upstreamId`，`applyQuotaDeltaAfterSnapshotUpsert` 用这组值。否则会出现"DB 已置 NULL 但内存配额仍按旧 id 累加"的幽灵配额。
2. **错误识别**：用 `constraint_name`（程序化可靠字段）而非 `detail`（人类可读文本）；未识别的约束直接 throw，不做无脑兜底。
3. **重试上限**：固定 1 次、无退避。目标是修正引用值，不是等待外部状态恢复。

## Test plan

新增 5 个用例，覆盖每条修复链路：

- [x] `retries with null api_key_id when INSERT hits api_keys FK violation`
- [x] `retries with null upstream_id when INSERT hits upstreams FK violation`
- [x] `skips quota delta for FK-retried column to avoid db/memory state drift`
- [x] `rethrows non-FK errors without retry`
- [x] `rethrows FK violation when constraint name is not recognized`

自动化校验：

- [x] \`pnpm test:run tests/unit/services/billing-cost-service.test.ts\` —— 18/18 通过（原 13 + 新 5）
- [x] \`pnpm test:run tests/unit/services/\` —— 1117/1117 全量通过，无回归
- [x] \`pnpm exec tsc --noEmit\` 通过
- [x] \`pnpm lint\` 通过
- [x] \`pnpm build\` 通过
- [ ] 合入后发 v0.3.0-alpha.4 → 部署 → smoke test 不再出现 \`failed to persist billing snapshot\` 日志

## 设计依据

本 PR 的方案选型经 Codex 二次评审协助钉定。关键分歧点：

- 单纯的"snapshot 写前从 request_logs 反查 FK 列"（PR #168 的做法）治标不治本，本质是 TOCTOU。
- catch-and-retry 看似不优雅但 100% 消除 race，是符合 schema 设计意图（两列本就允许 NULL）的正确做法。
- 把 reconcile 与 catch-retry 叠加，能在常见路径上避免重试日志噪音，同时在真实并发删除窗口下保证正确性。

## 已知后续

部署日志中同时出现一条独立的 \`request_logs.duration_ms\` integer 溢出错误（值 9461868115 ≈ 109 天），来自后台 stale reconciler。属于另一个独立 bug，将在另一个 PR 单独修。