### PR TITLE
docs(readme): link to VitePress docs site (#167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Verify](https://github.com/g1331/AutoRouter/actions/workflows/verify.yml/badge.svg)](https://github.com/g1331/AutoRouter/actions/workflows/verify.yml)
 [![Release](https://github.com/g1331/AutoRouter/actions/workflows/release.yml/badge.svg)](https://github.com/g1331/AutoRouter/actions/workflows/release.yml)
 [![codecov](https://codecov.io/gh/g1331/AutoRouter/graph/badge.svg)](https://codecov.io/gh/g1331/AutoRouter)
+[![Docs](https://img.shields.io/badge/Docs-WIP-orange?logo=vite&logoColor=white)](https://g1331.github.io/AutoRouter/)
 
 <!-- Badges: Tech -->
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -11,6 +11,7 @@
 [![Verify](https://github.com/g1331/AutoRouter/actions/workflows/verify.yml/badge.svg)](https://github.com/g1331/AutoRouter/actions/workflows/verify.yml)
 [![Release](https://github.com/g1331/AutoRouter/actions/workflows/release.yml/badge.svg)](https://github.com/g1331/AutoRouter/actions/workflows/release.yml)
 [![codecov](https://codecov.io/gh/g1331/AutoRouter/graph/badge.svg)](https://codecov.io/gh/g1331/AutoRouter)
+[![Docs](https://img.shields.io/badge/Docs-WIP-orange?logo=vite&logoColor=white)](https://g1331.github.io/AutoRouter/)
 
 <!-- Badges: Tech -->
 


### PR DESCRIPTION
## Summary

补 issue #167 落地后的门面入口。VitePress 文档站已部署到 https://g1331.github.io/AutoRouter/，但仓库门面没有任何指向，访客无从发现。

- `README.md` / `README_EN.md` Status 徽章组追加一个 `Docs` 徽章，颜色 `orange` 标注 `WIP`，链接到 Pages 站点
- 仓库 About → Website 字段已通过 `gh repo edit --homepage` 同步设为 Pages URL（不在本 PR diff 中体现，是仓库 metadata）

## 为什么标 WIP

Phase 1 仅完成站点脚手架与 34 篇正文占位，第一批 10 篇正文尚未撰写。徽章带 `WIP` 颜色避免访客点进去看到大量占位反而困惑；Phase 2 第一批 10 篇合入后，把徽章颜色翻成 `blue` 或去掉 WIP 标记即可。

## Test plan

- [x] `pnpm format:check` 全绿（仅 markdown 改动，无需 build / test）
- [ ] 合并后 README 顶部 Docs 徽章渲染正常并链向 Pages 站点
- [ ] 仓库首页右上 About 区显示 Website 链接