### PR TITLE
test(proxy): 补齐模型列表前移修复的守卫与跨 provider 用例

### DIFF
--- a/tests/unit/api/proxy/route.test.ts
+++ b/tests/unit/api/proxy/route.test.ts
@@ -6392,6 +6392,161 @@ describe("proxy route upstream selection", () => {
     );
   });
 
+  it("should still 403 model list when key has allowed models but no authorized active upstream", async () => {
+    const { db } = await import("@/lib/db");
+    const { forwardRequest } = await import("@/lib/services/proxy-client");
+    const { selectFromProviderType } = await import("@/lib/services/load-balancer");
+
+    vi.mocked(db.query.apiKeys.findMany).mockResolvedValueOnce([
+      {
+        id: "key-1",
+        keyHash: "hash-1",
+        keyPrefix: "sk-test",
+        name: "Orphaned Model List Key",
+        expiresAt: null,
+        isActive: true,
+        allowedModels: ["gpt-5.5"],
+      },
+    ]);
+    // The key is bound to an upstream that is absent from the active set
+    // (inactive or deleted), so it ends up with zero authorized active upstreams
+    // and the local model-list short-circuit must not fire.
+    vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([
+      { upstreamId: "up-bound-inactive" },
+    ]);
+    // An openai_chat_compatible upstream is active but NOT authorized for this key,
+    // so the request still falls through to NO_AUTHORIZED_UPSTREAMS.
+    vi.mocked(db.query.upstreams.findMany).mockResolvedValueOnce([
+      {
+        id: "up-openai-active",
+        name: "openai-active",
+        providerType: "openai",
+        routeCapabilities: ["openai_chat_compatible"],
+        baseUrl: "https://api.openai.com",
+        isDefault: false,
+        isActive: true,
+        timeout: 60,
+        priority: 0,
+        weight: 1,
+        modelRules: null,
+        allowedModels: null,
+        modelRedirects: null,
+      },
+    ]);
+
+    const request = new NextRequest("http://localhost/api/proxy/v1/models", {
+      method: "GET",
+      headers: {
+        authorization: "Bearer sk-test",
+      },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["models"] }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data).toEqual({
+      error: expect.objectContaining({
+        code: "NO_AUTHORIZED_UPSTREAMS",
+        reason: "NO_AUTHORIZED_UPSTREAMS",
+        did_send_upstream: false,
+      }),
+    });
+    expect(selectFromProviderType).not.toHaveBeenCalled();
+    expect(forwardRequest).not.toHaveBeenCalled();
+  });
+
+  it("should list models across providers for a key authorized on multiple upstreams", async () => {
+    const { db } = await import("@/lib/db");
+    const { forwardRequest } = await import("@/lib/services/proxy-client");
+
+    vi.mocked(db.query.apiKeys.findMany).mockResolvedValueOnce([
+      {
+        id: "key-1",
+        keyHash: "hash-1",
+        keyPrefix: "sk-test",
+        name: "Multi-provider Model List Key",
+        expiresAt: null,
+        isActive: true,
+        allowedModels: ["gpt-5.5", "claude-3.7", "unserved-model"],
+      },
+    ]);
+    vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([
+      { upstreamId: "up-openai" },
+      { upstreamId: "up-anthropic" },
+    ]);
+    // The discovery list now reflects ALL authorized active upstreams regardless
+    // of route capability: claude-3.7 is only served by the Anthropic upstream,
+    // yet it appears on the OpenAI-style /v1/models response, while a model no
+    // upstream serves is filtered out.
+    vi.mocked(db.query.upstreams.findMany).mockResolvedValueOnce([
+      {
+        id: "up-openai",
+        name: "openai-main",
+        providerType: "openai",
+        routeCapabilities: ["openai_chat_compatible"],
+        baseUrl: "https://api.openai.com",
+        isDefault: false,
+        isActive: true,
+        timeout: 60,
+        priority: 0,
+        weight: 1,
+        modelRules: [
+          {
+            type: "exact",
+            value: "gpt-5.5",
+            targetModel: null,
+            source: "manual",
+            displayLabel: null,
+          },
+        ],
+        allowedModels: null,
+        modelRedirects: null,
+      },
+      {
+        id: "up-anthropic",
+        name: "anthropic-main",
+        providerType: "anthropic",
+        routeCapabilities: ["anthropic_messages"],
+        baseUrl: "https://api.anthropic.com",
+        isDefault: false,
+        isActive: true,
+        timeout: 60,
+        priority: 0,
+        weight: 1,
+        modelRules: [
+          {
+            type: "exact",
+            value: "claude-3.7",
+            targetModel: null,
+            source: "manual",
+            displayLabel: null,
+          },
+        ],
+        allowedModels: null,
+        modelRedirects: null,
+      },
+    ]);
+
+    const request = new NextRequest("http://localhost/api/proxy/v1/models", {
+      method: "GET",
+      headers: {
+        authorization: "Bearer sk-test",
+      },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["models"] }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.data.map((item: { id: string }) => item.id)).toEqual(["gpt-5.5", "claude-3.7"]);
+    expect(forwardRequest).not.toHaveBeenCalled();
+  });
+
   it("should reject when API key not authorized for selected upstream", async () => {
     const { db } = await import("@/lib/db");
     const { forwardRequest } = await import("@/lib/services/proxy-client");


### PR DESCRIPTION
## Summary

承接已合并的 PR #202（随 `v0.5.3` 上线），补齐两条单元测试，锁定模型列表前移修复在两个边界上的行为。仅新增测试，无运行时代码改动，因此无需再次发版。

## Related Issue

Follow-up to #202。

## Type of Change

- [x] Tests (adding or updating tests)

## Changes

在 `tests/unit/api/proxy/route.test.ts` 新增两条用例：

其一，守卫否定分支：密钥配置了 `allowed_models` 但没有任何授权的 active 上游（绑定上游已停用或删除）时，`GET /v1/models` 仍按原语义返回 `403 NO_AUTHORIZED_UPSTREAMS`，本地模型列表短路逻辑不触发、不泄出列表。这道用例固定了 `authorizedActiveUpstreams.length > 0` 守卫的否定分支，防止后续重构无意改回退原拒绝语义。

其二，跨 provider 行为：密钥授权了多家上游（OpenAI chat + Anthropic）时，`/v1/models` 按全部授权 active 上游聚合可见模型。`claude-3.7` 仅由 Anthropic 上游通过 `exact` 规则命中，却出现在 OpenAI 风格的 `/v1/models` 响应里，而未被任一上游服务的模型被过滤。该用例把 PR #202 引入的「跨 provider 全量列出」这一行为变化固定下来，便于将来若有意收敛时能被测试捕获。

## Test Plan

- [x] `pnpm test:run tests/unit/api/proxy/route.test.ts`（76 passed / 1 skipped，含两条新增用例）
- [x] `pnpm exec tsc --noEmit`
- [x] ESLint + Prettier 对改动文件均通过

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions
