### PR TITLE
fix(billing): detect FK violations from error messages

### DIFF
--- a/src/lib/services/billing-cost-service.ts
+++ b/src/lib/services/billing-cost-service.ts
@@ -29,10 +29,33 @@ function extractConstraintName(error: {
   return undefined;
 }
 
+function extractForeignKeyConstraintFromMessage(message: string): string | undefined {
+  const match = message.match(/violates foreign key constraint "([^"]+)"/);
+  return match?.[1];
+}
+
+function collectErrorMessages(error: unknown): string[] {
+  if (typeof error !== "object" || error === null) return [];
+
+  const messages: string[] = [];
+  const direct = error as { message?: unknown; stack?: unknown; cause?: unknown };
+  if (typeof direct.message === "string") messages.push(direct.message);
+  if (typeof direct.stack === "string") messages.push(direct.stack);
+
+  const cause = direct.cause;
+  if (typeof cause === "object" && cause !== null) {
+    const inner = cause as { message?: unknown; stack?: unknown };
+    if (typeof inner.message === "string") messages.push(inner.message);
+    if (typeof inner.stack === "string") messages.push(inner.stack);
+  }
+
+  return messages;
+}
+
 /**
  * 提取 Postgres FK 违例信息。drizzle-orm 0.45 会把驱动抛出的 PostgresError 包成
  * DrizzleQueryError 并将原错误塞到 `.cause` 上，因此外层对象本身没有 `code` 字段。
- * 这里同时检查顶层与 `.cause` 一层，并兼容 postgres-js 的 constraint 字段。
+ * 这里同时检查顶层与 `.cause` 一层，并兼容 postgres-js 的 constraint 字段与错误文本。
  */
 function extractPgForeignKeyViolation(error: unknown): PgForeignKeyViolation | null {
   if (typeof error !== "object" || error === null) return null;
@@ -53,6 +76,13 @@ function extractPgForeignKeyViolation(error: unknown): PgForeignKeyViolation | n
         code: "23503",
         constraint_name: extractConstraintName(inner),
       };
+    }
+  }
+
+  for (const message of collectErrorMessages(error)) {
+    const constraintName = extractForeignKeyConstraintFromMessage(message);
+    if (constraintName) {
+      return { code: "23503", constraint_name: constraintName };
     }
   }
 

--- a/tests/unit/services/billing-cost-service.test.ts
+++ b/tests/unit/services/billing-cost-service.test.ts
@@ -642,6 +642,50 @@ describe("billing-cost-service", () => {
     );
   });
 
+  it("retries with null upstream_id when wrapped FK violation only exposes message text", async () => {
+    requestLogsFindFirstMock.mockResolvedValueOnce({
+      apiKeyId: "still-valid-key",
+      upstreamId: "doomed-upstream-id",
+    });
+    const fkError = Object.assign(
+      new Error(
+        'Failed query: insert into "request_billing_snapshots" ...: insert or update on table "request_billing_snapshots" violates foreign key constraint "request_billing_snapshots_upstream_id_upstreams_id_fk"'
+      ),
+      {
+        cause: new Error(
+          'insert or update on table "request_billing_snapshots" violates foreign key constraint "request_billing_snapshots_upstream_id_upstreams_id_fk"'
+        ),
+      }
+    );
+    onConflictDoUpdateMock.mockRejectedValueOnce(fkError).mockResolvedValueOnce(undefined);
+
+    const { calculateAndPersistRequestBillingSnapshot } =
+      await import("../../../src/lib/services/billing-cost-service");
+
+    await calculateAndPersistRequestBillingSnapshot({
+      requestLogId: "log-message-only-fk-retry",
+      apiKeyId: "still-valid-key",
+      upstreamId: "doomed-upstream-id",
+      model: "gpt-4.1-smoke",
+      usage: { promptTokens: 6, completionTokens: 3, totalTokens: 9 },
+    });
+
+    expect(onConflictDoUpdateMock).toHaveBeenCalledTimes(2);
+    expect(valuesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        apiKeyId: "still-valid-key",
+        upstreamId: null,
+      })
+    );
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nulledColumn: "upstreamId",
+        constraint: "request_billing_snapshots_upstream_id_upstreams_id_fk",
+      }),
+      expect.stringContaining("FK violation retried")
+    );
+  });
+
   it("skips quota delta for FK-retried column to avoid db/memory state drift", async () => {
     // 重试时 upstream_id 被置 NULL，配额累加必须基于实际写入值（NULL），
     // 否则数据库快照已无 upstream 维度但内存配额仍按旧 id 累加，造成幽灵配额。


### PR DESCRIPTION
## Summary

Fix billing snapshot FK retry detection when the deployed Postgres/Drizzle error only exposes the violated constraint in the error message text.

## Related Issue

Follow-up to deploy smoke failure observed in run `26326869522`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (code improvement without changing functionality)
- [x] Tests (adding or updating tests)
- [ ] Build/CI (changes to build system or CI configuration)

## Changes

- Parse `violates foreign key constraint "..."` from top-level and cause error messages when Postgres FK metadata fields are unavailable.
- Keep the existing exact FK column mapping so only known `api_key_id` and `upstream_id` billing snapshot constraints are retried with `NULL`.
- Add a regression test for the production-shaped wrapped error that only exposes the upstream FK constraint in message text.

## Test Plan

- [x] Local tests pass (`pnpm test:run tests/unit/services/billing-cost-service.test.ts`)
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`eslint` via commit hook)
- [ ] Manual testing completed

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [ ] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

N/A

## Additional Notes

The previous fix handled `constraint_name` and `constraint` fields, but the deployed error in run `26326869522` did not expose those fields to the application-level detector. The constraint name was still present in the error message text, so this patch uses that text as the final FK detection source.