### PR TITLE
docs(deployment): fix two review findings on PR #177 (#167)

### DIFF
--- a/docs/guide/deployment/cliproxy-sidecar.md
+++ b/docs/guide/deployment/cliproxy-sidecar.md
@@ -171,14 +171,22 @@ docker compose \
 docker compose -f docker-compose.yml up -d
 ```
 
-`cliproxy-auth` 与 `cliproxy-logs` 两个 named volume 在显式 `docker volume rm` 之前保留，再次启用 sidecar 时已登录账号无需重新授权。如果需要彻底清理 OAuth 凭据：
+`cliproxy-auth` 与 `cliproxy-logs` 两个 named volume 在显式 `docker volume rm` 之前保留，再次启用 sidecar 时已登录账号无需重新授权。如果需要彻底清理 OAuth 凭据，先找出实际卷名再删除——`docker-compose.cliproxy.yml` 中的 volumes 段没有声明 `name:`，Compose 会自动给卷加上「项目名」前缀，所以宿主机上看到的卷名不是 `cliproxy-auth`，而是 `<项目名>_cliproxy-auth`。项目名默认取自部署目录的小写化形式：`/opt/autorouter` 部署目录对应项目名 `autorouter`，因此实际卷名通常是 `autorouter_cliproxy-auth` 与 `autorouter_cliproxy-logs`。
+
+稳妥的做法是先列出再删：
 
 ```bash
