### PR TITLE
feat(cliproxy): 日志面板展示后端透传的具体错误原因

### DIFF
--- a/src/components/admin/cliproxy-instance-logs-panel.tsx
+++ b/src/components/admin/cliproxy-instance-logs-panel.tsx
@@ -38,10 +38,13 @@ export function CliproxyInstanceLogsPanel({ instance }: CliproxyInstanceLogsPane
     data: result,
     isLoading,
     isError,
+    error,
     refetch,
     isFetching,
   } = useCliproxyInstanceLogs(instance.id, { limit: CLIPROXY_LOGS_DEFAULT_LIMIT });
   const [keyword, setKeyword] = useState("");
+
+  const errorMessage = error instanceof Error ? error.message : null;
 
   const filtered = useMemo(() => {
     const lines = result?.lines ?? [];
@@ -79,9 +82,12 @@ export function CliproxyInstanceLogsPanel({ instance }: CliproxyInstanceLogsPane
             <Skeleton className="h-6 w-full" />
           </div>
         ) : isError ? (
-          <p className="py-8 text-center type-body-medium text-destructive">
-            {t("logsLoadFailed")}
-          </p>
+          <div className="space-y-2 py-8 text-center">
+            <p className="type-body-medium text-destructive">{t("logsLoadFailed")}</p>
+            {errorMessage ? (
+              <p className="break-words type-body-small text-muted-foreground">{errorMessage}</p>
+            ) : null}
+          </div>
         ) : !result || result.lines.length === 0 ? (
           <p className="py-8 text-center type-body-medium text-muted-foreground">
             {t("logsEmpty")}

--- a/tests/components/cliproxy-instance-logs-panel.test.tsx
+++ b/tests/components/cliproxy-instance-logs-panel.test.tsx
@@ -53,7 +53,7 @@ describe("CliproxyInstanceLogsPanel", () => {
     expect(screen.getByText("logsTitle")).toBeInTheDocument();
   });
 
-  it("加载失败展示错误", () => {
+  it("加载失败展示错误标题", () => {
     useCliproxyInstanceLogsMock.mockReturnValue({
       data: undefined,
       isError: true,
@@ -62,6 +62,25 @@ describe("CliproxyInstanceLogsPanel", () => {
     });
     render(<CliproxyInstanceLogsPanel instance={instance} />);
     expect(screen.getByText("logsLoadFailed")).toBeInTheDocument();
+  });
+
+  it("加载失败时把后端透传的具体原因（如 logging to file disabled）也展示出来", () => {
+    useCliproxyInstanceLogsMock.mockReturnValue({
+      data: undefined,
+      isError: true,
+      error: new Error(
+        "CLIProxyAPI 管理 API 调用失败：CLIProxyAPI 管理 API 返回异常状态码 400：logging to file disabled"
+      ),
+      refetch: vi.fn(),
+      isFetching: false,
+    });
+    render(<CliproxyInstanceLogsPanel instance={instance} />);
+    expect(screen.getByText("logsLoadFailed")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "CLIProxyAPI 管理 API 调用失败：CLIProxyAPI 管理 API 返回异常状态码 400：logging to file disabled"
+      )
+    ).toBeInTheDocument();
   });
 
   it("空日志展示提示", () => {


### PR DESCRIPTION
## Summary

接 PR #200：v0.5.1 已经把 CLIProxyAPI 上游 4xx 的错误正文拼到 `CliproxyManagementApiError.message` 上，但前端日志面板仍只展示通用的 `logsLoadFailed` 文案，把真正的根因（如 `logging to file disabled`）吞掉。

现在 panel 在 `isError` 时额外展示 `error.message` —— 例如 CLIProxyAPI 端未启用 `LoggingToFile` 时，用户能直接在 UI 上看到 "logging to file disabled"，不再需要去翻后端日志才知道为什么 502。

## Changes

- `src/components/admin/cliproxy-instance-logs-panel.tsx`：错误态新增第二行展示 `error.message`，灰字、可换行
- 同步组件测试覆盖：错误带 message 时被渲染、错误不带 message 时仍展示通用标题

## Test plan

- [x] pnpm exec tsc --noEmit
- [x] pnpm lint
- [x] pnpm test:run tests/components/cliproxy-instance-logs-panel.test.tsx（8 通过）
- [ ] CI 全绿