### PR TITLE
fix(proxy): 区分上游空内容流与首字超时

### DIFF
--- a/docs/guide/architecture/failover-circuit.md
+++ b/docs/guide/architecture/failover-circuit.md
@@ -105,11 +105,13 @@ export const DEFAULT_FAILOVER_CONFIG: FailoverConfig = {
 
 代理层把两类错误判定为可故障转移：
 
-**异常类（`isFailoverableError`，`route.ts:842-863`）**：
+**异常类（`isFailoverableError`，`route.ts:844-869`）**：
 
 - `CircuitBreakerOpenError`
-- `FirstByteTimeoutError` / `StreamIdleTimeoutError`
+- `FirstByteTimeoutError` / `StreamIdleTimeoutError` / `UpstreamNoContentStreamError`
 - 错误消息包含 `timed out` / `timeout` / `econnrefused` / `econnreset` / `socket hang up` / `network` / `fetch failed` / `circuit breaker`
+
+`UpstreamNoContentStreamError` 表示上游 SSE 流正常关闭、但没有产生任何 content-bearing chunk（典型表现是只发送 `response.created` 等 metadata 事件就 `[DONE]`）。它与 `FirstByteTimeoutError` 的关键区别在于：首字超时计时器从未触发，上游是「主动提前结束流」，因此错误文案会同时携带实际耗时与配置阈值，避免把配置值误读成实际等待时长。
 
 **HTTP 响应类（`shouldTriggerFailover`，`failover-config.ts:57-73`）**：
 

--- a/src/app/api/proxy/v1/[...path]/route.ts
+++ b/src/app/api/proxy/v1/[...path]/route.ts
@@ -17,6 +17,7 @@ import {
   applyCompensationHeaders,
   FirstByteTimeoutError,
   StreamIdleTimeoutError,
+  UpstreamNoContentStreamError,
   type ProxyResult,
   type HeaderDiff,
 } from "@/lib/services/proxy-client";
@@ -823,6 +824,7 @@ function getErrorType(
 ): FailoverAttempt["error_type"] {
   if (error instanceof CircuitBreakerOpenError) return "circuit_open";
   if (error instanceof FirstByteTimeoutError) return "first_byte_timeout";
+  if (error instanceof UpstreamNoContentStreamError) return "upstream_no_content_stream";
   if (error instanceof StreamIdleTimeoutError) return "stream_idle_timeout";
   if (statusCode === 429) return "http_429";
   if (statusCode && statusCode >= 400 && statusCode < 500) return "http_4xx";
@@ -843,7 +845,11 @@ function isFailoverableError(error: unknown): boolean {
   if (error instanceof CircuitBreakerOpenError) {
     return true;
   }
-  if (error instanceof FirstByteTimeoutError || error instanceof StreamIdleTimeoutError) {
+  if (
+    error instanceof FirstByteTimeoutError ||
+    error instanceof StreamIdleTimeoutError ||
+    error instanceof UpstreamNoContentStreamError
+  ) {
     return true;
   }
   if (error instanceof Error) {

--- a/src/components/admin/routing-decision-timeline.tsx
+++ b/src/components/admin/routing-decision-timeline.tsx
@@ -591,6 +591,7 @@ function RetryTimeline({
     switch (errorType) {
       case "timeout":
       case "first_byte_timeout":
+      case "upstream_no_content_stream":
       case "stream_idle_timeout":
         return <Clock className="w-3 h-3 text-status-warning" />;
       case "http_5xx":
@@ -665,6 +666,7 @@ function RetryTimeline({
                     attempt.error_type === "http_5xx" && "text-status-error",
                     (attempt.error_type === "timeout" ||
                       attempt.error_type === "first_byte_timeout" ||
+                      attempt.error_type === "upstream_no_content_stream" ||
                       attempt.error_type === "stream_idle_timeout") &&
                       "text-status-warning",
                     attempt.error_type === "http_429" && "text-orange-500",

--- a/src/lib/services/proxy-client.ts
+++ b/src/lib/services/proxy-client.ts
@@ -87,6 +87,24 @@ export class StreamIdleTimeoutError extends Error {
   }
 }
 
+/**
+ * Error raised when an upstream SSE stream closes cleanly before producing any
+ * content-bearing chunk. This is distinct from FirstByteTimeoutError: the
+ * configured first-byte timer never fired — the upstream simply finished the
+ * stream early (often after sending only metadata events).
+ */
+export class UpstreamNoContentStreamError extends Error {
+  constructor(
+    public readonly elapsedMs: number,
+    public readonly firstByteTimeoutMs: number
+  ) {
+    super(
+      `Upstream closed SSE stream after ${(elapsedMs / 1000).toFixed(2)}s without producing any content-bearing chunk (first-byte timeout config: ${Math.round(firstByteTimeoutMs / 1000)}s)`
+    );
+    this.name = "UpstreamNoContentStreamError";
+  }
+}
+
 function maskSecretValue(value: string): string {
   const trimmed = value.trim();
   if (trimmed.length <= 6) return "***";
@@ -943,6 +961,8 @@ async function waitForFirstStreamContent(options: {
     return;
   }
 
+  const startedAt = Date.now();
+
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const timeoutPromise = new Promise<never>((_resolve, reject) => {
     timeoutId = setTimeout(() => {
@@ -953,7 +973,7 @@ async function waitForFirstStreamContent(options: {
 
   const streamDoneBeforeContentPromise = options.onStreamDone.then(() => {
     if (!options.hasFirstContent()) {
-      throw new FirstByteTimeoutError(options.timeoutMs ?? 0);
+      throw new UpstreamNoContentStreamError(Date.now() - startedAt, options.timeoutMs ?? 0);
     }
   });
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -587,6 +587,10 @@
     "journeyRequestNotSent": "Did not send the request upstream; the flow ended inside the gateway",
     "retryErrorType": {
       "timeout": "timeout",
+      "first_byte_timeout": "first-byte timeout",
+      "upstream_no_content_stream": "upstream no-content stream",
+      "stream_idle_timeout": "stream idle timeout",
+      "stream_error": "stream error",
       "http_5xx": "HTTP 5xx",
       "http_4xx": "HTTP 4xx",
       "http_429": "HTTP 429",

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -592,6 +592,10 @@
     "journeyRequestNotSent": "未发送到上游，流程在网关内结束",
     "retryErrorType": {
       "timeout": "超时",
+      "first_byte_timeout": "首字超时",
+      "upstream_no_content_stream": "上游空内容流",
+      "stream_idle_timeout": "流空闲超时",
+      "stream_error": "流异常",
       "http_5xx": "5xx 错误",
       "http_4xx": "4xx 错误",
       "http_429": "429 限流",

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -470,6 +470,7 @@ export interface TestUpstreamResponse {
 export type FailoverErrorType =
   | "timeout"
   | "first_byte_timeout"
+  | "upstream_no_content_stream"
   | "stream_idle_timeout"
   | "stream_error"
   | "http_5xx"

--- a/tests/unit/api/proxy/route.test.ts
+++ b/tests/unit/api/proxy/route.test.ts
@@ -121,6 +121,18 @@ vi.mock("@/lib/services/proxy-client", () => {
     }
   }
 
+  class UpstreamNoContentStreamError extends Error {
+    constructor(
+      public readonly elapsedMs: number,
+      public readonly firstByteTimeoutMs: number
+    ) {
+      super(
+        `Upstream closed SSE stream after ${(elapsedMs / 1000).toFixed(2)}s without producing any content-bearing chunk (first-byte timeout config: ${Math.round(firstByteTimeoutMs / 1000)}s)`
+      );
+      this.name = "UpstreamNoContentStreamError";
+    }
+  }
+
   return {
     forwardRequest: vi.fn(),
     prepareUpstreamForProxy: vi.fn((upstream, timeoutConfig) => ({
@@ -157,6 +169,7 @@ vi.mock("@/lib/services/proxy-client", () => {
     ),
     FirstByteTimeoutError,
     StreamIdleTimeoutError,
+    UpstreamNoContentStreamError,
   };
 });
 

--- a/tests/unit/services/proxy-client.test.ts
+++ b/tests/unit/services/proxy-client.test.ts
@@ -1758,7 +1758,7 @@ describe("proxy-client", () => {
       await assertion;
     });
 
-    it("should fail first-byte validation when stream closes before content-bearing data", async () => {
+    it("should raise UpstreamNoContentStreamError when stream closes before content-bearing data", async () => {
       const sseData = 'data: {"type":"response.created"}\n\ndata: [DONE]\n\n';
       const mockResponse = new Response(sseData, {
         status: 200,
@@ -1781,8 +1781,8 @@ describe("proxy-client", () => {
           "req-123"
         )
       ).rejects.toMatchObject({
-        name: "FirstByteTimeoutError",
-        timeoutMs: 1000,
+        name: "UpstreamNoContentStreamError",
+        firstByteTimeoutMs: 1000,
       });
     });
 


### PR DESCRIPTION
## Summary

修复 `waitForFirstStreamContent` 错误消息把"配置阈值"误当成"实际等待时长"的语义 bug。原先 `streamDoneBeforeContentPromise` 分支与真超时分支共用 `FirstByteTimeoutError(timeoutMs)`，导致上游 SSE 流在 2–5 秒内正常关闭却没产生 content-bearing chunk 时，UI 与日志固定显示 `Upstream first byte timed out after 30s` —— 实际只等了 3 秒。

- 新增 `UpstreamNoContentStreamError`，构造函数同时接收 `elapsedMs`（实际耗时）与 `firstByteTimeoutMs`（配置阈值），文案如实呈现 `Upstream closed SSE stream after 3.58s without producing any content-bearing chunk (first-byte timeout config: 30s)`。
- `FailoverErrorType` 增加 `upstream_no_content_stream`；`getErrorType` 与 `isFailoverableError` 单独识别该类，故障转移行为与之前一致。
- 顺手补齐 `retryErrorType` 字典里此前缺失的 `first_byte_timeout` / `stream_idle_timeout` / `stream_error` 三项中英文，避免运行时回落到原始枚举名。

## Investigation evidence

生产环境 `rc-cx-pro` 上游六条 503 的实测耗时 vs 错误文案：

| reqId | 上游响应 | 耗时 | 错误文案 |
|-------|---------|------|---------|
| b19e6722 | 200 / text/event-stream | 2.23 s | `timed out after 30s` |
| 44eac652 | 200 / text/event-stream | 3.63 s | `timed out after 30s` |
| 6bff51e5 | 200 / text/event-stream | 4.55 s | `timed out after 30s` |
| acfcc4c9 | 200 / text/event-stream | 3.58 s | `timed out after 30s` |
| 0b0f13f5 | 200 / text/event-stream | 2.58 s | `timed out after 30s` |
| 2ef5ecd3 | 200 / text/event-stream | 2.68 s | `timed out after 30s` |

`firstByteTimeout` 配置为默认 30 秒，但每条都在 2–5 秒结束。`setTimeout` 计时器没有触发，命中的是 `streamDoneBeforeContentPromise` 分支——上游正常完成了 SSE 流但只发送 metadata 事件。

## Behavior changes

- 新场景的 `error_type` 由 `first_byte_timeout` 变更为 `upstream_no_content_stream`。**之前依赖匹配 `first_byte_timeout` 的失败规则需要追加 `upstream_no_content_stream` 才能继续覆盖该场景。**
- 历史 `request_logs` 行保留原 `first_byte_timeout` 值，不做迁移。
- 不引入 `recordFailure` 调用变更（电路熔断行为保持原状）；如需让该错误也计入熔断失败计数，应作为独立 PR 评估。

## Test plan

- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test:run`（147 文件 / 2487 用例全绿，其中 `tests/unit/services/proxy-client.test.ts` 的 path B 用例已改为期望新错误类）