### PR TITLE
chore(billing): 临时加 FK 违例诊断日志，定位 PG driver 实际约束名字段

### DIFF
--- a/src/lib/services/billing-cost-service.ts
+++ b/src/lib/services/billing-cost-service.ts
@@ -69,6 +69,51 @@ function resolveViolatedFkColumn(
 }
 
 /**
+ * 临时诊断：当 FK 重试探测失败时，把错误对象与 .cause 上所有 own enumerable 标量
+ * 字段平摊后打印出来。目的是定位 PG driver 实际使用的约束名字段（已尝试过
+ * constraint_name / constraint 均落空），看清真实形状后再做永久修复。
+ *
+ * 仅打 warn 级别，永远不影响主流程；包在 try/catch 里防止序列化自身抛错。
+ */
+function logBillingFkDiagnostic(
+  error: unknown,
+  requestLogId: string,
+  reason: string,
+  extra?: Record<string, unknown>
+): void {
+  try {
+    const flattenScalarOwnProps = (obj: unknown): Record<string, unknown> | null => {
+      if (!obj || typeof obj !== "object") return null;
+      const out: Record<string, unknown> = {};
+      for (const key of Object.getOwnPropertyNames(obj)) {
+        const value = (obj as Record<string, unknown>)[key];
+        if (typeof value === "string") {
+          out[key] = value.length > 300 ? `${value.slice(0, 300)}...` : value;
+        } else if (typeof value === "number" || typeof value === "boolean" || value === null) {
+          out[key] = value;
+        }
+      }
+      return out;
+    };
+    const cause = (error as { cause?: unknown })?.cause;
+    log.warn(
+      {
+        requestLogId,
+        reason,
+        errCtor: (error as { constructor?: { name?: string } })?.constructor?.name,
+        errFlat: flattenScalarOwnProps(error),
+        causeCtor: (cause as { constructor?: { name?: string } })?.constructor?.name,
+        causeFlat: flattenScalarOwnProps(cause),
+        ...extra,
+      },
+      "billing snapshot FK diagnostic"
+    );
+  } catch {
+    /* 诊断永不破坏主流程 */
+  }
+}
+
+/**
  * 写 snapshot 时若 api_key_id / upstream_id 违反 FK 约束（典型场景：caller 持有的
  * id 在请求处理与异步 snapshot 写入之间被并发删除——reconcile 也无法消除这一
  * TOCTOU 窗口），把违反的那一列置 NULL 后单次重试。
@@ -89,9 +134,21 @@ async function upsertBillingSnapshotWithFkRetry(
     return { apiKeyId: values.apiKeyId ?? null, upstreamId: values.upstreamId ?? null };
   } catch (error) {
     const violation = extractPgForeignKeyViolation(error);
-    if (!violation) throw error;
+    if (!violation) {
+      logBillingFkDiagnostic(
+        error,
+        requestLogId,
+        "extract returned null (not detected as FK 23503)"
+      );
+      throw error;
+    }
     const column = resolveViolatedFkColumn(violation.constraint_name);
-    if (!column) throw error;
+    if (!column) {
+      logBillingFkDiagnostic(error, requestLogId, "detected 23503 but constraint name unresolved", {
+        detectedConstraintName: violation.constraint_name,
+      });
+      throw error;
+    }
 
     const patchedValues: BillingSnapshotInsertValues = { ...values, [column]: null };
     const patchedSet: BillingSnapshotUpdateSet = { ...updateSet, [column]: null };


### PR DESCRIPTION
## 背景

alpha.6 → alpha.7 两轮字段名兼容修复（先 \`constraint_name\`，再补 \`constraint\` 兜底）部署到生产后，FK 违例**仍然没触发 retry**：

\`\`\`
docker logs autorouter --since 30m | grep "deploy-smoke-26326869522"
→ 0 行 FK violation retried
→ 1 行 failed to persist billing snapshot（同样的 upstream_id FK 违例）
\`\`\`

意味着 cause 对象上**既无 \`constraint_name\` 也无 \`constraint\` 字段**。继续凭推测加字段名兜底是徒劳——必须先看清生产 PG driver 实际抛出的错误形状是什么。

## 改动

仅在 \`upsertBillingSnapshotWithFkRetry\` 的 catch 内增加诊断分支：

- \`extractPgForeignKeyViolation\` 返回 null（连 23503 都没识别）→ 打诊断 warn
- 识别到 23503 但 \`resolveViolatedFkColumn\` 拿到 null（约束名缺失/未知）→ 打诊断 warn（带上 \`detectedConstraintName\`）

诊断 warn 内容：
- \`errCtor\` / \`causeCtor\`：构造函数名（哪怕 minified 也能区分类）
- \`errFlat\` / \`causeFlat\`：所有 own enumerable 的 string / number / boolean / null 字段（string 截断 300 字符）
- \`reason\`：命中哪条诊断分支

诊断函数包在 try/catch 里，序列化自身抛错也不影响主流程；不改 retry 逻辑、不动 \`extractPgForeignKeyViolation\` 与 \`resolveViolatedFkColumn\`。

## 这是临时代码

属于"先看清形状，再做永久修复"的诊断手段。下次部署看到一次真实输出后再单独开 PR 永久修字段名探测或改走父表存在性检查方案。

## Test plan

- [x] \`pnpm test:run tests/unit/services/billing-cost-service.test.ts\` → 20 passed（断言用 \`toHaveBeenCalledWith\` 不要求独占调用，加 warn 不破坏）
- [x] \`pnpm test:run\` 全量 → 147 files / 2486 passed / 1 skipped
- [x] \`pnpm exec tsc --noEmit\` → 0 errors
- [x] \`pnpm lint\` → 0 errors
- [x] \`pnpm format:check\` → 通过
- [x] pre-commit 全部通过
- [ ] 合并 + 发版 + Personal Deploy 后看一次 \`docker logs autorouter | grep "billing snapshot FK diagnostic"\`，根据 \`causeFlat\` 中的实际字段名决定下一步永久修复方向

Refs: #170, #172