### PR TITLE
fix(dashboard): 统一消费金额格式，避免小额显示过长

### DIFF
--- a/src/components/dashboard/chart-theme.ts
+++ b/src/components/dashboard/chart-theme.ts
@@ -114,3 +114,12 @@ export function formatDuration(ms: number): string {
   }
   return `${Math.round(ms)}ms`;
 }
+
+export function formatCost(usd: number): string {
+  if (usd === 0) return "$0.00";
+  if (usd >= 1_000_000) return `$${(usd / 1_000_000).toFixed(2)}M`;
+  if (usd >= 1_000) return `$${(usd / 1_000).toFixed(2)}K`;
+  if (usd >= 0.01) return `$${usd.toFixed(2)}`;
+  // 小于一分时保留四位小数，既能让真实存在的消费显示出来，又不会过长
+  return `$${usd.toFixed(4)}`;
+}

--- a/src/components/dashboard/leaderboard-section.tsx
+++ b/src/components/dashboard/leaderboard-section.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import type { StatsLeaderboardResponse, DistributionItem } from "@/types/api";
 
-import { formatNumber, UPSTREAM_COLORS_DARK } from "./chart-theme";
+import { formatCost, formatNumber, UPSTREAM_COLORS_DARK } from "./chart-theme";
 import { DashboardLoadingBlock, DashboardLoadingSurface } from "./dashboard-loading";
 
 interface LeaderboardSectionProps {
@@ -38,12 +38,6 @@ function getTtftClass(ttftMs: number): string {
   if (ttftMs >= 1000) return "text-status-error";
   if (ttftMs >= 500) return "text-status-warning";
   return "text-status-success";
-}
-
-function formatCost(usd: number): string {
-  if (usd === 0) return "$0.00";
-  if (usd < 0.01) return `$${usd.toFixed(6)}`;
-  return `$${usd.toFixed(4)}`;
 }
 
 const RANK_ROW_BASE =

--- a/src/components/dashboard/stats-cards.tsx
+++ b/src/components/dashboard/stats-cards.tsx
@@ -15,7 +15,7 @@ import {
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
-import { formatDuration, formatNumber } from "./chart-theme";
+import { formatCost, formatDuration, formatNumber } from "./chart-theme";
 import { DashboardLoadingBlock, DashboardLoadingSurface } from "./dashboard-loading";
 
 interface StatsCardsProps {
@@ -50,12 +50,6 @@ function getTtftPerformanceClass(ttftMs: number): string {
 function formatCacheRate(rate: number): string {
   const normalizedRate = Number.isFinite(rate) ? Math.min(Math.max(rate, 0), 100) : 0;
   return `${normalizedRate.toFixed(2)}%`;
-}
-
-function formatCost(usd: number): string {
-  if (usd === 0) return "$0.00";
-  if (usd < 0.01) return `$${usd.toFixed(6)}`;
-  return `$${usd.toFixed(4)}`;
 }
 
 interface DeltaBadgeProps {

--- a/tests/components/dashboard/leaderboard-section.test.tsx
+++ b/tests/components/dashboard/leaderboard-section.test.tsx
@@ -197,6 +197,36 @@ describe("LeaderboardSection", () => {
       expect(screen.getByText("10.0K")).toBeInTheDocument();
     });
 
+    it("renders costs with two decimals", () => {
+      render(<LeaderboardSection data={mockData} isLoading={false} />);
+
+      expect(screen.getByText("$12.50")).toBeInTheDocument();
+      expect(screen.getByText("$8.00")).toBeInTheDocument();
+      expect(screen.getByText("$0.50")).toBeInTheDocument();
+    });
+
+    it("renders sub-cent cost with four decimals", () => {
+      const data: StatsLeaderboardResponse = {
+        api_keys: [
+          {
+            id: "key-tiny",
+            name: "Tiny Key",
+            key_prefix: "sk-tiny",
+            request_count: 1,
+            total_tokens: 10,
+            total_cost_usd: 0.006599,
+            model_distribution: [],
+          },
+        ],
+        upstreams: [],
+        models: [],
+      };
+
+      render(<LeaderboardSection data={data} isLoading={false} />);
+
+      expect(screen.getByText("$0.0066")).toBeInTheDocument();
+    });
+
     it("renders distribution pie charts with fixed dimensions", () => {
       render(<LeaderboardSection data={mockData} isLoading={false} />);
 

--- a/tests/components/dashboard/stats-cards.test.tsx
+++ b/tests/components/dashboard/stats-cards.test.tsx
@@ -200,6 +200,38 @@ describe("StatsCards", () => {
     });
   });
 
+  describe("Cost formatting", () => {
+    it("renders zero cost as $0.00", () => {
+      render(<StatsCards {...defaultProps} totalCostToday={0} />);
+
+      expect(screen.getByText("$0.00")).toBeInTheDocument();
+    });
+
+    it("renders sub-cent cost with four decimals", () => {
+      render(<StatsCards {...defaultProps} totalCostToday={0.006599} />);
+
+      expect(screen.getByText("$0.0066")).toBeInTheDocument();
+    });
+
+    it("renders regular cost with two decimals", () => {
+      render(<StatsCards {...defaultProps} totalCostToday={12.5} />);
+
+      expect(screen.getByText("$12.50")).toBeInTheDocument();
+    });
+
+    it("abbreviates thousand-dollar cost with K suffix", () => {
+      render(<StatsCards {...defaultProps} totalCostToday={1234.5} />);
+
+      expect(screen.getByText("$1.23K")).toBeInTheDocument();
+    });
+
+    it("abbreviates million-dollar cost with M suffix", () => {
+      render(<StatsCards {...defaultProps} totalCostToday={2_500_000} />);
+
+      expect(screen.getByText("$2.50M")).toBeInTheDocument();
+    });
+  });
+
   describe("Icons", () => {
     it("renders activity icon for requests", () => {
       render(


### PR DESCRIPTION
## Summary

统一仪表盘消费金额的展示格式，修复「今日消费」卡片在小额场景下显示过长的问题（例如 `$0.006599` 占用九个字符，明显长于同排其它卡片）。

## Related Issue

无

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (code improvement without changing functionality)
- [x] Tests (adding or updating tests)

## Changes

- 将 `formatCost` 提取到 `src/components/dashboard/chart-theme.ts`，仪表盘统计卡片与排行榜共用同一份实现，消除两处重复。
- 调整金额格式：小于一分从六位小数改为四位小数；常规金额改为两位小数；千级与百万级分别用 `K` / `M` 缩写。
- 同步修复排行榜「消费金额」列里相同的小额六位小数缺陷。
- 为 `stats-cards` 与 `leaderboard-section` 补充金额格式化单元测试。

显示效果对照：`$0.006599` → `$0.0066`，`$16.9599` → `$16.96`，`$1234.5000` → `$1.23K`，`$2500000.0000` → `$2.50M`。

## Test Plan

- [x] Local tests pass (`pnpm test:run`)，`tests/components/dashboard/` 共 81 项通过
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes，改动文件 ESLint 通过
- [ ] Manual testing completed

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [ ] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Additional Notes

本次仅改动 dashboard 三个源文件与两个测试文件，不涉及接口、数据格式或持久化变更。
