### PR TITLE
fix(billing): FK 违例探测兼容 constraint 字段名，补齐 PR #170 漏掉的兜底

### DIFF
--- a/src/lib/services/billing-cost-service.ts
+++ b/src/lib/services/billing-cost-service.ts
@@ -20,31 +20,38 @@ interface PgForeignKeyViolation {
   constraint_name?: string;
 }
 
+function extractConstraintName(error: {
+  constraint_name?: unknown;
+  constraint?: unknown;
+}): string | undefined {
+  if (typeof error.constraint_name === "string") return error.constraint_name;
+  if (typeof error.constraint === "string") return error.constraint;
+  return undefined;
+}
+
 /**
  * 提取 Postgres FK 违例信息。drizzle-orm 0.45 会把驱动抛出的 PostgresError 包成
  * DrizzleQueryError 并将原错误塞到 `.cause` 上，因此外层对象本身没有 `code` 字段。
- * 这里同时检查顶层与 `.cause` 一层，覆盖两种形状；非 FK 违例返回 null。
+ * 这里同时检查顶层与 `.cause` 一层，并兼容 postgres-js 的 constraint 字段。
  */
 function extractPgForeignKeyViolation(error: unknown): PgForeignKeyViolation | null {
   if (typeof error !== "object" || error === null) return null;
 
-  const direct = error as { code?: unknown; constraint_name?: unknown };
+  const direct = error as { code?: unknown; constraint_name?: unknown; constraint?: unknown };
   if (direct.code === "23503") {
     return {
       code: "23503",
-      constraint_name:
-        typeof direct.constraint_name === "string" ? direct.constraint_name : undefined,
+      constraint_name: extractConstraintName(direct),
     };
   }
 
   const cause = (error as { cause?: unknown }).cause;
   if (typeof cause === "object" && cause !== null) {
-    const inner = cause as { code?: unknown; constraint_name?: unknown };
+    const inner = cause as { code?: unknown; constraint_name?: unknown; constraint?: unknown };
     if (inner.code === "23503") {
       return {
         code: "23503",
-        constraint_name:
-          typeof inner.constraint_name === "string" ? inner.constraint_name : undefined,
+        constraint_name: extractConstraintName(inner),
       };
     }
   }

--- a/tests/unit/services/billing-cost-service.test.ts
+++ b/tests/unit/services/billing-cost-service.test.ts
@@ -602,6 +602,46 @@ describe("billing-cost-service", () => {
     );
   });
 
+  it("retries with null upstream_id when wrapped FK violation uses constraint field", async () => {
+    requestLogsFindFirstMock.mockResolvedValueOnce({
+      apiKeyId: "still-valid-key",
+      upstreamId: "doomed-upstream-id",
+    });
+    const fkError = Object.assign(new Error("Failed query: insert into ..."), {
+      cause: {
+        code: "23503",
+        constraint: "request_billing_snapshots_upstream_id_upstreams_id_fk",
+      },
+    });
+    onConflictDoUpdateMock.mockRejectedValueOnce(fkError).mockResolvedValueOnce(undefined);
+
+    const { calculateAndPersistRequestBillingSnapshot } =
+      await import("../../../src/lib/services/billing-cost-service");
+
+    await calculateAndPersistRequestBillingSnapshot({
+      requestLogId: "log-wrapped-constraint-retry",
+      apiKeyId: "still-valid-key",
+      upstreamId: "doomed-upstream-id",
+      model: "gpt-4.1-smoke",
+      usage: { promptTokens: 6, completionTokens: 3, totalTokens: 9 },
+    });
+
+    expect(onConflictDoUpdateMock).toHaveBeenCalledTimes(2);
+    expect(valuesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        apiKeyId: "still-valid-key",
+        upstreamId: null,
+      })
+    );
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nulledColumn: "upstreamId",
+        constraint: "request_billing_snapshots_upstream_id_upstreams_id_fk",
+      }),
+      expect.stringContaining("FK violation retried")
+    );
+  });
+
   it("skips quota delta for FK-retried column to avoid db/memory state drift", async () => {
     // 重试时 upstream_id 被置 NULL，配额累加必须基于实际写入值（NULL），
     // 否则数据库快照已无 upstream 维度但内存配额仍按旧 id 累加，造成幽灵配额。


### PR DESCRIPTION
## 背景

v0.3.0-alpha.6 部署后 deploy smoke test 再次复现 FK 违例：

\`\`\`
constraint: request_billing_snapshots_upstream_id_upstreams_id_fk
params: api_key_id = null, upstream_id = 已删除的 smoke upstream id
msg: failed to persist billing snapshot
\`\`\`

但日志**没有** PR #170 加的 warn \`billing snapshot FK violation retried with NULL\`——说明 retry 分支未被触发。

## 根因

\`extractPgForeignKeyViolation\` 识别到 \`code === "23503"\` ✓，但读取约束名时只检查了 \`constraint_name\` 字段，拿到 undefined。\`resolveViolatedFkColumn(undefined)\` 返回 null，\`if (!column) throw error\` 把错误抛回外层，retry 一次也没跑。

理论上 \`postgres-js 3.4.9\` 应该用 \`constraint_name\` 字段（源码 \`connection.js:46\` 确认），但实际生产场景中错误对象上没有这个字段——可能是序列化路径丢失、driver 版本差异或其它原因。

## 修复

抽出 \`extractConstraintName\` helper，对 PostgresError 同时探测两种字段名：
- \`constraint_name\`（postgres-js 标准字段，主路径）
- \`constraint\`（兜底，覆盖未来 driver 改名或其他平铺路径）

顶层与 \`.cause\` 两条分支都套用该 helper。

## Test plan

- [x] 新增用例验证 wrapped + \`cause.constraint\`（无 \`_name\` 后缀）+ upstream_id 约束能正确触发 retry，把 upstream_id 置 NULL
- [x] \`pnpm test:run tests/unit/services/billing-cost-service.test.ts\` → 20 passed（含新增 1 个）
- [x] \`pnpm test:run\` 全量 → 147 files / 2486 passed / 1 skipped
- [x] \`pnpm exec tsc --noEmit\` → 0 errors
- [x] \`pnpm lint\` → 0 errors
- [x] \`pnpm format:check\` → 通过
- [x] pre-commit 全部通过
- [ ] 合并 + 发版 + Personal Deploy 内置 smoke test 实地验证（触发原 bug 的同一路径）

## 已知边界（本 PR 不处理）

\`upsertBillingSnapshotWithFkRetry\` 仍然只 retry 一次。当前生产 race 单次 retry 够用——\`api_key_id\` 通常已被 reconcile 路径在 INSERT 前置 null（看 alpha.6 日志 params 第二位即是 null），第二次 INSERT 只剩 upstream_id 一列要置 null。若未来 smoke 流程改为在 reconcile 之前同时删两个父记录，需要把 retry 改为最多两次循环——届时再单独开 PR。

Refs: #168, #169, #170