### PR TITLE
fix(billing): 识别 drizzle 包装后的 FK 违例，补齐 PR #169 漏掉的真实形状

### DIFF
--- a/src/lib/services/billing-cost-service.ts
+++ b/src/lib/services/billing-cost-service.ts
@@ -15,12 +15,41 @@ const log = createLogger("billing-cost-service");
 type BillingSnapshotInsertValues = typeof requestBillingSnapshots.$inferInsert;
 type BillingSnapshotUpdateSet = Partial<BillingSnapshotInsertValues>;
 
-function isPgForeignKeyViolation(
-  error: unknown
-): error is { code: string; constraint_name?: string } {
-  return (
-    typeof error === "object" && error !== null && (error as { code?: unknown }).code === "23503"
-  );
+interface PgForeignKeyViolation {
+  code: "23503";
+  constraint_name?: string;
+}
+
+/**
+ * 提取 Postgres FK 违例信息。drizzle-orm 0.45 会把驱动抛出的 PostgresError 包成
+ * DrizzleQueryError 并将原错误塞到 `.cause` 上，因此外层对象本身没有 `code` 字段。
+ * 这里同时检查顶层与 `.cause` 一层，覆盖两种形状；非 FK 违例返回 null。
+ */
+function extractPgForeignKeyViolation(error: unknown): PgForeignKeyViolation | null {
+  if (typeof error !== "object" || error === null) return null;
+
+  const direct = error as { code?: unknown; constraint_name?: unknown };
+  if (direct.code === "23503") {
+    return {
+      code: "23503",
+      constraint_name:
+        typeof direct.constraint_name === "string" ? direct.constraint_name : undefined,
+    };
+  }
+
+  const cause = (error as { cause?: unknown }).cause;
+  if (typeof cause === "object" && cause !== null) {
+    const inner = cause as { code?: unknown; constraint_name?: unknown };
+    if (inner.code === "23503") {
+      return {
+        code: "23503",
+        constraint_name:
+          typeof inner.constraint_name === "string" ? inner.constraint_name : undefined,
+      };
+    }
+  }
+
+  return null;
 }
 
 function resolveViolatedFkColumn(
@@ -52,8 +81,9 @@ async function upsertBillingSnapshotWithFkRetry(
       .onConflictDoUpdate({ target: requestBillingSnapshots.requestLogId, set: updateSet });
     return { apiKeyId: values.apiKeyId ?? null, upstreamId: values.upstreamId ?? null };
   } catch (error) {
-    if (!isPgForeignKeyViolation(error)) throw error;
-    const column = resolveViolatedFkColumn(error.constraint_name);
+    const violation = extractPgForeignKeyViolation(error);
+    if (!violation) throw error;
+    const column = resolveViolatedFkColumn(violation.constraint_name);
     if (!column) throw error;
 
     const patchedValues: BillingSnapshotInsertValues = { ...values, [column]: null };
@@ -65,7 +95,7 @@ async function upsertBillingSnapshotWithFkRetry(
     });
 
     log.warn(
-      { requestLogId, nulledColumn: column, constraint: error.constraint_name },
+      { requestLogId, nulledColumn: column, constraint: violation.constraint_name },
       "billing snapshot FK violation retried with NULL"
     );
 

--- a/tests/unit/services/billing-cost-service.test.ts
+++ b/tests/unit/services/billing-cost-service.test.ts
@@ -519,18 +519,26 @@ describe("billing-cost-service", () => {
     );
   });
 
-  it("retries with null api_key_id when INSERT hits api_keys FK violation", async () => {
+  it("retries with null api_key_id when INSERT hits api_keys FK violation (drizzle-wrapped)", async () => {
     // 真实生产 race：reconcile 读到的 api_key_id 在 reconcile→INSERT 之间被并发删除，
     // INSERT 撞 FK；helper 应当捕获 PG 23503 + 对应约束名后单次重试，把 apiKeyId 置 NULL。
     // reconcile 此时还能读到旧 id（cascade 尚未触发），下一刻 INSERT 才撞 FK。
+    //
+    // 关键：drizzle-orm 0.45 抛出的是 DrizzleQueryError，原始 PostgresError 挂在 `.cause`，
+    // 外层没有 `code` 字段。本测试用这种形状复现生产真实链路；下一个测试覆盖
+    // 平铺形状（postgres-js 在少数路径上可能不经 drizzle 包装直接抛出）。
     requestLogsFindFirstMock.mockResolvedValueOnce({
       apiKeyId: "doomed-key-id",
       upstreamId: "still-valid-upstream",
     });
-    const fkError = Object.assign(new Error("FK violation"), {
-      code: "23503",
-      constraint_name: "request_billing_snapshots_api_key_id_api_keys_id_fk",
-      table_name: "request_billing_snapshots",
+    const fkError = Object.assign(new Error("Failed query: insert into ..."), {
+      query: "insert into request_billing_snapshots ...",
+      params: ["doomed-key-id"],
+      cause: {
+        code: "23503",
+        constraint_name: "request_billing_snapshots_api_key_id_api_keys_id_fk",
+        table_name: "request_billing_snapshots",
+      },
     });
     onConflictDoUpdateMock.mockRejectedValueOnce(fkError).mockResolvedValueOnce(undefined);
 
@@ -562,7 +570,9 @@ describe("billing-cost-service", () => {
     );
   });
 
-  it("retries with null upstream_id when INSERT hits upstreams FK violation", async () => {
+  it("retries with null upstream_id when INSERT hits upstreams FK violation (flat shape)", async () => {
+    // 兼容形状：PostgresError 直接冒出来（未经 DrizzleQueryError 包装），
+    // 探测函数也需识别。覆盖 postgres-js 在连接级 / 异常退出路径上的情况。
     requestLogsFindFirstMock.mockResolvedValueOnce({
       apiKeyId: "still-valid-key",
       upstreamId: "doomed-upstream-id",
@@ -658,6 +668,30 @@ describe("billing-cost-service", () => {
         usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
       })
     ).rejects.toBe(otherError);
+
+    expect(onConflictDoUpdateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows wrapped non-FK errors without retry", async () => {
+    // 防回归：wrapped 形状里的 cause.code 若不是 23503（例如 23505 唯一约束、08006 连接断开），
+    // 探测函数必须返回 null，绝不能把所有带 cause 的 DrizzleQueryError 都误判为 FK 违例。
+    const wrappedUniqueErr = Object.assign(new Error("Failed query: insert into ..."), {
+      cause: { code: "23505", constraint_name: "some_unique_constraint" },
+    });
+    onConflictDoUpdateMock.mockRejectedValueOnce(wrappedUniqueErr);
+
+    const { calculateAndPersistRequestBillingSnapshot } =
+      await import("../../../src/lib/services/billing-cost-service");
+
+    await expect(
+      calculateAndPersistRequestBillingSnapshot({
+        requestLogId: "log-wrapped-non-fk",
+        apiKeyId: "key-1",
+        upstreamId: "up-1",
+        model: null,
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      })
+    ).rejects.toBe(wrappedUniqueErr);
 
     expect(onConflictDoUpdateMock).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## 背景

PR #169（v0.3.0-alpha.4）部署后，生产 deploy smoke test 仍然复现同一 FK 违例：

```
request_billing_snapshots_api_key_id_api_keys_id_fk
deploy-smoke-26324373275-key 删除后 15ms，billing snapshot INSERT 撞 FK
```

且日志中**完全找不到** PR #169 加的 warn `"billing snapshot FK violation retried with NULL"`——意味着 catch-and-retry 分支从未真正执行过。

## 根因

drizzle-orm 0.45 在 `node_modules/drizzle-orm/errors.js` 的 `DrizzleQueryError` 把驱动抛出的 PostgresError 包了一层，原始错误塞到 `.cause` 上：

```js
class DrizzleQueryError extends Error {
  constructor(query, params, cause) {
    super(\`Failed query: \${query}\nparams: \${params}\`);
    this.cause = cause; // ← 真正带 code/constraint_name 的 PostgresError 在这
  }
}
```

PR #169 的 `isPgForeignKeyViolation` 只检查 `error.code === "23503"`，对外层 DrizzleQueryError 永远返回 false，retry 分支永远不会触发，错误原样冒出来落到 `persistBillingSnapshotSafely` 的 catch 打印 `"failed to persist billing snapshot"`。

PR #169 的单元测试用 \`Object.assign(new Error(), { code, constraint_name })\` 直接平铺字段，没复现真实的 wrap 形状，所以测试通过但生产失败。

## 修复

1. **`src/lib/services/billing-cost-service.ts`**：把探测函数改为 \`extractPgForeignKeyViolation\`，同时检查 \`error\` 和 \`error.cause\` 单层（drizzle 0.45 是单层包装，已查证），返回统一形状的 violation 信息，retry 分支不再二次按错误形状判断。

2. **`tests/unit/services/billing-cost-service.test.ts`**：
   - 把 api_key_id retry 用例改用真实 wrapped 形状 \`{ cause: { code, constraint_name } }\` 复现生产链路；
   - 保留一个平铺形状用例覆盖 postgres-js 不经包装直接抛出的边界场景；
   - 新增 wrapped 非 FK 错误（cause.code = 23505）的负面测试，防止把所有带 cause 的 DrizzleQueryError 误判为 FK 违例。

## Codex double check

已和 Codex 商量方案，推荐采用「保留 catch-and-retry 思路，只修探测函数 + 测试用真实形状」，备选方案（SELECT FOR SHARE / schema 改为 ON DELETE SET NULL / 测试侧 workaround）均不建议作为主线修复。本 PR 即按推荐方案实现。

## Test plan

- [x] \`pnpm test:run tests/unit/services/billing-cost-service.test.ts\` → 19 passed
- [x] \`pnpm test:run\` 全量 → 147 files, 2484 passed / 1 skipped
- [x] \`pnpm exec tsc --noEmit\` → 0 errors
- [x] \`pnpm lint\` → 0 errors
- [x] \`pnpm format:check\` → 通过
- [x] pre-commit 全部通过
- [ ] 合并 + 发版 + Personal Deploy 内置 smoke test 实地回归（同样会创建/删除临时 key，是触发原 bug 的同一路径）

Refs: #168, #169