### PR TITLE
fix(proxy): 模型列表端点不再被 openai_chat_compatible 能力误拦

### DIFF
--- a/src/app/api/proxy/v1/[...path]/route.ts
+++ b/src/app/api/proxy/v1/[...path]/route.ts
@@ -2660,6 +2660,47 @@ async function handleProxy(request: NextRequest, context: RouteContext): Promise
       : activeUpstreams.map((upstream) => upstream.id);
   const allowedUpstreamIdSet = new Set(allowedUpstreamIds);
 
+  // Serve the OpenAI-compatible model list locally for keys that declare allowed
+  // models. Model listing is a discovery endpoint and must not be gated on a
+  // specific route capability (openai_chat_compatible): a key whose authorized
+  // upstreams only expose openai_responses / codex_cli_responses can still
+  // enumerate its allowed models, mirroring what those upstreams actually serve.
+  const apiKeyAllowedModels = normalizeApiKeyAllowedModels(validApiKey.allowedModels);
+  if (isOpenAIModelListRequest(request.method, path) && apiKeyAllowedModels) {
+    const authorizedActiveUpstreams = activeUpstreams.filter((upstream) =>
+      allowedUpstreamIdSet.has(upstream.id)
+    );
+    if (authorizedActiveUpstreams.length > 0) {
+      const visibleModels = getApiKeyVisibleModelList(
+        apiKeyAllowedModels,
+        authorizedActiveUpstreams
+      );
+
+      try {
+        await logLocalApiKeyModelListRequest({
+          apiKeyId: validApiKey.id,
+          apiKeyName: apiKeySnapshot.apiKeyName,
+          apiKeyPrefix: apiKeySnapshot.apiKeyPrefix,
+          request,
+          path,
+          requestId,
+          startTime,
+          matchedRouteCapability,
+          routeMatchSource: matchedRouteMatchSource,
+        });
+      } catch (error) {
+        log.error({ err: error, requestId }, "failed to log local API key model list request");
+      }
+
+      return new Response(Buffer.from(createApiKeyModelListResponseBody(visibleModels)), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+    }
+  }
+
   const primaryCandidatePool = resolveRouteCapabilityCandidatePool(
     activeUpstreams,
     allowedUpstreamIdSet,
@@ -2819,34 +2860,6 @@ async function handleProxy(request: NextRequest, context: RouteContext): Promise
     }
 
     return rejectedResponse;
-  }
-
-  const apiKeyAllowedModels = normalizeApiKeyAllowedModels(validApiKey.allowedModels);
-  if (isOpenAIModelListRequest(request.method, path) && apiKeyAllowedModels) {
-    const visibleModels = getApiKeyVisibleModelList(apiKeyAllowedModels, finalCapabilityCandidates);
-
-    try {
-      await logLocalApiKeyModelListRequest({
-        apiKeyId: validApiKey.id,
-        apiKeyName: apiKeySnapshot.apiKeyName,
-        apiKeyPrefix: apiKeySnapshot.apiKeyPrefix,
-        request,
-        path,
-        requestId,
-        startTime,
-        matchedRouteCapability,
-        routeMatchSource: matchedRouteMatchSource,
-      });
-    } catch (error) {
-      log.error({ err: error, requestId }, "failed to log local API key model list request");
-    }
-
-    return new Response(Buffer.from(createApiKeyModelListResponseBody(visibleModels)), {
-      status: 200,
-      headers: {
-        "content-type": "application/json",
-      },
-    });
   }
 
   let selectedCandidate = finalCapabilityCandidates[0];

--- a/tests/unit/api/proxy/route.test.ts
+++ b/tests/unit/api/proxy/route.test.ts
@@ -6318,6 +6318,80 @@ describe("proxy route upstream selection", () => {
     expect(forwardRequest).not.toHaveBeenCalled();
   });
 
