### PR TITLE
docs: drop stale Phase 1 scaffold copy & realign top entry pages (#167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Verify](https://github.com/g1331/AutoRouter/actions/workflows/verify.yml/badge.svg)](https://github.com/g1331/AutoRouter/actions/workflows/verify.yml)
 [![Release](https://github.com/g1331/AutoRouter/actions/workflows/release.yml/badge.svg)](https://github.com/g1331/AutoRouter/actions/workflows/release.yml)
 [![codecov](https://codecov.io/gh/g1331/AutoRouter/graph/badge.svg)](https://codecov.io/gh/g1331/AutoRouter)
-[![Docs](https://img.shields.io/badge/Docs-WIP-orange?logo=vite&logoColor=white)](https://g1331.github.io/AutoRouter/)
+[![Docs](https://img.shields.io/badge/Docs-online-3eaf7c?logo=vite&logoColor=white)](https://g1331.github.io/AutoRouter/)
 
 <!-- Badges: Tech -->
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -11,7 +11,7 @@
 [![Verify](https://github.com/g1331/AutoRouter/actions/workflows/verify.yml/badge.svg)](https://github.com/g1331/AutoRouter/actions/workflows/verify.yml)
 [![Release](https://github.com/g1331/AutoRouter/actions/workflows/release.yml/badge.svg)](https://github.com/g1331/AutoRouter/actions/workflows/release.yml)
 [![codecov](https://codecov.io/gh/g1331/AutoRouter/graph/badge.svg)](https://codecov.io/gh/g1331/AutoRouter)
-[![Docs](https://img.shields.io/badge/Docs-WIP-orange?logo=vite&logoColor=white)](https://g1331.github.io/AutoRouter/)
+[![Docs](https://img.shields.io/badge/Docs-online-3eaf7c?logo=vite&logoColor=white)](https://g1331.github.io/AutoRouter/)
 
 <!-- Badges: Tech -->
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -4,18 +4,24 @@ layout: home
 hero:
   name: AutoRouter
   text: AI API Gateway
-  tagline: English documentation is in progress.
+  tagline: Documentation is currently maintained in Simplified Chinese only.
   actions:
     - theme: brand
-      text: 简体中文
+      text: 简体中文文档
       link: /
     - theme: alt
       text: GitHub
       link: https://github.com/g1331/AutoRouter
 ---
 
-## English documentation status
+## Language status
 
-The English locale is reserved as a placeholder. Translation work will follow the Chinese first-batch (10 documents) once the Chinese versions stabilize. Progress is tracked in [issue #167](https://github.com/g1331/AutoRouter/issues/167).
+The Simplified Chinese documentation is the source of truth and is feature-complete (34 documents covering deployment, usage, and architecture). The English locale exists as a navigation slot but has no translated content yet.
 
-Please refer to the [Simplified Chinese documentation](/) for the most up-to-date content.
+If you read English only and need to understand a specific topic, the recommended workflow is:
+
+- Open the [Simplified Chinese site](/) and pick the document via the top nav (部署指南 / 使用指南 / 架构介绍).
+- Use your browser's translation feature, or copy the page content into your preferred translator.
+- Code samples, configuration keys, environment variable names, CLI commands, and error messages in those pages are already in English and do not require translation.
+
+There is no committed timeline for an official English translation. Pull requests that translate individual pages are welcome — see [`docs/guide/architecture/contributing`](/guide/architecture/contributing) on the Chinese site for branch naming and review conventions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,19 +30,36 @@ features:
     details: 记录候选集、路由决策、故障转移历史与计费快照，便于排障与成本分析。
 ---
 
-## 文档进度
+## 从哪里开始
 
-文档体系当前处于 Phase 1 脚手架阶段：导航与 sidebar 已铺好，正文按主题分批撰写。具体进度参见 [issue #167](https://github.com/g1331/AutoRouter/issues/167)。
+按读者所处的部署阶段提供三条入口路径，每条路径按建议顺序串起最小可用文档集，访客可按需读完即跑通。
 
-第一批优先撰写 10 篇，确保陌生访客可以独立完成「部署 → 登记 CPA 实例 → OAuth 登录 → 客户端调用」全流程：
+### 路径 A · 部署上线
+
+适合「拿到项目准备搭起来」的访客，目标是把 AutoRouter 跑到能登录管理后台。
 
 1. [部署形态总览](/guide/deployment/overview)
 2. [快速开始（源码 docker compose）](/guide/deployment/quickstart)
-3. [CI 部署后追加 CLIProxyAPI sidecar](/guide/deployment/cliproxy-sidecar)
-4. [环境变量参考](/guide/deployment/env-reference)
-5. [添加第一个上游](/guide/usage/first-upstream)
-6. [创建客户端 API Key](/guide/usage/client-keys)
-7. [通过 AutoRouter 调用模型](/guide/usage/invoke-models)
-8. [CLIProxyAPI 首次使用指南](/guide/usage/cliproxy-first-time)
-9. [整体架构总览](/guide/architecture/overview)
-10. [请求生命周期](/guide/architecture/request-lifecycle)
+3. [环境变量参考](/guide/deployment/env-reference)
+4. [CI 部署后追加 CLIProxyAPI sidecar](/guide/deployment/cliproxy-sidecar)
+
+### 路径 B · 接入第一次调用
+
+适合「部署完成，准备第一次发起请求」的访客，目标是从管理后台配置到客户端拿到响应。
+
+1. [管理后台导览](/guide/usage/admin-overview)
+2. [添加第一个上游](/guide/usage/first-upstream)
+3. [创建客户端 API Key](/guide/usage/client-keys)
+4. [通过 AutoRouter 调用模型](/guide/usage/invoke-models)
+5. [CLIProxyAPI 首次使用指南](/guide/usage/cliproxy-first-time)
+
+### 路径 C · 理解架构与贡献
+
+适合「想了解内部实现或评估架构」的开发者。
+
+1. [整体架构总览](/guide/architecture/overview)
+2. [请求生命周期](/guide/architecture/request-lifecycle)
+3. [安全模型](/guide/architecture/security)
+4. [贡献指南与代码规范](/guide/architecture/contributing)
+
+完整文档清单（部署 10 / 使用 13 / 架构 11 共 34 篇）通过顶部导航与左侧 sidebar 访问。文档结构、撰写背景与版本规划参见 [issue #167](https://github.com/g1331/AutoRouter/issues/167)。


### PR DESCRIPTION
## 背景

文档站 34/34 早已合入 master，但访客首屏与 README badge 还在传达「文档没好」的错误信号。本 PR 把这三处与现实矛盾的过时文案修掉。

## 改动清单

### `docs/index.md`
- 删除「当前处于 Phase 1 脚手架阶段」「第一批优先撰写 10 篇」整段
- 替换为「从哪里开始」按读者状态切分的三条路径：
  - **A 部署上线**（4 篇）：overview → quickstart → env-reference → cliproxy-sidecar
  - **B 接入第一次调用**（5 篇）：admin-overview → first-upstream → client-keys → invoke-models → cliproxy-first-time
  - **C 理解架构与贡献**（4 篇）：overview → request-lifecycle → security → contributing
- 把 34 篇完整清单的引导移到段末，链接保留 issue 作为撰写背景

### `docs/en/index.md`
- 删除「English documentation is in progress」与「Translation work will follow the Chinese first-batch once the Chinese versions stabilize」这两处会让访客误以为翻译即将完成的表述
- 改为如实声明：英文版仅占位、中文版是 source of truth，给出阅读中文版 + 浏览器翻译的实操工作流；明确说没有时间表、欢迎单篇翻译 PR

### `README.md` / `README_EN.md`
- Docs badge 从 `Docs-WIP-orange` 改为 `Docs-online-3eaf7c`（vue 主色），与「34/34 文档已上线」事实对齐

## 不在本 PR 范围

下列 issue #167 衍生的收尾工作单独处理，避免本次小步改动越界：

- README.md / README_EN.md 双语主体减负 + 链接到 CPA / circuit-breaker 章节
- 英文版翻译滚动补齐（`docs/en/` 整站正文）
- `docs/cliproxy-deployment.md` / `docs/circuit-breaker.md` 旧长篇与 `legacySidebar` 的清退决策
- 自定义域名（`CNAME`）optional 项

## Test plan

- [x] `pnpm docs:build` 本地通过
- [x] pre-commit（prettier / end-of-file / trim trailing whitespace）全过
- [ ] CI: Build VitePress site / Quality / Verify Status 等 12 项 pass