-docker volume rm cliproxy-auth cliproxy-logs
+# 列出本机所有 cliproxy 相关的卷，确认实际名称与项目名前缀
+docker volume ls --filter name=cliproxy
+
+# 用上一条列出的实际卷名删除；以 /opt/autorouter 部署目录为例：
+docker volume rm autorouter_cliproxy-auth autorouter_cliproxy-logs
 ```
 
+如果部署目录不是 `/opt/autorouter`、或显式通过 `-p` / `COMPOSE_PROJECT_NAME` 指定了别的项目名，请把上述命令中的 `autorouter` 替换为实际项目名前缀。直接执行 `docker volume rm cliproxy-auth cliproxy-logs`（无前缀）通常会报 `Error: No such volume`，因为该名称的卷并不存在。
+
 ::: danger 清理 cliproxy-auth 会清空 OAuth 凭据
-`cliproxy-auth` 中存放 Codex / Claude / Gemini 的 OAuth token 明文。删除该卷后，所有账号都需要在 CLIProxyAPI 管理端重新登录，AutoRouter 管理端登记的实例记录仍在但池上游会因为无可用账号而失效。生产环境执行前务必确认。
+`cliproxy-auth`（实际名 `<项目名>_cliproxy-auth`）中存放 Codex / Claude / Gemini 的 OAuth token 明文。删除该卷后，所有账号都需要在 CLIProxyAPI 管理端重新登录，AutoRouter 管理端登记的实例记录仍在但池上游会因为无可用账号而失效。生产环境执行前务必确认。
 :::
 
 ## 不在本页范围内

--- a/docs/guide/deployment/env-reference.md
+++ b/docs/guide/deployment/env-reference.md
@@ -89,18 +89,26 @@ openssl rand -hex 32
 
 ## 请求录制
 
-请求录制功能存在两套默认值：代码层是「保守默认」（默认禁用、默认脱敏、默认 `all` 模式），而仓库内的 `docker-compose.yml` 把这些字段重新覆盖成「部署默认」（默认启用、默认不脱敏、默认 `failure` 模式），更贴合「捕获生产侧失败请求样本」的运维场景。两套默认在排障时容易引起困惑，下表分别列出。
+请求录制的运行期开关已经全部搬到「数据库中的 Runtime Settings 单例」（表 `traffic_recording_settings`），由 `src/lib/services/traffic-recording-service.ts:167` 的 `getTrafficRecordingSettings()` 读取，首次读取时按以下默认值初始化：
 
-| 变量                        | 必填 | 代码默认                                  | docker-compose 默认 | 重启           | 说明                                                                              |
-| --------------------------- | ---- | ----------------------------------------- | ------------------- | -------------- | --------------------------------------------------------------------------------- |
-| `RECORDER_ENABLED`          | 否   | 未设置即视为禁用；显式 `true` 或 `1` 启用 | `true`              | 重启           | 是否启用请求录制                                                                  |
-| `RECORDER_MODE`             | 否   | `all`                                     | `failure`           | 重启           | 录制范围。可取 `all` / `success` / `failure`                                      |
-| `RECORDER_FIXTURES_DIR`     | 否   | `tests/fixtures`                          | `tests/fixtures`    | 重启           | 录制文件目录                                                                      |
-| `RECORDER_REDACT_SENSITIVE` | 否   | `true`                                    | `false`             | 运行时配置覆盖 | 是否脱敏敏感字段。运行期实际行为由「Runtime Settings」覆盖，env var 只是 fallback |
+| Runtime Settings 字段 | 默认值      | 说明                                    |
+| --------------------- | ----------- | --------------------------------------- |
+| `enabled`             | `false`     | 是否开启录制                            |
+| `mode`                | `"failure"` | 录制范围：`all` / `success` / `failure` |
+| `redact_sensitive`    | `true`      | 是否脱敏敏感字段                        |
+| `retention_days`      | `7`         | 录制文件保留天数                        |
 
-::: warning RECORDER_REDACT_SENSITIVE 在生产部署下默认 false
-`docker-compose.yml` 把该字段默认置为 `false`，这意味着开箱即用的录制内容会保留敏感字段。任何打算把录制文件用于回放、归档或共享给第三方的部署，都应当显式把该字段改为 `true`，或在管理后台 Runtime Settings 中开启脱敏。
+修改方式：管理后台「系统 → 请求录制」页面（`/system/traffic-recording`）。修改后立即生效，不需要重启。
+
+::: warning 三个 RECORDER\_\* 环境变量当前不再作为运行时开关
+`.env.example` 与 `docker-compose.yml` 仍包含 `RECORDER_ENABLED`、`RECORDER_MODE`、`RECORDER_REDACT_SENSITIVE` 三个键，但它们**已经不再控制运行期行为**——代码层的 `shouldRecordFixture()` 只从 Runtime Settings 拿值，不再回退到 env var。即便 `.env` 中显式设置任意值，是否开启录制、录制模式、是否脱敏都以管理后台 Runtime Settings 的当前值为准。这三个键是历史遗留，未来可能被清理；不要据其调整部署预期。
 :::
+
+唯一仍生效的录制相关 env var 是文件目录：
+
+| 变量                    | 必填 | 默认值           | 重启 | 说明                                                                                                                |
+| ----------------------- | ---- | ---------------- | ---- | ------------------------------------------------------------------------------------------------------------------- |
+| `RECORDER_FIXTURES_DIR` | 否   | `tests/fixtures` | 重启 | 录制文件落盘目录。由 `resolveRecordingRoot()` / `getTrafficRecordingRoot()` 直接读取 env var，未走 Runtime Settings |
 
 ## CLIProxyAPI Sidecar（可选）
 
@@ -160,5 +168,5 @@ CLIProxyAPI 涉及两类地址，含义不同：
 - `.env.example`：字段清单与注释来源
 - `docker-compose.yml`、`docker-compose.cliproxy.yml`：`${VAR:-default}` 形式的部署默认值
 - `src/lib/utils/config.ts`：代码层的默认值、必填校验与 fail-fast 逻辑
-- `src/lib/services/traffic-recording-service.ts`、`tests/unit/services/traffic-recorder.test.ts`：录制相关字段的代码默认值与运行时配置覆盖关系
+- `src/lib/services/traffic-recording-service.ts`、`tests/unit/services/traffic-recorder.test.ts`：录制功能已迁移到数据库 Runtime Settings 单例，仅 `RECORDER_FIXTURES_DIR` 仍通过 env var 生效
 - `.github/workflows/deploy-personal.yml`：CI 自动生成 `.env` 时的填值规则


### PR DESCRIPTION
## Summary

PR #177（部署批次）合入 master 后两处审查级偏差的修复。所有修改前都对照源码核实。

| 修订项 | 错误前提（已撤） | 当前写法 | 验证出处 |
| --- | --- | --- | --- |
| `RECORDER_*` 环境变量 | env-reference.md 写「代码默认 vs docker-compose 默认」两套并列，并以 warning 强调 `RECORDER_REDACT_SENSITIVE` 在部署侧默认 `false` | 三个 env var（`RECORDER_ENABLED` / `RECORDER_MODE` / `RECORDER_REDACT_SENSITIVE`）当前已不再控制运行期行为；行为由数据库 `traffic_recording_settings` 单例决定，默认 `enabled: false` / `mode: failure` / `redact_sensitive: true` / `retention_days: 7`；改 `/system/traffic-recording` 即时生效。env-var 表只保留仍生效的 `RECORDER_FIXTURES_DIR` | `src/lib/services/traffic-recording-service.ts:167`（`getTrafficRecordingSettings`）与同文件第 148 行（`resolveRecordingRoot` 仍读 env var）|
| Sidecar 卷清理命令 | cliproxy-sidecar.md 写 `docker volume rm cliproxy-auth cliproxy-logs`，在默认部署下会报 `No such volume` 并让 OAuth 凭据继续留在磁盘 | 改为先 `docker volume ls --filter name=cliproxy` 查实际卷名（受 Compose 项目名前缀影响），再 `docker volume rm autorouter_cliproxy-auth autorouter_cliproxy-logs`；加段说明项目名前缀机制与 `DEPLOY_DIR` / `COMPOSE_PROJECT_NAME` 调整方式 | `docker-compose.cliproxy.yml` 与 `docker-compose.yml` 的 `volumes:` 段均未声明 `name:`，仅网络 `autorouter-net` 有显式覆盖 |

## Test plan

- [x] `pnpm format:check` 全绿
- [x] `pnpm docs:build` 3.19s 构建成功
- [ ] CI 的 `Docs` workflow build job 通过
- [ ] 全套 Verify 通过（pull_request 触发会跑全套）
- [x] **已得到用户在 [PR #178 评论后的会话中](https://github.com/g1331/AutoRouter/pull/178) 的合并授权：「ci 通过后就完成两个 pr 的合并」**；CI 通过后即按授权合并