+  it("should return model list for keys bound only to non-chat-compatible upstreams", async () => {
+    const { db } = await import("@/lib/db");
+    const { forwardRequest } = await import("@/lib/services/proxy-client");
+    const { selectFromProviderType } = await import("@/lib/services/load-balancer");
+    const { logRequest } = await import("@/lib/services/request-logger");
+
+    vi.mocked(db.query.apiKeys.findMany).mockResolvedValueOnce([
+      {
+        id: "key-1",
+        keyHash: "hash-1",
+        keyPrefix: "sk-test",
+        name: "Codex-only Model List Key",
+        expiresAt: null,
+        isActive: true,
+        allowedModels: ["gpt-5.5", "gpt-5.4-high"],
+      },
+    ]);
+    vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([
+      { upstreamId: "up-codex-only" },
+    ]);
+    // The only authorized upstream exposes Codex/Responses capabilities, NOT
+    // openai_chat_compatible. Listing models must still succeed locally instead
+    // of returning NO_AUTHORIZED_UPSTREAMS.
+    vi.mocked(db.query.upstreams.findMany).mockResolvedValueOnce([
+      {
+        id: "up-codex-only",
+        name: "codex-only",
+        providerType: "openai",
+        routeCapabilities: ["openai_responses", "codex_cli_responses"],
+        baseUrl: "https://codex.example.com",
+        isDefault: false,
+        isActive: true,
+        timeout: 60,
+        priority: 0,
+        weight: 1,
+        modelRules: null,
+        allowedModels: null,
+        modelRedirects: null,
+      },
+    ]);
+
+    const request = new NextRequest("http://localhost/api/proxy/v1/models", {
+      method: "GET",
+      headers: {
+        authorization: "Bearer sk-test",
+      },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["models"] }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.data.map((item: { id: string }) => item.id)).toEqual(["gpt-5.5", "gpt-5.4-high"]);
+    expect(selectFromProviderType).not.toHaveBeenCalled();
+    expect(forwardRequest).not.toHaveBeenCalled();
+    expect(logRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKeyId: "key-1",
+        upstreamId: null,
+        method: "GET",
+        path: "models",
+        model: "(model-list)",
+        statusCode: 200,
+        routingDecision: expect.objectContaining({
+          matched_route_capability: "openai_chat_compatible",
+          did_send_upstream: false,
+          actual_upstream_id: null,
+        }),
+      })
+    );
+  });
+
   it("should reject when API key not authorized for selected upstream", async () => {
     const { db } = await import("@/lib/db");
     const { forwardRequest } = await import("@/lib/services/proxy-client");


### PR DESCRIPTION
## Summary

修复一个生产环境暴露的矛盾：仅绑定 Codex 形态上游（`openai_responses` / `codex_cli_responses`）的密钥能够正常调用模型，但调用 `GET /v1/models` 列模型时却返回 `403 NO_AUTHORIZED_UPSTREAMS`。根因是模型列表这个发现类端点被硬编码判定为 `openai_chat_compatible` 能力，并且本地模型列表处理逻辑被放在了能力授权拦截之后，导致非 chat 能力的密钥永远走不到本应为它服务的本地返回逻辑。

## Related Issue

无关联 issue，源自生产日志排查（请求 `request_id=6614756f`，路径 `models`，`capabilityCandidatesCount:1` / `authorizedCapabilityCandidatesCount:0`）。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or updating tests)

## Changes

将 `src/app/api/proxy/v1/[...path]/route.ts` 中的「本地模型列表」短路逻辑从能力授权拦截之后前移到之前，并把可见模型的过滤基准从「`openai_chat_compatible` 授权候选」改为「密钥实际授权的全部 active 上游（不限能力）」。

行为约定保持收敛：仅当密钥配置了 `allowed_models` 且至少存在一个授权的 active 上游时，才本地返回模型列表；若密钥没有任何授权 active 上游，则继续走原有拦截返回 403，原「无授权上游」语义不变。未配置 `allowed_models` 的密钥仍按原逻辑转发上游，不受影响。

## Test Plan

- [x] Local tests pass：`pnpm test:run tests/unit/api/proxy/route.test.ts`（74 passed / 1 skipped），含新增回归用例「密钥仅绑定不支持 `openai_chat_compatible` 的上游时，`GET /v1/models` 返回 200 本地列表而非 403」
- [x] Type check passes：`pnpm exec tsc --noEmit`
- [x] Lint passes：ESLint + Prettier 对改动文件均通过
- [ ] Manual testing completed（生产侧待部署后验证）

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [ ] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Additional Notes

并存的次要观察（本 PR 未一并处理，避免扩大改动范围）：`NO_AUTHORIZED_UPSTREAMS` 拦截分支（route.ts 内）只打 `log.warn` 后直接 `return`，未调用 `logRequest` 落库，因此这类 403 不会出现在管理后台请求日志里，仅存在于容器 stdout。与之相邻的 `NO_UPSTREAMS_CONFIGURED` 分支却会落库。这是一处可观测性上的落库不一致，可在后续单独评估是否补齐。
