### PR TITLE
fix(users): ADMIN_TOKEN 超级令牌豁免最后一个启用管理员守卫

### DIFF
--- a/src/app/[locale]/(dashboard)/system/users/page.tsx
+++ b/src/app/[locale]/(dashboard)/system/users/page.tsx
@@ -16,6 +16,7 @@ import { UsersTable } from "@/components/admin/users-table";
 import { UserUpstreamsDialog } from "@/components/admin/user-upstreams-dialog";
 import { Card } from "@/components/ui/card";
 import { useUsers } from "@/hooks/use-users";
+import { useAuth } from "@/providers/auth-provider";
 import type { User } from "@/types/api";
 
 type UserDialog = "edit" | "username" | "password" | "upstreams" | "keys" | "delete" | null;
@@ -29,12 +30,17 @@ export default function UsersPage() {
   const t = useTranslations("users");
   const tCommon = useTranslations("common");
   const { data, isLoading } = useUsers(page, pageSize);
+  const { principal } = useAuth();
+
+  // ADMIN_TOKEN 超级令牌独立于用户表、始终能管理系统，因此豁免“保留最后一个启用
+  // 管理员”的前端禁用；账号登录的管理员仍受限，后端按相同口径用 409 兜底。
+  const bypassLastAdminGuard = principal?.kind === "admin_token";
 
   const users = data?.items ?? [];
   // 全表启用管理员总数（由后端返回），用于跨分页判断最后一个启用管理员的危险操作禁用
   const activeAdminCount = data?.active_admin_total ?? 0;
   const isLastActiveAdmin = (user: User) =>
-    user.role === "admin" && user.is_active && activeAdminCount <= 1;
+    !bypassLastAdminGuard && user.role === "admin" && user.is_active && activeAdminCount <= 1;
 
   const openDialog = (type: Exclude<UserDialog, null>) => (user: User) => {
     setActiveUser(user);
@@ -64,6 +70,7 @@ export default function UsersPage() {
             <UsersTable
               users={users}
               activeAdminCount={activeAdminCount}
+              bypassLastAdminGuard={bypassLastAdminGuard}
               onEdit={openDialog("edit")}
               onChangeUsername={openDialog("username")}
               onResetPassword={openDialog("password")}

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -82,7 +82,9 @@ export async function PUT(request: NextRequest, context: RouteContext) {
       input.isActive = validated.is_active;
     }
 
-    const result = await updateUser(id, input);
+    const result = await updateUser(id, input, {
+      bypassLastActiveAdminGuard: auth.kind === "admin_token",
+    });
 
     return NextResponse.json(transformUserToApi(result));
   } catch (error) {
@@ -114,7 +116,7 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
 
   try {
     const { id } = await context.params;
-    await deleteUser(id);
+    await deleteUser(id, { bypassLastActiveAdminGuard: auth.kind === "admin_token" });
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     if (error instanceof UserNotFoundError) {

--- a/src/components/admin/users-table.tsx
+++ b/src/components/admin/users-table.tsx
@@ -40,6 +40,8 @@ interface UsersTableProps {
   users: User[];
   /** 当前可见数据中启用的管理员数量，用于在前端禁用最后一个启用管理员的危险操作。 */
   activeAdminCount: number;
+  /** 调用者是否为 ADMIN_TOKEN 超级令牌；为真时豁免“最后一个启用管理员”的禁用。 */
+  bypassLastAdminGuard?: boolean;
   onEdit: (user: User) => void;
   onChangeUsername: (user: User) => void;
   onResetPassword: (user: User) => void;
@@ -50,11 +52,13 @@ interface UsersTableProps {
 
 /**
  * 用户列表表格：展示账号信息，行内开关切换启用状态，下拉菜单聚合编辑与危险操作。
- * 最后一个启用的管理员在前端禁用停用与删除入口，服务端对跨页情形再做 409 兜底。
+ * 最后一个启用的管理员在前端禁用停用与删除入口，服务端对跨页情形再做 409 兜底；
+ * 当 bypassLastAdminGuard 为真（ADMIN_TOKEN 超级令牌登录）时该禁用被豁免。
  */
 export function UsersTable({
   users,
   activeAdminCount,
+  bypassLastAdminGuard = false,
   onEdit,
   onChangeUsername,
   onResetPassword,
@@ -68,7 +72,7 @@ export function UsersTable({
   const dateLocale = getDateLocale(locale);
 
   const isLastActiveAdmin = (user: User) =>
-    user.role === "admin" && user.is_active && activeAdminCount <= 1;
+    !bypassLastAdminGuard && user.role === "admin" && user.is_active && activeAdminCount <= 1;
 
   const handleToggle = async (user: User, nextActive: boolean) => {
     if (nextActive === user.is_active) {

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -305,15 +305,33 @@ export async function getUserById(id: string): Promise<UserListItem | null> {
 }
 
 /**
+ * Options for the admin mutations that are normally bounded by the "keep at
+ * least one active admin" guard. When the caller is the ADMIN_TOKEN super-admin
+ * — a credential that lives outside the users table and can always administer
+ * the system — the guard serves no purpose, so the route passes
+ * `bypassLastActiveAdminGuard: true` to allow deleting or demoting the final
+ * active admin user. Account-based admins never set it and stay guarded.
+ */
+export interface LastAdminGuardOptions {
+  bypassLastActiveAdminGuard?: boolean;
+}
+
+/**
  * Update a user's profile fields (display name, role, active state). Role
  * demotion and deactivation are guarded inside a transaction so the system can
- * never lose its last active admin (see {@link LastActiveAdminError}).
+ * never lose its last active admin (see {@link LastActiveAdminError}), unless
+ * the caller is the ADMIN_TOKEN super-admin (see {@link LastAdminGuardOptions}).
  *
  * @param id - The user id
  * @param input - The fields to change; omitted fields are left untouched
+ * @param options - Guard-bypass flags for the ADMIN_TOKEN super-admin
  * @returns The updated user list item
  */
-export async function updateUser(id: string, input: UserUpdateInput): Promise<UserListItem> {
+export async function updateUser(
+  id: string,
+  input: UserUpdateInput,
+  options: LastAdminGuardOptions = {}
+): Promise<UserListItem> {
   const now = new Date();
 
   const updated = await db.transaction(async (tx) => {
@@ -328,7 +346,7 @@ export async function updateUser(id: string, input: UserUpdateInput): Promise<Us
     const wasActiveAdmin = target.role === "admin" && target.isActive;
     const losesAdminCapability = !(nextRole === "admin" && nextActive);
 
-    if (wasActiveAdmin && losesAdminCapability) {
+    if (!options.bypassLastActiveAdminGuard && wasActiveAdmin && losesAdminCapability) {
       const [{ value: others }] = await tx
         .select({ value: count() })
         .from(users)
@@ -489,11 +507,13 @@ export async function changeOwnPassword(
  * transaction as the delete so SQLite — which does not enforce foreign keys at
  * runtime — cannot leave dangling ownership, and a concurrent self-service key
  * creation cannot slip a hanging reference past the cleanup. The last active
- * admin is protected from deletion.
+ * admin is protected from deletion unless the caller is the ADMIN_TOKEN
+ * super-admin (see {@link LastAdminGuardOptions}).
  *
  * @param id - The user id
+ * @param options - Guard-bypass flags for the ADMIN_TOKEN super-admin
  */
-export async function deleteUser(id: string): Promise<void> {
+export async function deleteUser(id: string, options: LastAdminGuardOptions = {}): Promise<void> {
   const now = new Date();
 
   await db.transaction(async (tx) => {
@@ -502,7 +522,7 @@ export async function deleteUser(id: string): Promise<void> {
       throw new UserNotFoundError(`User not found: ${id}`);
     }
 
-    if (target.role === "admin" && target.isActive) {
+    if (!options.bypassLastActiveAdminGuard && target.role === "admin" && target.isActive) {
       const [{ value: others }] = await tx
         .select({ value: count() })
         .from(users)

--- a/tests/components/users-page.test.tsx
+++ b/tests/components/users-page.test.tsx
@@ -20,6 +20,16 @@ vi.mock("@/hooks/use-users", () => ({
   useUsers: () => usersState.current,
 }));
 
+// useAuth：默认账号登录的管理员（不豁免），用例可切换为 ADMIN_TOKEN
+const authState = vi.hoisted(() => ({
+  current: { principal: { kind: "user", role: "admin" } } as {
+    principal: { kind: string; role?: string } | null;
+  },
+}));
+vi.mock("@/providers/auth-provider", () => ({
+  useAuth: () => authState.current,
+}));
+
 // 顶栏：仅回显标题
 vi.mock("@/components/admin/topbar", () => ({
   Topbar: ({ title }: { title: string }) => <div data-testid="topbar">{title}</div>,
@@ -27,10 +37,16 @@ vi.mock("@/components/admin/topbar", () => ({
 
 // 用户表格：捕获页面传入的 props，断言 activeAdminCount 计算
 const tableProps = vi.hoisted(() => ({
-  current: undefined as { users: User[]; activeAdminCount: number } | undefined,
+  current: undefined as
+    | { users: User[]; activeAdminCount: number; bypassLastAdminGuard?: boolean }
+    | undefined,
 }));
 vi.mock("@/components/admin/users-table", () => ({
-  UsersTable: (props: { users: User[]; activeAdminCount: number }) => {
+  UsersTable: (props: {
+    users: User[];
+    activeAdminCount: number;
+    bypassLastAdminGuard?: boolean;
+  }) => {
     tableProps.current = props;
     return <div data-testid="users-table" />;
   },
@@ -70,6 +86,7 @@ function makeUser(overrides: Partial<User>): User {
 beforeEach(() => {
   vi.clearAllMocks();
   usersState.current = { data: undefined, isLoading: true };
+  authState.current = { principal: { kind: "user", role: "admin" } };
   tableProps.current = undefined;
 });
 
@@ -106,5 +123,25 @@ describe("UsersPage", () => {
     expect(tableProps.current?.users).toHaveLength(3);
     // 仅统计启用状态的管理员，停用管理员不计入
     expect(tableProps.current?.activeAdminCount).toBe(1);
+    // 账号登录的管理员不豁免最后一个启用管理员守卫
+    expect(tableProps.current?.bypassLastAdminGuard).toBe(false);
+  });
+
+  it("ADMIN_TOKEN 登录时向表格传入豁免标志", () => {
+    authState.current = { principal: { kind: "admin_token" } };
+    usersState.current = {
+      data: {
+        items: [makeUser({ id: "a1", username: "root", role: "admin", is_active: true })],
+        total: 1,
+        page: 1,
+        page_size: 10,
+        total_pages: 1,
+        active_admin_total: 1,
+      },
+      isLoading: false,
+    };
+    render(<UsersPage />);
+
+    expect(tableProps.current?.bypassLastAdminGuard).toBe(true);
   });
 });

--- a/tests/components/users-table.test.tsx
+++ b/tests/components/users-table.test.tsx
@@ -126,6 +126,14 @@ describe("UsersTable", () => {
     expect(screen.getByRole("button", { name: "deleteUser" })).not.toBeDisabled();
   });
 
+  it("ADMIN_TOKEN 豁免时即便是最后一个启用管理员也不禁用危险操作", () => {
+    const admin = makeUser({ id: "a1", username: "root", role: "admin", is_active: true });
+    render(<UsersTable users={[admin]} activeAdminCount={1} bypassLastAdminGuard {...handlers} />);
+
+    expect(screen.getByRole("switch")).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "deleteUser" })).not.toBeDisabled();
+  });
+
   it("点击编辑与删除触发对应回调", () => {
     const user = makeUser({});
     render(<UsersTable users={[user]} activeAdminCount={0} {...handlers} />);

--- a/tests/unit/api/admin/users.test.ts
+++ b/tests/unit/api/admin/users.test.ts
@@ -17,6 +17,14 @@ vi.mock("@/lib/utils/api-auth", async (importActual) => {
       if (authHeader === "Bearer valid-admin-token") {
         return { kind: "admin_token" };
       }
+      if (authHeader === "Bearer account-admin-token") {
+        return {
+          kind: "user",
+          userId: "99999999-9999-4999-8999-999999999999",
+          role: "admin",
+          username: "account-admin",
+        };
+      }
       if (authHeader === "Bearer member-token") {
         return actual.errorResponse("Forbidden", 403);
       }
@@ -233,6 +241,26 @@ describe("GET/PUT/DELETE /api/admin/users/[id]", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.display_name).toBe("New");
+    // ADMIN_TOKEN 超级令牌调用方豁免“最后一个启用管理员”守卫
+    expect(userService.updateUser).toHaveBeenCalledWith(
+      USER_ID,
+      { displayName: "New" },
+      { bypassLastActiveAdminGuard: true }
+    );
+  });
+
+  it("does not bypass the last-active-admin guard for an account admin on update", async () => {
+    vi.mocked(userService.updateUser).mockResolvedValue(makeUser({ role: "member" }) as never);
+    await updateUserRoute(
+      makeRequest("Bearer account-admin-token", { role: "member" }),
+      ctx(USER_ID)
+    );
+    // 账号登录的管理员仍受守卫约束
+    expect(userService.updateUser).toHaveBeenCalledWith(
+      USER_ID,
+      { role: "member" },
+      { bypassLastActiveAdminGuard: false }
+    );
   });
 
   it("maps the last-active-admin lock to 409 on update", async () => {
@@ -253,6 +281,19 @@ describe("GET/PUT/DELETE /api/admin/users/[id]", () => {
     vi.mocked(userService.deleteUser).mockResolvedValue(undefined);
     const res = await deleteUserRoute(makeRequest(ADMIN), ctx(USER_ID));
     expect(res.status).toBe(204);
+    // ADMIN_TOKEN 超级令牌调用方豁免“最后一个启用管理员”守卫
+    expect(userService.deleteUser).toHaveBeenCalledWith(USER_ID, {
+      bypassLastActiveAdminGuard: true,
+    });
+  });
+
+  it("does not bypass the last-active-admin guard for an account admin on delete", async () => {
+    vi.mocked(userService.deleteUser).mockResolvedValue(undefined);
+    await deleteUserRoute(makeRequest("Bearer account-admin-token"), ctx(USER_ID));
+    // 账号登录的管理员仍受守卫约束
+    expect(userService.deleteUser).toHaveBeenCalledWith(USER_ID, {
+      bypassLastActiveAdminGuard: false,
+    });
   });
 
   it("maps the last-active-admin lock to 409 on delete", async () => {

--- a/tests/unit/services/user-service.test.ts
+++ b/tests/unit/services/user-service.test.ts
@@ -340,6 +340,36 @@ describe("user-service", () => {
       );
     });
 
+    it("demotes the last active admin when the guard is bypassed", async () => {
+      const admin = await createUser({
+        username: "admin",
+        password: "password123",
+        displayName: "Admin",
+        role: "admin",
+      });
+      const updated = await updateUser(
+        admin.id,
+        { role: "member" },
+        { bypassLastActiveAdminGuard: true }
+      );
+      expect(updated.role).toBe("member");
+    });
+
+    it("deactivates the last active admin when the guard is bypassed", async () => {
+      const admin = await createUser({
+        username: "admin",
+        password: "password123",
+        displayName: "Admin",
+        role: "admin",
+      });
+      const updated = await updateUser(
+        admin.id,
+        { isActive: false },
+        { bypassLastActiveAdminGuard: true }
+      );
+      expect(updated.isActive).toBe(false);
+    });
+
     it("deactivates a non-last admin", async () => {
       await createUser({
         username: "admin1",
@@ -476,6 +506,17 @@ describe("user-service", () => {
         role: "admin",
       });
       await expect(deleteUser(admin.id)).rejects.toBeInstanceOf(LastActiveAdminError);
+    });
+
+    it("deletes the last active admin when the guard is bypassed", async () => {
+      const admin = await createUser({
+        username: "admin",
+        password: "password123",
+        displayName: "Admin",
+        role: "admin",
+      });
+      await deleteUser(admin.id, { bypassLastActiveAdminGuard: true });
+      expect(await getUserById(admin.id)).toBeNull();
     });
 
     it("deletes a non-last admin", async () => {


### PR DESCRIPTION
## Summary

`ADMIN_TOKEN` 是独立于 `users` 表的超级令牌，其管理权限不依赖任何账号管理员存在。此前删除/降级/停用「最后一个启用管理员」的守卫（`LastActiveAdminError` → 409）对所有调用方一刀切，导致 ADMIN_TOKEN 这种本就拥有最高权限的身份也被挡住。本 PR 让 ADMIN_TOKEN 调用方豁免该守卫；账号登录的管理员仍受约束。

## Related Issue

无（仓库当前无对应开放 issue）。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes

- **服务层** `user-service.ts`：`updateUser` / `deleteUser` 新增可选参数 `LastAdminGuardOptions`，当 `bypassLastActiveAdminGuard` 为真时跳过「保留最后一个启用管理员」的事务内校验。
- **路由层** `admin/users/[id]/route.ts`：`PUT` / `DELETE` 按 `auth.kind === "admin_token"` 传入豁免标志；账号管理员传 `false`，仍由后端 409 兜底。
- **前端** `users-table.tsx`：新增 `bypassLastAdminGuard` 属性，为真时不禁用停用开关与删除入口；`users/page.tsx` 通过 `useAuth().principal.kind` 派生该标志并下传。
- **测试**：服务层、路由层、页面、表格四处补全「豁免」与「不豁免」两侧用例。

## Test Plan

- [x] Local tests pass（4 个相关测试文件，90 passed）
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes（eslint + prettier --check 干净）
- [ ] Manual testing completed

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [ ] Documentation has been updated (if applicable)