### PR TITLE
docs(deployment): phase 2 batch 1 — deployment side 4 docs (#167)

### DIFF
--- a/docs/guide/deployment/cliproxy-sidecar.md
+++ b/docs/guide/deployment/cliproxy-sidecar.md
@@ -5,19 +5,185 @@ outline: deep
 
 # CI 部署后追加 CLIProxyAPI sidecar
 
-::: warning 撰写中
-此文档目前为占位，正文尚未填充。完整撰写进度跟踪见 [issue #167](https://github.com/g1331/AutoRouter/issues/167)。
+`deploy-personal.yml` 完成后，目标服务器上只有主 `docker-compose.yml` 与作业生成的 `.env`，没有 `docker-compose.cliproxy.yml`、`cliproxy/` 目录以及 `.env` 中的 `CLIPROXY_*` 段。本页给出在不再触发 CI 的前提下，从服务器侧手工把 sidecar 资料补齐的完整步骤。
+
+如果是源码 + docker compose 路径，受管 sidecar 的资料已经在仓库里了，可以直接 `docker compose -f docker-compose.yml -f docker-compose.cliproxy.yml up -d` 启动，不需要本页这套补齐流程；本页仅针对「CI 部署 + 远端服务器」这条组合路径。
+
+## 前置条件
+
+- `deploy-personal.yml` 至少成功跑过一次，服务器上已经存在 `${DEPLOY_DIR}/docker-compose.yml` 与 `.env`（默认 `DEPLOY_DIR=/opt/autorouter`）。
+- 当前以可执行 `docker` 命令的用户身份登录到该服务器，并位于 `${DEPLOY_DIR}` 目录下。
+- 准备好两组 CLIProxyAPI 凭据（客户端 API Key 与管理密钥），稍后既要写入 `.env`，也要在 AutoRouter 管理端登记实例时录入；两侧必须一致。
+
+下面以默认部署目录为例。如果使用了自定义 `DEPLOY_DIR`，请把示例中的 `/opt/autorouter` 替换为实际路径。
+
+## 第一步：拉取 sidecar 叠加文件与配置资料
+
+`deploy-personal.yml` 通过 `raw.githubusercontent.com/<repo>/<release-tag>/docker-compose.yml` 拉取主 compose 文件。叠加文件与 cliproxy 目录使用同样的 URL 形态。请把示例中的 `<RELEASE_TAG>` 替换为本次部署使用的 release tag（与 `deploy-personal.yml` 触发时输入的 `confirm_release_id` 一致），保证与已运行镜像同源。
+
+```bash
+cd /opt/autorouter
+RELEASE_TAG=v0.1.0   # 替换为实际部署的 release tag
+BASE_URL=https://raw.githubusercontent.com/g1331/AutoRouter/${RELEASE_TAG}
+
+curl -fsSL -o docker-compose.cliproxy.yml "${BASE_URL}/docker-compose.cliproxy.yml"
+
+mkdir -p cliproxy
+curl -fsSL -o cliproxy/config.yaml.template "${BASE_URL}/cliproxy/config.yaml.template"
+curl -fsSL -o cliproxy/docker-entrypoint.sh "${BASE_URL}/cliproxy/docker-entrypoint.sh"
+chmod +x cliproxy/docker-entrypoint.sh
+```
+
+完成后目录结构应当与仓库 `cliproxy/` 一致：
+
+```
+/opt/autorouter
+├── .env
+├── docker-compose.yml
+├── docker-compose.cliproxy.yml
+└── cliproxy
+    ├── config.yaml.template
+    └── docker-entrypoint.sh
+```
+
+`docker-compose.cliproxy.yml` 把 `cliproxy/` 下两份文件以只读方式挂入容器，其中入口脚本会读取 `CLIPROXY_*` 环境变量、把模板渲染为实际的 `config.yaml`，再启动 CLIProxyAPI 进程。这就要求宿主路径必须与叠加文件的相对路径一致，所以本步骤必须在 `${DEPLOY_DIR}` 目录下执行。
+
+## 第二步：在 `.env` 中追加 `CLIPROXY_*` 段
+
+`deploy-personal.yml` 生成的 `.env` 不含 `CLIPROXY_*` 字段，需要手工追加。可以把 `.env.example` 中 CLIProxyAPI Sidecar 段拷过来再填值，也可以直接 `cat >>`：
+
+```bash
+cat >> /opt/autorouter/.env <<'EOF'
+
+# ============================================================================
+# CLIProxyAPI Sidecar
+# ============================================================================
+CLI_PROXY_IMAGE=eceasy/cli-proxy-api:latest
+CLIPROXY_PORT=8317
+CLIPROXY_CLIENT_API_KEY=<生成或自定的客户端 API Key>
+CLIPROXY_MANAGEMENT_KEY=<生成或自定的管理密钥>
+CLIPROXY_ALLOW_REMOTE=true
+CLIPROXY_PROXY_URL=
+EOF
+```
+
+填写说明：
+
+| 字段                      | 必填         | 取值要求                                                                                                         |
+| ------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `CLI_PROXY_IMAGE`         | 否（建议改） | 默认 `eceasy/cli-proxy-api:latest`。生产部署建议固定到具体 tag 或 digest，避免 `latest` 漂移                     |
+| `CLIPROXY_PORT`           | 否           | 默认 `8317`。如目标服务器该端口被占用，可改为其他端口，并相应调整后续登记实例时填写的地址                        |
+| `CLIPROXY_CLIENT_API_KEY` | 是           | 客户端 API Key，所有经 CLIProxyAPI 转发的代理请求需携带；必须与 AutoRouter 管理端登记实例时的客户端 API Key 一致 |
+| `CLIPROXY_MANAGEMENT_KEY` | 是           | 管理 API 密钥，AutoRouter 调用 CLIProxyAPI 管理接口时使用；必须与 AutoRouter 管理端登记实例时的管理密钥一致      |
+| `CLIPROXY_ALLOW_REMOTE`   | 否           | 默认 `true`。受管 sidecar 下 AutoRouter 与 CLIProxyAPI 跨容器，跨容器访问需置为 `true`，不要改为 `false`         |
+| `CLIPROXY_PROXY_URL`      | 否           | OAuth 出站代理。受限网络下填写 `http://`、`https://` 或 `socks5://` 形式，留空表示不使用                         |
+
+两个密钥可以用与 `ADMIN_TOKEN` 相同的方法生成：
+
+```bash
+openssl rand -hex 32
+```
+
+::: warning 这两个密钥要在三处保持一致
+`.env` 中的 `CLIPROXY_CLIENT_API_KEY` 与 `CLIPROXY_MANAGEMENT_KEY` 既是 CLIProxyAPI 容器启动时的配置来源，也是 AutoRouter 管理端登记 CLIProxyAPI 实例时录入的明文来源。任何一侧修改都要同步另一侧，否则连通性检测会失败。
 :::
 
-## 计划覆盖的内容
+## 第三步：双 `-f` 启动 sidecar
 
-沉淀真实部署踩过的路径：`curl` 拉叠加文件与 cliproxy 目录、追加 `.env` 段、双 `-f up -d`。
+引入叠加文件启动整个栈，会在已运行的 `autorouter` 与 `db` 之外新增 `cliproxyapi` 服务：
 
-## 在正文就绪前的临时建议
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.cliproxy.yml \
+  up -d
+```
 
-在该文档正文上线之前，可以参考以下材料获取等价信息：
+`docker compose` 看到两个 `-f` 时会把它们按顺序合并：第二个文件追加 `cliproxyapi` 服务、追加 `cliproxy-auth` 与 `cliproxy-logs` 两个 named volume，原 `autorouter` 与 `db` 服务保持不变。两个 volume 在显式删除前持久化，跨容器重启保留 OAuth 凭据与日志。
 
-- 项目仓库根目录的 [README.md](https://github.com/g1331/AutoRouter/blob/master/README.md)
-- 现有长篇 [`docs/cliproxy-deployment.md`](/cliproxy-deployment)
-- 现有长篇 [`docs/circuit-breaker.md`](/circuit-breaker)
-- 项目 [Issue 列表](https://github.com/g1331/AutoRouter/issues) 与 [OpenSpec 提案](https://github.com/g1331/AutoRouter/tree/master/openspec)
+观察启动结果：
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.cliproxy.yml \
+  ps
+
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.cliproxy.yml \
+  logs -f cliproxyapi
+```
+
+`cliproxyapi` 的 healthcheck 是 `wget http://localhost:${CLIPROXY_PORT:-8317}/healthz`，启动期 20 秒，间隔 30 秒，失败 3 次判 unhealthy。`STATUS` 列稳定为 `healthy` 即说明容器已就绪。
+
+::: tip 后续都需要带上两个 `-f`
+启用 sidecar 后，针对该部署的任何 compose 命令都需要带上两个 `-f`，否则 `docker compose` 只会看到主文件中的两个服务，对 `cliproxyapi` 的任何操作都会被视为停止该服务并清理。例如重启 cliproxy：
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.cliproxy.yml \
+  restart cliproxyapi
+```
+
+:::
+
+## 第四步：在 AutoRouter 管理端登记实例
+
+回到 AutoRouter 管理后台「CLIProxyAPI」面板，新增一条实例记录，运行模式选择「受管 sidecar」，按如下填写：
+
+| 字段           | 取值                                                      |
+| -------------- | --------------------------------------------------------- |
+| 代理基础地址   | `http://cliproxyapi:8317`（同一 Docker 网络的服务名解析） |
+| 管理 API 地址  | 同样以服务名 `cliproxyapi` 访问                           |
+| 客户端 API Key | 与 `.env` 中 `CLIPROXY_CLIENT_API_KEY` 完全一致           |
+| 管理 API 密钥  | 与 `.env` 中 `CLIPROXY_MANAGEMENT_KEY` 完全一致           |
+
+代理基础地址处不要填写 `http://localhost:8317`：AutoRouter 与 CLIProxyAPI 是两个独立容器，AutoRouter 容器内的 `localhost` 指向自身，根本到达不了 CLIProxyAPI。Docker 网络内的容器互访依赖服务名解析。
+
+保存后点击「连通性检测」，预期得到「地址可达且密钥有效」。检测失败的主要原因：
+
+| 现象                        | 原因                                                                                               |
+| --------------------------- | -------------------------------------------------------------------------------------------------- |
+| 「地址不可达」              | 代理基础地址填写了 `localhost`；或代理基础地址端口与 `CLIPROXY_PORT` 不一致；或 sidecar 容器未运行 |
+| 「客户端 API Key 校验失败」 | 实例记录中的客户端 API Key 与 `.env` 中 `CLIPROXY_CLIENT_API_KEY` 不一致                           |
+| 「管理 API 鉴权失败」       | 实例记录中的管理密钥与 `.env` 中 `CLIPROXY_MANAGEMENT_KEY` 不一致                                  |
+
+连通性检测通过后，下一步是 OAuth 登录账号与创建池上游。具体流程参见 [CLIProxyAPI 首次使用指南](../usage/cliproxy-first-time) 与现有长篇 [`docs/cliproxy-deployment.md`](/cliproxy-deployment)。
+
+## 升级与回滚
+
+升级 sidecar 资料时，把第一步的 `RELEASE_TAG` 改为新的 release tag 重新 `curl` 覆盖三份文件，然后重新执行第三步即可。`.env` 中的 `CLIPROXY_*` 段在版本升级时一般不需要变更，按需更新即可。
+
+要回退到不含 sidecar 的部署形态，先停掉并清理 `cliproxyapi` 服务，然后只用主文件启动：
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.cliproxy.yml \
+  stop cliproxyapi
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.cliproxy.yml \
+  rm -f cliproxyapi
+
+docker compose -f docker-compose.yml up -d
+```
+
+`cliproxy-auth` 与 `cliproxy-logs` 两个 named volume 在显式 `docker volume rm` 之前保留，再次启用 sidecar 时已登录账号无需重新授权。如果需要彻底清理 OAuth 凭据：
+
+```bash
+docker volume rm cliproxy-auth cliproxy-logs
+```
+
+::: danger 清理 cliproxy-auth 会清空 OAuth 凭据
+`cliproxy-auth` 中存放 Codex / Claude / Gemini 的 OAuth token 明文。删除该卷后，所有账号都需要在 CLIProxyAPI 管理端重新登录，AutoRouter 管理端登记的实例记录仍在但池上游会因为无可用账号而失效。生产环境执行前务必确认。
+:::
+
+## 不在本页范围内
+
+- 受管 sidecar 与外部 CLIProxyAPI 两种形态的对比、字段填写差异：参见后续「CLIProxyAPI 外部 vs sidecar 选择」与现有长篇 [`docs/cliproxy-deployment.md`](/cliproxy-deployment)。
+- OAuth 登录与池上游创建的完整流程：参见 [CLIProxyAPI 首次使用指南](../usage/cliproxy-first-time)。
+- 出站代理的取值与验证方式：参见后续「CLIProxyAPI 出站代理配置」与现有长篇出站代理小节。
+- `CLIPROXY_*` 字段的完整参考与默认值：参见 [环境变量参考](./env-reference) 的 CLIProxyAPI 段。

--- a/docs/guide/deployment/env-reference.md
+++ b/docs/guide/deployment/env-reference.md
@@ -5,19 +5,160 @@ outline: deep
 
 # 环境变量参考
 
-::: warning 撰写中
-此文档目前为占位，正文尚未填充。完整撰写进度跟踪见 [issue #167](https://github.com/g1331/AutoRouter/issues/167)。
+本页把 `.env.example` 中的每一个字段按段落展开，标注用途、默认值、生成方式、修改后是否需要重启。所有「代码默认值」与 `docker-compose.yml` 中的 `${VAR:-default}` 默认值都按仓库现状记录；二者偶尔不一致时分别说明，避免读者在源码与部署之间被绕晕。
+
+下表中「修改后是否需要重启」一栏的含义：
+
+- **重启**：变量在进程启动时一次性读取，修改后必须重启对应容器才能生效。
+- **无需重启**：变量由后台轮询或下次请求时按需读取，修改后下一次取数即可生效（实际多为 docker compose 配置类，重启更稳妥）。
+- **运行时配置覆盖**：变量是默认值，但管理后台的「Runtime Settings」会覆盖它，运行期以后者为准。
+
+`.env.example` 中带 `# ` 行首注释的变量都是可选项，未在 `.env` 中显式设置时按表中默认值或代码默认值行为。
+
+## Docker 部署相关
+
+| 变量               | 必填 | 默认值                            | 重启 | 说明                                                                                                                                                                                            |
+| ------------------ | ---- | --------------------------------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AUTOROUTER_IMAGE` | 否   | `ghcr.io/g1331/autorouter:latest` | 重启 | `docker-compose.yml` 中 `autorouter` 服务的镜像引用。建议显式 pin 到具体 tag 或带 digest 的形式，避免 `latest` 漂移。`deploy-personal.yml` 会用 `workflow_dispatch` 输入的 `image_ref` 覆盖此值 |
+| `PORT`             | 否   | `3331`（docker-compose 默认）     | 重启 | 宿主机侧端口，映射到容器内 `3000`。`docker-compose.yml` 中是 `"${PORT:-3331}:3000"`；与代码中应用监听端口 `3000` 不要混淆                                                                       |
+
+## PostgreSQL 凭据（受 docker-compose 使用）
+
+| 变量                | 必填 | 默认值       | 重启 | 说明                                                                                                                                                           |
+| ------------------- | ---- | ------------ | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POSTGRES_USER`     | 否   | `autorouter` | 重启 | `db` 服务的 PostgreSQL 超级用户                                                                                                                                |
+| `POSTGRES_PASSWORD` | 是   | 无           | 重启 | PostgreSQL 密码。`docker-compose.yml` 不为该字段提供 fallback；缺失会导致 `db` 启动失败。`deploy-personal.yml` 首次部署时用 `openssl rand -base64 24` 自动生成 |
+| `POSTGRES_DB`       | 否   | `autorouter` | 重启 | 数据库名                                                                                                                                                       |
+
+`POSTGRES_*` 三项仅用于 `db` 容器内部 PostgreSQL 实例。应用侧连接靠下面的 `DATABASE_URL`，二者必须保持口径一致。
+
+## 数据库连接
+
+| 变量             | 必填             | 默认值                                                             | 重启 | 说明                                                                                                                                             |
+| ---------------- | ---------------- | ------------------------------------------------------------------ | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `DB_TYPE`        | 否               | 由代码自动推断：有 `DATABASE_URL` 时为 `postgres`，否则为 `sqlite` | 重启 | 取值 `postgres` 或 `sqlite`。生产环境若未显式设置 `DB_TYPE` 且 `DATABASE_URL` 缺失，应用会快速失败拒绝静默回退到 SQLite                          |
+| `DATABASE_URL`   | 生产 PG 模式下是 | 无                                                                 | 重启 | PostgreSQL 连接串。Docker 部署默认值 `postgresql://autorouter:<password>@db:5432/autorouter`，host 必须为 `db`（容器服务名），不能填 `localhost` |
+| `SQLITE_DB_PATH` | 否               | `./data/dev.sqlite`                                                | 重启 | 仅 `DB_TYPE=sqlite` 时生效。本地轻量场景用                                                                                                       |
+
+::: warning DATABASE_URL 中的密码必须与 POSTGRES_PASSWORD 一致
+`docker-compose.yml` 分别把这两个值传给应用容器与 `db` 容器，二者不会自动同步。任何一侧改动后必须同步修改另一侧并重启栈，否则应用容器会反复重启并报 `password authentication failed`。
 :::
 
-## 计划覆盖的内容
+## 加密与管理鉴权（必填）
 
-把 `.env.example` 的每个字段一一展开：用途、默认值、生成方式、修改后是否需要重启。
+| 变量                  | 必填 | 默认值 | 重启 | 说明                                                                                                                                                    |
+| --------------------- | ---- | ------ | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ENCRYPTION_KEY`      | 是   | 无     | 重启 | Fernet 加密密钥。代码强制其为 base64 编码、长度 44 字符（对应 32 字节）。用于加密上游 API Key、CLIProxyAPI 凭据等敏感字段写入数据库前后。生成方式见下文 |
+| `ENCRYPTION_KEY_FILE` | 否   | 无     | 重启 | 从文件读取密钥。优先级与 `ENCRYPTION_KEY` 的关系以代码实现为准；通常二选一即可                                                                          |
+| `ADMIN_TOKEN`         | 是   | 无     | 重启 | 管理 API token。`/api/admin/*` 与登录页都用 `Authorization: Bearer <token>` 比对。缺失时所有管理请求会被拒绝                                            |
 
-## 在正文就绪前的临时建议
+生成 `ENCRYPTION_KEY` 的两种等价方式：
 
-在该文档正文上线之前，可以参考以下材料获取等价信息：
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+# 或
+openssl rand -base64 32
+```
 
-- 项目仓库根目录的 [README.md](https://github.com/g1331/AutoRouter/blob/master/README.md)
-- 现有长篇 [`docs/cliproxy-deployment.md`](/cliproxy-deployment)
-- 现有长篇 [`docs/circuit-breaker.md`](/circuit-breaker)
-- 项目 [Issue 列表](https://github.com/g1331/AutoRouter/issues) 与 [OpenSpec 提案](https://github.com/g1331/AutoRouter/tree/master/openspec)
+生成 `ADMIN_TOKEN`：
+
+```bash
+openssl rand -hex 32
+```
+
+::: danger ENCRYPTION_KEY 丢失后果
+该密钥用于解密所有已加密上游凭据；丢失等同于丢失所有上游配置。强烈建议在密码管理器或安全密钥仓库中备份，并在多机部署间使用同一份密钥。轮换密钥需要先用旧密钥读出再用新密钥重新加密，仓库目前未提供自动迁移工具，需要手工脚本处理。
+:::
+
+## 日志与可观测
+
+| 变量                 | 必填 | 默认值                                   | 重启 | 说明                                                                                                   |
+| -------------------- | ---- | ---------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------ |
+| `LOG_LEVEL`          | 否   | 生产 `info`，开发 `debug`                | 重启 | Pino 日志级别。可取值 `fatal` / `error` / `warn` / `info` / `debug` / `trace`                          |
+| `LOG_RETENTION_DAYS` | 否   | `90`                                     | 重启 | 请求日志保留天数。后台清理任务以该值为界                                                               |
+| `DEBUG_LOG_HEADERS`  | 否   | `false`                                  | 重启 | 是否在日志中输出请求头。仅排障时短时开启；含敏感字段，长期开启有泄露风险                               |
+| `CORS_ORIGINS`       | 否   | `http://localhost:3000`（代码 fallback） | 重启 | 允许的跨域来源，逗号分隔；为空时退化到上述代码 fallback。`docker-compose.yml` 默认透传空值，由代码兜底 |
+
+`HEALTH_CHECK_INTERVAL` 与 `HEALTH_CHECK_TIMEOUT` 是代码默认值 `30` 秒与 `10` 秒，目前未在 `.env.example` 中暴露，确有需要可通过 `.env` 注入。
+
+## 功能开关
+
+| 变量               | 必填 | 默认值  | 重启 | 说明                                                                                        |
+| ------------------ | ---- | ------- | ---- | ------------------------------------------------------------------------------------------- |
+| `ALLOW_KEY_REVEAL` | 否   | `false` | 重启 | 是否允许通过 Admin API 揭示完整的客户端 API Key。生产环境务必保持关闭，仅在受控场景临时开启 |
+
+## 请求录制
+
+请求录制功能存在两套默认值：代码层是「保守默认」（默认禁用、默认脱敏、默认 `all` 模式），而仓库内的 `docker-compose.yml` 把这些字段重新覆盖成「部署默认」（默认启用、默认不脱敏、默认 `failure` 模式），更贴合「捕获生产侧失败请求样本」的运维场景。两套默认在排障时容易引起困惑，下表分别列出。
+
+| 变量                        | 必填 | 代码默认                                  | docker-compose 默认 | 重启           | 说明                                                                              |
+| --------------------------- | ---- | ----------------------------------------- | ------------------- | -------------- | --------------------------------------------------------------------------------- |
+| `RECORDER_ENABLED`          | 否   | 未设置即视为禁用；显式 `true` 或 `1` 启用 | `true`              | 重启           | 是否启用请求录制                                                                  |
+| `RECORDER_MODE`             | 否   | `all`                                     | `failure`           | 重启           | 录制范围。可取 `all` / `success` / `failure`                                      |
+| `RECORDER_FIXTURES_DIR`     | 否   | `tests/fixtures`                          | `tests/fixtures`    | 重启           | 录制文件目录                                                                      |
+| `RECORDER_REDACT_SENSITIVE` | 否   | `true`                                    | `false`             | 运行时配置覆盖 | 是否脱敏敏感字段。运行期实际行为由「Runtime Settings」覆盖，env var 只是 fallback |
+
+::: warning RECORDER_REDACT_SENSITIVE 在生产部署下默认 false
+`docker-compose.yml` 把该字段默认置为 `false`，这意味着开箱即用的录制内容会保留敏感字段。任何打算把录制文件用于回放、归档或共享给第三方的部署，都应当显式把该字段改为 `true`，或在管理后台 Runtime Settings 中开启脱敏。
+:::
+
+## CLIProxyAPI Sidecar（可选）
+
+下列变量仅在以受管 sidecar 形态运行 CLIProxyAPI 时需要，即同时引入 `docker-compose.cliproxy.yml`。使用外部独立 CLIProxyAPI 的部署无需设置。
+
+| 变量                      | 必填 | 默认值                        | 重启 | 说明                                                                                                                      |
+| ------------------------- | ---- | ----------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------- |
+| `CLI_PROXY_IMAGE`         | 否   | `eceasy/cli-proxy-api:latest` | 重启 | CLIProxyAPI 镜像引用。建议固定到具体 tag 或 digest                                                                        |
+| `CLIPROXY_PORT`           | 否   | `8317`                        | 重启 | CLIProxyAPI 监听端口，AutoRouter 通过该端口转发代理请求与调用管理 API                                                     |
+| `CLIPROXY_CLIENT_API_KEY` | 是   | 无                            | 重启 | 客户端 API Key。所有经 CLIProxyAPI 转发的代理请求都需携带；必须与 AutoRouter 管理端登记实例时填写的客户端 API Key 一致    |
+| `CLIPROXY_MANAGEMENT_KEY` | 是   | 无                            | 重启 | 管理 API 密钥。AutoRouter 调用 CLIProxyAPI 管理接口时使用；必须与 AutoRouter 管理端登记实例时填写的管理密钥一致           |
+| `CLIPROXY_ALLOW_REMOTE`   | 否   | `true`                        | 重启 | 是否允许非本机访问 CLIProxyAPI 管理 API。受管 sidecar 下 AutoRouter 与 CLIProxyAPI 跨容器，必须保持为 `true`              |
+| `CLIPROXY_PROXY_URL`      | 否   | 空（不使用代理）              | 重启 | CLIProxyAPI 的出站代理，供其访问 Codex / Claude / Gemini 的登录与模型 API。支持 `http://` / `https://` / `socks5://` 形式 |
+
+::: warning 两个密钥要在三处保持一致
+`CLIPROXY_CLIENT_API_KEY` 与 `CLIPROXY_MANAGEMENT_KEY` 同时是 CLIProxyAPI 配置来源与 AutoRouter 管理端「登记实例」时录入的明文来源。任何一侧改动都需要同步另一侧，否则连通性检测会失败。具体步骤参见 [CI 部署后追加 CLIProxyAPI sidecar](./cliproxy-sidecar)。
+:::
+
+## 两类地址的区分
+
+CLIProxyAPI 涉及两类地址，含义不同：
+
+| 地址类型             | 方向                                   | 配置位置                                                                                                           |
+| -------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| CLIProxyAPI 服务地址 | AutoRouter -> CLIProxyAPI              | AutoRouter 管理端「登记实例」时填写。受管 sidecar 下为 `http://cliproxyapi:8317`（容器服务名），不在 `.env` 中配置 |
+| OAuth 出站代理       | CLIProxyAPI -> Codex / Claude / Gemini | `.env` 中 `CLIPROXY_PROXY_URL`                                                                                     |
+
+二者不要混填。受管 sidecar 下「服务地址」必须用服务名 `cliproxyapi` 而不是 `localhost`，否则 AutoRouter 容器无法到达 CLIProxyAPI 容器。
+
+## 构建期变量（不在运行时 `.env` 中）
+
+下列变量是镜像构建期使用，不需要写到 `.env`，列出仅供参考：
+
+| 变量                      | 用途                                                                                                          |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_APP_VERSION` | 应用版本号。`release.yml` 通过 `docker build --build-arg` 注入，运行期通过 `/api/health` 返回值与 UI 顶部展示 |
+| `NEXT_TELEMETRY_DISABLED` | 关闭 Next.js 匿名遥测，`release.yml` 与开发指令中默认设为 `1`                                                 |
+| `NODE_ENV`                | 通常由 docker / Next.js 自动设置                                                                              |
+
+## 修改后如何安全生效
+
+变量分两类情况：
+
+- 在 `.env` 中改任何字段后，单独 `docker compose restart <service>` 不一定能让新值生效，因为 Compose 把 `.env` 内的值在 `up` 时注入到容器环境。最稳妥的做法：
+  ```bash
+  docker compose up -d
+  # 或带 sidecar 时
+  docker compose -f docker-compose.yml -f docker-compose.cliproxy.yml up -d
+  ```
+  这会让 Compose 检测到环境变化并重建相关容器，原 named volume 数据不受影响。
+- 若涉及 `ENCRYPTION_KEY` 变更，需要先在旧密钥下导出已加密字段、用新密钥重新加密后再写回。仓库未提供自动迁移工具，盲目轮换密钥会导致所有上游凭据无法解密。
+
+## 来源对照
+
+本页的事实依据：
+
+- `.env.example`：字段清单与注释来源
+- `docker-compose.yml`、`docker-compose.cliproxy.yml`：`${VAR:-default}` 形式的部署默认值
+- `src/lib/utils/config.ts`：代码层的默认值、必填校验与 fail-fast 逻辑
+- `src/lib/services/traffic-recording-service.ts`、`tests/unit/services/traffic-recorder.test.ts`：录制相关字段的代码默认值与运行时配置覆盖关系
+- `.github/workflows/deploy-personal.yml`：CI 自动生成 `.env` 时的填值规则

--- a/docs/guide/deployment/overview.md
+++ b/docs/guide/deployment/overview.md
@@ -5,19 +5,97 @@ outline: deep
 
 # 部署形态总览
 
-::: warning 撰写中
-此文档目前为占位，正文尚未填充。完整撰写进度跟踪见 [issue #167](https://github.com/g1331/AutoRouter/issues/167)。
-:::
+AutoRouter 的官方部署路径目前是两条，差别在于「镜像是否由 CI 构建、由谁把 docker compose 拉到服务器、由谁维护 `.env`」。CLIProxyAPI 受管 sidecar 是叠加在任一主路径之上的可选形态。本页说明这两条主路径与叠加形态的适用范围，便于在动手之前选定方向，避免后续把两条路径的命令混用。
 
-## 计划覆盖的内容
+## 两条主路径
 
-解释「源码 + docker compose」「CI + 远端 SSH」两条主路径的差别，以及何时引入 `docker-compose.cliproxy.yml` 叠加文件。
+| 路径                                          | 镜像来源                                                                  | docker compose 文件来源                                                  | `.env` 维护方                                                    | 适合场景                                                                                      |
+| --------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **A. 源码 + docker compose**                  | 本地从 `Dockerfile` 构建，或从 `ghcr.io/g1331/autorouter` 拉取已发布镜像  | 仓库内 `docker-compose.yml`                                              | 手工拷贝 `.env.example` 后编辑                                   | 个人服务器、临时验证、与项目同步开发                                                          |
+| **B. CI + 远端 SSH（`deploy-personal.yml`）** | 由 `release.yml` 在打 tag 时构建并推送到 `ghcr.io/g1331/autorouter:<tag>` | 部署作业通过 `curl` 从对应 tag 的 `raw.githubusercontent.com` 拉到服务器 | 部署作业首次运行时自动生成，缺失字段会用 `openssl rand` 随机填充 | 个人长期服务器、希望按 release tag 升级回滚、不愿意把 GitHub Actions 之外的部署脚本带上服务器 |
 
-## 在正文就绪前的临时建议
+两条路径产出的运行形态是等价的——都是 `autorouter` 与 `db` 两个容器、共享 `autorouter-net` bridge 网络、两个 named volume（`autorouter-data`、`postgres-data`）。区别只在「谁把这些文件放到服务器、谁负责更新它们」。
 
-在该文档正文上线之前，可以参考以下材料获取等价信息：
+### 路径 A：源码 + docker compose
 
-- 项目仓库根目录的 [README.md](https://github.com/g1331/AutoRouter/blob/master/README.md)
-- 现有长篇 [`docs/cliproxy-deployment.md`](/cliproxy-deployment)
-- 现有长篇 [`docs/circuit-breaker.md`](/circuit-breaker)
-- 项目 [Issue 列表](https://github.com/g1331/AutoRouter/issues) 与 [OpenSpec 提案](https://github.com/g1331/AutoRouter/tree/master/openspec)
+适合直接对接本地开发节奏的部署。最短命令链是：
+
+```bash
+git clone https://github.com/g1331/AutoRouter.git
+cd AutoRouter
+cp .env.example .env       # 然后按需修改 .env 中的密钥
+docker compose up -d
+```
+
+镜像默认值在 `docker-compose.yml` 中：
+
+```yaml
+image: ${AUTOROUTER_IMAGE:-ghcr.io/g1331/autorouter:latest}
+```
+
+`AUTOROUTER_IMAGE` 未设置时使用 `latest` tag。若希望与某个具体 release 对齐，请在 `.env` 中显式 pin 到 `ghcr.io/g1331/autorouter:v<version>` 或带 digest 的 `ghcr.io/g1331/autorouter@sha256:<digest>`，避免 `latest` 漂移。
+
+完整步骤见 [快速开始（源码 docker compose）](./quickstart)，每个环境变量字段的语义见 [环境变量参考](./env-reference)。
+
+### 路径 B：CI + 远端 SSH（`deploy-personal.yml`）
+
+适合个人长期服务器的「按 release 升级 / 按 tag 回滚」节奏。部署的触发方式不是 push，而是手工在 GitHub Actions 页面对 `deploy-personal.yml` 触发 `workflow_dispatch`，输入三个参数：
+
+| 输入                 | 含义                       | 形式                                                                                                     |
+| -------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `image_ref`          | 要部署的镜像引用           | `v0.1.0`（自动补全 `ghcr.io/g1331/autorouter:` 前缀），或 `ghcr.io/...` 完整引用，或 `sha256:...` digest |
+| `environment_name`   | GitHub Environment 名称    | 默认 `personal-production`，作业会绑定到该 environment 的 secrets 与审批策略                             |
+| `confirm_release_id` | 用于二次确认的 release tag | 例如 `v0.1.0`；作业会校验该 tag 存在并在 `origin/master` 路径上                                          |
+
+工作流通过 `appleboy/ssh-action` 登录目标服务器、`mkdir -p ${DEPLOY_DIR}`（默认 `/opt/autorouter`，可由 secret `DEPLOY_DIR` 覆盖）、`curl` 拉对应 tag 的 `docker-compose.yml`、首次部署时自动生成 `.env`（`POSTGRES_PASSWORD` / `ENCRYPTION_KEY` 由 `openssl rand` 随机填充，`ADMIN_TOKEN` 来自 GitHub secret），最后执行 `docker pull` 与 `docker compose up -d --remove-orphans`。完成后还会通过 `/api/health` 与一次完整代理 smoke test 校验部署可用性。
+
+需要在 GitHub 上配置的 secrets：
+
+| Secret            | 必填 | 默认值            | 用途                                                       |
+| ----------------- | ---- | ----------------- | ---------------------------------------------------------- |
+| `SERVER_HOST`     | 是   | 无                | 目标服务器主机名或 IP                                      |
+| `SERVER_USER`     | 是   | 无                | SSH 登录用户                                               |
+| `SSH_PRIVATE_KEY` | 是   | 无                | SSH 私钥                                                   |
+| `SERVER_PORT`     | 否   | `22`              | SSH 端口                                                   |
+| `DEPLOY_DIR`      | 否   | `/opt/autorouter` | 部署目录                                                   |
+| `ADMIN_TOKEN`     | 是   | 无                | 管理 API token，作业会在 `.env` 中强制写入；缺失会终止部署 |
+
+发布镜像本身由独立的 `release.yml` 完成：向 `master` 推送 `v*` 形式的 tag 即触发构建并推送到 `ghcr.io`。tag 命名遵守 `vMAJOR.MINOR.PATCH` 或 `vMAJOR.MINOR.PATCH-(alpha|beta).N`，且必须指向 `origin/master` 上的提交。release notes 由 `git-cliff` 按 `cliff.toml` 规则自动生成。
+
+完整配置步骤参见 [GitHub Actions CI 部署](./github-actions)。
+
+## 何时叠加 CLIProxyAPI sidecar
+
+CLIProxyAPI 是 AutoRouter 用来承接 Codex、Claude、Gemini 等 OAuth 上游账号的代理服务。它有两种与 AutoRouter 协作的形态，仓库为受管 sidecar 形态提供了可选叠加文件 `docker-compose.cliproxy.yml`：
+
+| CLIProxyAPI 形态                                           | 是否需要本仓库的叠加文件 | 配置位置                                                                                                                  |
+| ---------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| **外部 CLIProxyAPI**（已独立部署或与 AutoRouter 分开运维） | 不需要                   | 在 AutoRouter 管理端「登记实例」时填写外部地址即可                                                                        |
+| **受管 sidecar**（与 AutoRouter 一起编排、统一启停）       | 需要                     | 启动时同时引入 `docker-compose.cliproxy.yml`：`docker compose -f docker-compose.yml -f docker-compose.cliproxy.yml up -d` |
+
+叠加文件中 `cliproxyapi` 服务挂入仓库内的 `cliproxy/config.yaml.template` 与 `cliproxy/docker-entrypoint.sh`，入口脚本在容器启动时读取 `CLIPROXY_*` 环境变量并把模板渲染为实际配置。OAuth 凭据由 named volume `cliproxy-auth` 持久化，跨容器重建保留登录状态。该服务默认仅在 `autorouter-net` 内可达，AutoRouter 通过服务名 `cliproxyapi` 访问；除非确有需要，不要解开端口映射对外暴露。
+
+需要特别强调的是「容器服务名」与「`localhost`」的差别：在受管 sidecar 形态下，AutoRouter 与 CLIProxyAPI 是两个独立容器，AutoRouter 的「`localhost`」指向自身容器，不会到达 CLIProxyAPI。登记实例时的代理地址必须填写 `http://cliproxyapi:8317`，使用同一 Docker 网络中的服务名解析。
+
+## 路径与叠加形态的组合
+
+两条主路径与 CLIProxyAPI 叠加可以任意组合，常见组合如下：
+
+| 主路径                   | 是否带 sidecar | 启动命令                                                                    | 适用                                                                                                                                              |
+| ------------------------ | -------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A. 源码 + docker compose | 否             | `docker compose up -d`                                                      | 只需要常规上游（OpenAI / Anthropic 等普通 API Key）                                                                                               |
+| A. 源码 + docker compose | 是             | `docker compose -f docker-compose.yml -f docker-compose.cliproxy.yml up -d` | 本地或个人服务器同时治理 Codex / Claude / Gemini OAuth 账号                                                                                       |
+| B. CI + 远端 SSH         | 否             | `deploy-personal.yml` 触发即完成                                            | 远端服务器按 release tag 升级，且不需要 OAuth 类上游                                                                                              |
+| B. CI + 远端 SSH         | 是             | `deploy-personal.yml` 完成后手工补 sidecar                                  | 远端服务器需要 OAuth 类上游，但 `deploy-personal.yml` 不会自动配置 sidecar，须按 [CI 部署后追加 CLIProxyAPI sidecar](./cliproxy-sidecar) 手工补齐 |
+
+`deploy-personal.yml` 当前只拉主 `docker-compose.yml`，不会拉 `docker-compose.cliproxy.yml` 与 `cliproxy/` 目录，也不会维护 `.env` 中的 `CLIPROXY_*` 段。因此「CI 部署 + sidecar」是一条两步路径：先用 CI 完成 AutoRouter 主部署，再手工把 sidecar 资料补到服务器。
+
+## 不在本页范围内
+
+下列内容由其他专门页面承载，避免本页膨胀成「全量部署手册」：
+
+- 源码 + docker compose 的最小完整步骤：[快速开始（源码 docker compose）](./quickstart)
+- CI 部署完成后手工补 sidecar 的具体命令：[CI 部署后追加 CLIProxyAPI sidecar](./cliproxy-sidecar)
+- 每个环境变量的字段说明：[环境变量参考](./env-reference)
+- CLIProxyAPI 的两种形态对比与详细字段填写：参见现有长篇 [`docs/cliproxy-deployment.md`](/cliproxy-deployment) 与未来的「CLIProxyAPI 外部 vs sidecar 选择」「CLIProxyAPI 首次使用指南」
+- HTTPS 与反向代理：参见后续「HTTPS 与反向代理」一节

--- a/docs/guide/deployment/quickstart.md
+++ b/docs/guide/deployment/quickstart.md
@@ -5,19 +5,154 @@ outline: deep
 
 # 快速开始（源码 docker compose）
 
-::: warning 撰写中
-此文档目前为占位，正文尚未填充。完整撰写进度跟踪见 [issue #167](https://github.com/g1331/AutoRouter/issues/167)。
+本页给出从克隆仓库到首次成功登录管理后台的最短路径。完成后会得到两个容器：`autorouter`（Next.js 应用）与 `db`（PostgreSQL 16），共享 `autorouter-net` bridge 网络，数据持久化到 named volume。CLIProxyAPI 是否需要叠加，根据是否要承接 Codex / Claude / Gemini 等 OAuth 上游账号决定，本页不涉及，需要时另见 [CI 部署后追加 CLIProxyAPI sidecar](./cliproxy-sidecar) 与现有长篇 [`docs/cliproxy-deployment.md`](/cliproxy-deployment)。
+
+## 前置依赖
+
+| 工具                               | 用途                       | 推荐版本                                  |
+| ---------------------------------- | -------------------------- | ----------------------------------------- |
+| Docker Engine 与 Docker Compose v2 | 启动两个容器、共享网络与卷 | Docker 24+；`docker compose` 子命令需可用 |
+| `git`                              | 克隆仓库                   | 任意现代版本                              |
+| `openssl` 或 Node.js               | 生成加密密钥与管理 token   | 二者任一即可                              |
+
+无需在宿主机预装 Node.js / pnpm；构建与运行都发生在容器内。
+
+## 第一步：克隆仓库
+
+```bash
+git clone https://github.com/g1331/AutoRouter.git
+cd AutoRouter
+```
+
+仓库根目录的 `docker-compose.yml` 与 `.env.example` 是本次部署的全部主要资料。
+
+## 第二步：生成两个必填密钥
+
+`.env.example` 中标注 `REQUIRED` 的字段共两个：`ENCRYPTION_KEY` 与 `ADMIN_TOKEN`。前者用于上游密钥的 Fernet 加密，后者用于 `/api/admin/*` 接口鉴权。任意泄露都会造成严重影响，必须在首次启动前生成强随机值。
+
+`ENCRYPTION_KEY` 必须是 base64 编码的 32 字节：
+
+```bash
+# 使用 Node.js
+node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+
+# 或使用 openssl
+openssl rand -base64 32
+```
+
+`ADMIN_TOKEN` 没有长度规定，但建议生成不少于 32 字节的高熵字符串：
+
+```bash
+openssl rand -hex 32
+```
+
+::: warning 务必备份 ENCRYPTION_KEY
+丢失 `ENCRYPTION_KEY` 等同于丢失数据库中所有已加密的上游 API Key——上游记录还在，但解密会全部失败，需要逐条重新填写。建议在密码管理器或安全的密钥仓库中保存一份。
 :::
 
-## 计划覆盖的内容
+## 第三步：编写 `.env`
 
-5 分钟版：克隆仓库、配置 `.env`、`docker compose up -d`、登录管理后台。
+把 `.env.example` 拷为 `.env`：
 
-## 在正文就绪前的临时建议
+```bash
+cp .env.example .env
+```
 
-在该文档正文上线之前，可以参考以下材料获取等价信息：
+最小可启动配置需要修改下列几行。其余字段保留默认值即可，每个字段的语义见 [环境变量参考](./env-reference)。
 
-- 项目仓库根目录的 [README.md](https://github.com/g1331/AutoRouter/blob/master/README.md)
-- 现有长篇 [`docs/cliproxy-deployment.md`](/cliproxy-deployment)
-- 现有长篇 [`docs/circuit-breaker.md`](/circuit-breaker)
-- 项目 [Issue 列表](https://github.com/g1331/AutoRouter/issues) 与 [OpenSpec 提案](https://github.com/g1331/AutoRouter/tree/master/openspec)
+```env
+# 自行选定强随机密码
+POSTGRES_PASSWORD=<strong-postgres-password>
+
+# 数据库连接串中的密码必须与 POSTGRES_PASSWORD 严格一致
+DATABASE_URL=postgresql://autorouter:<strong-postgres-password>@db:5432/autorouter
+
+# 第二步生成的 base64 32 字节密钥
+ENCRYPTION_KEY=<your-base64-32-byte-key>
+
+# 第二步生成的高熵 token
+ADMIN_TOKEN=<your-strong-admin-token>
+```
+
+`DATABASE_URL` 的 host 必须是 `db`——这是 `docker-compose.yml` 中 PostgreSQL 容器的服务名。在 Docker 网络内填 `localhost` 会指向 AutoRouter 容器自身而非数据库。
+
+`AUTOROUTER_IMAGE` 默认值 `ghcr.io/g1331/autorouter:latest` 指向最新发布。生产部署建议显式 pin 到具体 tag 或 digest，例如：
+
+```env
+AUTOROUTER_IMAGE=ghcr.io/g1331/autorouter:v0.1.0
+# 或
+AUTOROUTER_IMAGE=ghcr.io/g1331/autorouter@sha256:<digest>
+```
+
+## 第四步：启动
+
+```bash
+docker compose up -d
+```
+
+首次启动会拉取 `ghcr.io/g1331/autorouter` 与 `postgres:16-alpine` 两个镜像。`db` 服务的 healthcheck 通过后，`autorouter` 服务才会启动；这是 `docker-compose.yml` 中 `depends_on.condition: service_healthy` 的约束。
+
+`autorouter` 自身的 healthcheck 是定时请求 `http://localhost:3000/api/health`，间隔 30 秒，失败 3 次判定为 unhealthy，启动期 40 秒。`db` 的 healthcheck 是 `pg_isready`，间隔 10 秒。
+
+观察启动状态：
+
+```bash
+docker compose ps
+docker compose logs -f autorouter
+```
+
+## 第五步：验证端到端可达
+
+宿主机端口默认为 `${PORT:-3331}`，对应容器内的 `3000` 端口。健康端点的响应包含版本号：
+
+```bash
+curl http://localhost:3331/api/health
+```
+
+预期得到形如下方的 JSON：
+
+```json
+{
+  "status": "healthy",
+  "timestamp": "2026-05-23T09:00:00.000Z",
+  "version": "0.1.0"
+}
+```
+
+管理 API 的鉴权使用 `ADMIN_TOKEN`：
+
+```bash
+curl -H "Authorization: Bearer <ADMIN_TOKEN>" \
+  http://localhost:3331/api/admin/health?active_only=true
+```
+
+返回 `200` 即说明应用、数据库与管理端鉴权均工作正常。
+
+## 第六步：登录管理后台
+
+打开浏览器访问：
+
+```
+http://<server-host>:3331/
+```
+
+页面会重定向到 `/login`，使用 `ADMIN_TOKEN` 登录。登录成功后进入仪表盘。
+
+后续推荐的接入顺序：
+
+1. 添加第一个上游：参考 [添加第一个上游](../usage/first-upstream)。
+2. 创建第一把客户端 API Key：参考 [创建客户端 API Key](../usage/client-keys)。
+3. 用 OpenAI 兼容客户端发一笔请求：参考 [通过 AutoRouter 调用模型](../usage/invoke-models)。
+4. 需要 Codex / Claude / Gemini OAuth 上游时，按 [CLIProxyAPI 首次使用指南](../usage/cliproxy-first-time) 接入 sidecar。
+
+## 常见首启动问题
+
+下面只列出最常见的几类启动期错误。完整排障路径参见后续「常见部署问题排查」与 [故障排查手册](../usage/troubleshooting)。
+
+`autorouter` 容器反复重启、日志含 `ENCRYPTION_KEY is required` 或 `ADMIN_TOKEN is required`：第三步的两个密钥未在 `.env` 中正确设置，或 `.env` 文件不在 `docker-compose.yml` 同目录下。
+
+`db` 容器 healthcheck 长时间不通过、日志含 `FATAL: password authentication failed`：`.env` 中 `POSTGRES_PASSWORD` 与 `DATABASE_URL` 内的密码不一致。`docker-compose.yml` 把两者分开读取，二者必须严格相同。
+
+宿主机访问 `http://<host>:3331/` 拒绝连接：宿主机防火墙未放行 `PORT`（默认 `3331`），或 `PORT` 被其他服务占用。可在 `.env` 中改为其他端口，例如 `PORT=8331`，再 `docker compose up -d` 即可生效。
+
+容器内 AutoRouter 报「上游地址不可达」并且地址形如 `http://localhost:xxxx`：填写了 `localhost`，但实际上目标服务在另一个容器中。Docker 网络内应使用「容器服务名」而非 `localhost`，例如 `http://cliproxyapi:8317`。


### PR DESCRIPTION
## Summary

Phase 2 起跑：撰写 issue #167 第一批 10 篇中的部署侧 4 篇正文，严格以仓库源码为依据。

| 文档 | 路径 | 主要内容 |
| --- | --- | --- |
| 部署形态总览 | `docs/guide/deployment/overview.md` | 源码 + docker compose vs CI + 远端 SSH 两条主路径，何时引入 `docker-compose.cliproxy.yml`，「容器服务名 vs `localhost`」陷阱 |
| 快速开始 | `docs/guide/deployment/quickstart.md` | 从克隆到登录管理后台的端到端命令链，含 `ENCRYPTION_KEY` / `ADMIN_TOKEN` 生成、`POSTGRES_PASSWORD` 与 `DATABASE_URL` 一致性、healthcheck 行为 |
| CI 部署后追加 CLIProxyAPI sidecar | `docs/guide/deployment/cliproxy-sidecar.md` | `deploy-personal.yml` 完成后在服务器上手工补 sidecar 资料的完整步骤：`curl` 拉叠加文件、追加 `.env`、双 `-f up -d`、登记实例、升级与回滚 |
| 环境变量参考 | `docs/guide/deployment/env-reference.md` | `.env.example` 每个字段一一展开：代码默认 vs docker-compose 默认、必填情况、修改后重启行为、运行时配置覆盖关系；含录制功能两套默认差异的明确标注 |

## 事实依据

逐条以仓库当前源码为根：

- `docker-compose.yml` / `docker-compose.cliproxy.yml`：服务定义、网络、卷、healthcheck、`${VAR:-default}` 默认值
- `.env.example`：字段清单与代码注释
- `.github/workflows/deploy-personal.yml`：`workflow_dispatch` 输入、secrets 列表、自动生成 `.env` 的规则、smoke test 行为
- `.github/workflows/release.yml`：tag 规则、镜像构建与推送、`git-cliff` release notes
- `cliproxy/config.yaml.template` / `cliproxy/docker-entrypoint.sh`：模板字段、入口脚本必填校验
- `src/lib/utils/config.ts`：代码默认值、必填校验、生产 fail-fast 行为
- `src/lib/services/traffic-recording-service.ts` 与对应测试：录制相关字段的代码默认与运行时覆盖关系
- `src/app/api/health/route.ts`：健康端点响应 schema

无法在源码中验证的具体值（例如 `v0.1.0` 这种示例 release tag）均以「\`<RELEASE_TAG>\` 替换为实际部署的 release tag」形式标注，避免给出假数据。

## 不在本 PR 范围

- 使用侧 4 篇与架构侧 2 篇（Phase 2 后续两个 PR）
- README 减负
- UI helper text
- 4 篇之外的其他占位文档

## Test plan

- [x] `pnpm format:check` 全绿（prettier 自动对齐了 markdown 表格列宽）
- [x] `pnpm docs:build` 3.15 s 构建成功
- [x] 占位文档现有 cross-link 与新正文 cross-link 均使用相对路径，构建未报 dead link
- [ ] CI 的 `Docs` workflow build job 通过
- [ ] 合并后 Pages 站点四篇文档可访问，sidebar 入口正常