### PR TITLE
fix(request-logger): clamp duration_ms 到 INT4 上限，防止 reconcile 写入溢出

### DIFF
--- a/src/lib/services/request-logger.ts
+++ b/src/lib/services/request-logger.ts
@@ -17,6 +17,7 @@ const log = createLogger("request-logger");
 const REQUEST_LOG_STALE_MINUTES = 15;
 const REQUEST_LOG_STALE_SCAN_LIMIT = 200;
 const STALE_REQUEST_LOG_STATUS_CODE = 520;
+const INT4_MAX = 2_147_483_647;
 const STALE_REQUEST_LOG_ERROR_MESSAGE =
   "Request did not settle before the stale reconciliation timeout window";
 
@@ -406,9 +407,14 @@ export async function updateRequestLog(
   if (input.cacheReadTokens !== undefined) updateValues.cacheReadTokens = input.cacheReadTokens;
 
   if (input.statusCode !== undefined) updateValues.statusCode = input.statusCode;
-  if (input.durationMs !== undefined) updateValues.durationMs = input.durationMs;
+  if (input.durationMs !== undefined)
+    updateValues.durationMs =
+      input.durationMs === null ? null : Math.min(Math.max(0, input.durationMs), INT4_MAX);
   if (input.routingDurationMs !== undefined)
-    updateValues.routingDurationMs = input.routingDurationMs;
+    updateValues.routingDurationMs =
+      input.routingDurationMs === null
+        ? null
+        : Math.min(Math.max(0, input.routingDurationMs), INT4_MAX);
   if (input.errorMessage !== undefined) updateValues.errorMessage = input.errorMessage;
 
   if (input.routingType !== undefined) updateValues.routingType = input.routingType;
@@ -480,8 +486,12 @@ export async function logRequest(input: LogRequestInput): Promise<RequestLog> {
       cacheCreation1hTokens: input.cacheCreation1hTokens ?? 0,
       cacheReadTokens: input.cacheReadTokens ?? 0,
       statusCode: input.statusCode,
-      durationMs: input.durationMs,
-      routingDurationMs: input.routingDurationMs ?? null,
+      durationMs:
+        input.durationMs === null ? null : Math.min(Math.max(0, input.durationMs), INT4_MAX),
+      routingDurationMs:
+        input.routingDurationMs === undefined || input.routingDurationMs === null
+          ? null
+          : Math.min(Math.max(0, input.routingDurationMs), INT4_MAX),
       errorMessage: input.errorMessage ?? null,
       // Routing decision fields
       routingType: input.routingType ?? null,
@@ -542,7 +552,7 @@ export async function reconcileStaleInProgressRequestLogs(options?: {
       continue;
     }
 
-    const durationMs = Math.max(0, now.getTime() - createdAt.getTime());
+    const durationMs = Math.min(Math.max(0, now.getTime() - createdAt.getTime()), INT4_MAX);
     const updated = await updateRequestLog(candidate.id, {
       statusCode: STALE_REQUEST_LOG_STATUS_CODE,
       durationMs,

--- a/tests/unit/services/request-logger-db.test.ts
+++ b/tests/unit/services/request-logger-db.test.ts
@@ -524,4 +524,49 @@ describe("request-logger (db flows)", () => {
       },
     });
   });
+
+  it("reconcileStaleInProgressRequestLogs clamps overflow durationMs before updating", async () => {
+    const { reconcileStaleInProgressRequestLogs } = await import("@/lib/services/request-logger");
+
+    const int4Max = 2_147_483_647;
+    const now = new Date("2026-03-07T12:00:00.000Z");
+    requestLogsFindManyMock.mockResolvedValueOnce([
+      {
+        id: "log-overflow",
+        createdAt: new Date(now.getTime() - int4Max - 1_000),
+        isStream: false,
+      },
+    ]);
+
+    const returningMock = vi.fn().mockResolvedValueOnce([
+      {
+        id: "log-overflow",
+        statusCode: 520,
+        apiKeyId: null,
+        upstreamId: null,
+        model: null,
+      },
+    ]);
+    const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+    const setMock = vi.fn().mockImplementation((values) => {
+      if (typeof values.durationMs === "number" && values.durationMs > int4Max) {
+        throw new RangeError("integer out of range");
+      }
+      return { where: whereMock };
+    });
+    dbUpdateMock.mockReturnValue({ set: setMock });
+    calculateAndPersistRequestBillingSnapshotMock.mockResolvedValueOnce({
+      status: "unbilled",
+      unbillableReason: "usage_missing",
+      finalCost: null,
+      source: null,
+    });
+
+    await expect(reconcileStaleInProgressRequestLogs({ now })).resolves.toBe(1);
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        durationMs: int4Max,
+      })
+    );
+  });
 });


### PR DESCRIPTION
## 背景

v0.3.0-alpha.5 部署后启动日志报错：

\`\`\`
module: "request-logger"
err: value "9469525256" is out of range for type integer
duration_ms = 9469525256 ms ≈ 109.6 天
request_log_id = c848a0b0-5ac1-4eb9-9d6b-2dda7114e1d2
msg: "failed to reconcile stale in-progress request logs"
\`\`\`

数据库里存在一条 109 天前创建、\`status_code\` 一直为 NULL 的 in-progress 日志（大概率是某次进程崩溃 / OOM 时正在处理请求未来得及收尾）。\`reconcileStaleInProgressRequestLogs\` 启动时把这条 row 写入实际 elapsed（≈ 9.4e9 ms），超出 PG \`integer\` 列上限 2,147,483,647（≈ 24.85 天），每次启动都失败。

## 根因

\`schema-pg.ts:301-302\` 把 \`duration_ms\` / \`routing_duration_ms\` 定义成 \`integer\`（INT4），而原始写入路径没有 clamp，假设 elapsed 不会超界。

## 修复

在 \`src/lib/services/request-logger.ts\` 提取 \`INT4_MAX = 2_147_483_647\` 常量，把 clamp 集中到三个中央入口：

1. **\`reconcileStaleInProgressRequestLogs\`** — \`now - createdAt\` 计算后 \`Math.min(..., INT4_MAX)\`
2. **\`updateRequestLog\`** — \`durationMs\` / \`routingDurationMs\` 入参非 null 时统一 clamp
3. **\`logRequest\`** — \`INSERT values\` 构造 \`durationMs\` / \`routingDurationMs\` 时同样 clamp

\`route.ts\` 所有调用都通过这两个函数入库，自动获得防护；null 透传不动。

## 数据库已存在的 stale row

不需要单独写 SQL 修——下次 reconcile 命中就会被 clamp 到 INT4_MAX 写入，同步标记 \`status_code = 520\`。

## Codex double check

已和 Codex 商量方案，对比 schema 升级为 bigint 的方案后明确选择 clamp（改动最小、零迁移风险、零数据迁移）。本 PR 即按推荐方案实施。

## Test plan

- [x] \`pnpm test:run tests/unit/services/request-logger-db.test.ts\` → 9 passed（含新增 clamp 用例）
- [x] \`pnpm test:run\` 全量 → 147 files, 2485 passed / 1 skipped
- [x] \`pnpm exec tsc --noEmit\` → 0 errors
- [x] \`pnpm lint\` → 0 errors
- [x] \`pnpm format:check\` → 通过
- [x] pre-commit 全部通过
- [ ] 合并 + 发版 + 部署后验证启动日志无 \`failed to reconcile stale in-progress request logs\` 错误