### PR TITLE
fix(ui): 将 ThemeProvider 上移至根布局消除切换语言时的脚本告警

### DIFF
--- a/docs/guide/architecture/i18n.md
+++ b/docs/guide/architecture/i18n.md
@@ -112,9 +112,19 @@ src/app/
 
 ### 根 vs locale 分工
 
-`src/app/layout.tsx` 只负责 HTML 骨架、字体变量、`<html>` 标签的 `lang` 属性，**不引入 next-intl**。所有 i18n 上下文集中在 `src/app/[locale]/layout.tsx`：
+`src/app/layout.tsx` 负责 HTML 骨架、字体变量、`<html>` 标签的 `lang` 属性，并在 `<body>` 内挂载主题 Provider（`ThemeProvider`）。把主题 Provider 放在语言段**之上**是有意为之：切换语言会重新挂载整个 `[locale]` 子树，若主题 Provider 留在 `[locale]/layout.tsx`，next-themes 注入的防闪脚本（一个内联 `<script>`）会在客户端跳转时被重复渲染，触发 React 19 的「Encountered a script tag while rendering React component」告警；提升到根布局后它只挂载一次，告警消失。根布局**不引入 next-intl**，所有 i18n 上下文集中在 `src/app/[locale]/layout.tsx`：
 
 ```ts
+// src/app/layout.tsx（根布局，节选）
+<html lang={locale} suppressHydrationWarning>
+  <body className={manrope.className}>
+    <ThemeProvider>{children}</ThemeProvider>
+  </body>
+</html>
+```
+
+```ts
+// src/app/[locale]/layout.tsx
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
 }
@@ -130,18 +140,16 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
   const messages = await getMessages();
 
   return (
-    <ThemeProvider>
-      <NextIntlClientProvider messages={messages}>
-        <QueryProvider>
-          <TooltipProvider>
-            <AuthProvider>
-              <div className="min-h-dvh bg-background text-foreground">{children}</div>
-              <Toaster />
-            </AuthProvider>
-          </TooltipProvider>
-        </QueryProvider>
-      </NextIntlClientProvider>
-    </ThemeProvider>
+    <NextIntlClientProvider messages={messages}>
+      <QueryProvider>
+        <TooltipProvider>
+          <AuthProvider>
+            <div className="min-h-dvh bg-background text-foreground">{children}</div>
+            <Toaster />
+          </AuthProvider>
+        </TooltipProvider>
+      </QueryProvider>
+    </NextIntlClientProvider>
   );
 }
 ```

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,7 +8,6 @@ import { Locale } from "@/i18n/config";
 import { routing } from "@/i18n/routing";
 import { AuthProvider } from "@/providers/auth-provider";
 import { QueryProvider } from "@/providers/query-provider";
-import { ThemeProvider } from "@/providers/theme-provider";
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
@@ -30,17 +29,15 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
   const messages = await getMessages();
 
   return (
-    <ThemeProvider>
-      <NextIntlClientProvider messages={messages}>
-        <QueryProvider>
-          <TooltipProvider>
-            <AuthProvider>
-              <div className="min-h-dvh bg-background text-foreground">{children}</div>
-              <Toaster />
-            </AuthProvider>
-          </TooltipProvider>
-        </QueryProvider>
-      </NextIntlClientProvider>
-    </ThemeProvider>
+    <NextIntlClientProvider messages={messages}>
+      <QueryProvider>
+        <TooltipProvider>
+          <AuthProvider>
+            <div className="min-h-dvh bg-background text-foreground">{children}</div>
+            <Toaster />
+          </AuthProvider>
+        </TooltipProvider>
+      </QueryProvider>
+    </NextIntlClientProvider>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+
+import { ThemeProvider } from "@/providers/theme-provider";
+
 import "./globals.css";
 
 const manrope = localFont({
@@ -59,7 +62,9 @@ export default async function RootLayout({ children, params }: RootLayoutProps) 
       className={`${manrope.variable} ${jetbrainsMono.variable}`}
     >
       <head />
-      <body className={manrope.className}>{children}</body>
+      <body className={manrope.className}>
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary

将 next-themes 的 `ThemeProvider` 从 `src/app/[locale]/layout.tsx` 上移到根布局 `src/app/layout.tsx`，消除在登录页（及任意页面）**切换语言**时 React 19 抛出的控制台告警：`Encountered a script tag while rendering React component`。

## Related Issue

无关联 issue。该告警由用户在本地 dev 环境切换语言时反馈，定位为 next-themes + React 19 的放置位置问题，与已合并的多用户门户改动无关（`theme-provider.tsx` / `[locale]/layout.tsx` 最近一次改动来自更早的 UI 重构提交）。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Changes

- `src/app/layout.tsx`：引入并在 `<body>` 内挂载 `<ThemeProvider>{children}</ThemeProvider>`。
- `src/app/[locale]/layout.tsx`：移除 `ThemeProvider` 的 import 与包裹层；内层 `NextIntlClientProvider → QueryProvider → TooltipProvider → AuthProvider` 的相对嵌套顺序保持不变。
- `docs/guide/architecture/i18n.md`：同步更新「根 vs locale 分工」一节的 Provider 树示例与说明。

### 根因

切换语言会改变 URL 的 `[locale]` 段，Next.js 据此重新挂载整个 `[locale]` 子树。`ThemeProvider` 原先位于该子树内，随之被重挂载，导致 next-themes 注入的防闪内联 `<script>` 在客户端跳转时被重复渲染，触发 React 19 告警。提升到语言段**之上**的根布局后，它在整个会话内只挂载一次，告警消除——这也是 next-themes 推荐的标准放置位置。

## Test Plan

- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`) + `pnpm format:check`
- [x] Local tests pass：`useTheme` 消费者（theme-toggle / usage-chart / sidebar）+ 壳层/语言切换/登录页组件测试共 77 个用例通过
- [x] Manual testing completed：Chrome DevTools 实测登录页多次往返切换语言（zh↔en），控制台**不再出现** `script tag` 告警；`<html>` 仍正确施加 `dark` 类与 `color-scheme`，防闪脚本在位，语言切换正常

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary（本次为纯 Provider 位置迁移，无新增逻辑，复用既有组件测试覆盖；真实布局树由 Playwright E2E 网关覆盖）
- [x] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

无视觉变化（纯 Provider 树结构迁移，渲染输出一致）。验证以控制台告警消失 + `<html>` 主题类施加正常为准。

## Additional Notes

内层 Provider 相对顺序不变，所有 `useTheme` 消费者仍是根 `ThemeProvider` 的后代，主题施加与防闪行为不受影响。sonner `Toaster` 写死 `theme="dark"`、不消费 `useTheme`，不受迁移影响。