### PR TITLE
feat(ui): 管理后台弹窗接入原生容器变形（container transform）动画

### DIFF
--- a/src/app/[locale]/(dashboard)/keys/page.tsx
+++ b/src/app/[locale]/(dashboard)/keys/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Key } from "lucide-react";
 
@@ -12,6 +12,7 @@ import { RevokeKeyDialog } from "@/components/admin/revoke-key-dialog";
 import { Topbar } from "@/components/admin/topbar";
 import { Card } from "@/components/ui/card";
 import { useAPIKeys } from "@/hooks/use-api-keys";
+import { useContainerMorph } from "@/hooks/use-container-morph";
 import type { APIKey } from "@/types/api";
 
 interface KeysLoadingSkeletonProps {
@@ -61,6 +62,10 @@ export default function KeysPage() {
   const [editingKey, setEditingKey] = useState<APIKey | null>(null);
   const pageSize = 10;
 
+  // 容器变形动画：记录触发弹窗的源元素（表格行 / 卡片），关闭时收回同一元素。
+  const { startMorph, canMorph } = useContainerMorph();
+  const morphSourceRef = useRef<HTMLElement | null>(null);
+
   const t = useTranslations("keys");
   const tCommon = useTranslations("common");
   const { data, isLoading } = useAPIKeys(page, pageSize);
@@ -82,7 +87,25 @@ export default function KeysPage() {
           <KeysLoadingSkeleton loadingLabel={tCommon("loading")} />
         ) : (
           <>
-            <KeysTable keys={data?.items || []} onRevoke={setRevokeKey} onEdit={setEditingKey} />
+            <KeysTable
+              keys={data?.items || []}
+              onRevoke={(key, source) => {
+                morphSourceRef.current = source;
+                startMorph(() => setRevokeKey(key), {
+                  source,
+                  name: "morph-key-revoke",
+                  mode: "enter",
+                });
+              }}
+              onEdit={(key, source) => {
+                morphSourceRef.current = source;
+                startMorph(() => setEditingKey(key), {
+                  source,
+                  name: "morph-key-form",
+                  mode: "enter",
+                });
+              }}
+            />
 
             {data && data.total_pages > 1 && (
               <Card variant="filled" className="border border-divider">
@@ -99,13 +122,34 @@ export default function KeysPage() {
         )}
       </div>
 
-      <RevokeKeyDialog apiKey={revokeKey} open={!!revokeKey} onClose={() => setRevokeKey(null)} />
+      <RevokeKeyDialog
+        apiKey={revokeKey}
+        open={!!revokeKey}
+        onClose={() => {
+          startMorph(() => setRevokeKey(null), {
+            source: morphSourceRef.current,
+            name: "morph-key-revoke",
+            mode: "exit",
+          });
+        }}
+        morph={canMorph}
+      />
 
       {editingKey && (
         <EditKeyDialog
           apiKey={editingKey}
           open={!!editingKey}
-          onOpenChange={(open) => !open && setEditingKey(null)}
+          onOpenChange={(open) => {
+            if (!open) {
+              startMorph(() => setEditingKey(null), {
+                source: morphSourceRef.current,
+                name: "morph-key-form",
+                mode: "exit",
+              });
+            }
+          }}
+          morph={canMorph}
+          morphName="morph-key-form"
         />
       )}
     </>

--- a/src/app/[locale]/(dashboard)/system/billing/page.tsx
+++ b/src/app/[locale]/(dashboard)/system/billing/page.tsx
@@ -56,6 +56,7 @@ import {
   useUpdateBillingTierRule,
 } from "@/hooks/use-billing";
 import { useBackgroundSyncTasks } from "@/hooks/use-background-sync";
+import { useContainerMorph } from "@/hooks/use-container-morph";
 import type {
   BillingModelPrice,
   BillingManualOverride,
@@ -489,6 +490,11 @@ export default function BillingPage() {
   const [selectedResetModels, setSelectedResetModels] = useState<string[]>([]);
   const [resetDialogTargets, setResetDialogTargets] = useState<string[] | null>(null);
   const [recentlySavedModel, setRecentlySavedModel] = useState<string | null>(null);
+
+  // 容器变形动画：单行重置以该行的重置按钮为源、展开收回；批量重置无单一源，
+  // 弹窗单独淡入（hook 对 source 为空安全降级）。
+  const { startMorph, canMorph } = useContainerMorph();
+  const morphSourceRef = useRef<HTMLElement | null>(null);
   const modelPrices = useBillingModelPrices(modelPricePage, modelPricePageSize, modelPriceQuery);
   const tierRules = useBillingTierRules();
   const syncPrices = useSyncBillingPrices();
@@ -975,15 +981,25 @@ export default function BillingPage() {
     });
   };
 
-  const openResetDialog = (models: string[]) => {
+  const openResetDialog = (models: string[], source?: HTMLElement | null) => {
     const normalized = [...new Set(models.map((m) => m.trim()).filter(Boolean))];
     if (normalized.length === 0) {
       return;
     }
-    setResetDialogTargets(normalized);
+    morphSourceRef.current = source ?? null;
+    startMorph(() => setResetDialogTargets(normalized), {
+      source: source ?? null,
+      name: "morph-billing-override-reset",
+      mode: "enter",
+    });
   };
 
-  const closeResetDialog = () => setResetDialogTargets(null);
+  const closeResetDialog = () =>
+    startMorph(() => setResetDialogTargets(null), {
+      source: morphSourceRef.current,
+      name: "morph-billing-override-reset",
+      mode: "exit",
+    });
 
   const handleConfirmReset = async () => {
     if (!resetDialogTargets || resetOverrides.isPending) {
@@ -1392,7 +1408,9 @@ export default function BillingPage() {
                                 variant="ghost"
                                 size="icon"
                                 className="h-8 w-8 shrink-0"
-                                onClick={() => openResetDialog([override.model])}
+                                onClick={(event) =>
+                                  openResetDialog([override.model], event.currentTarget)
+                                }
                                 disabled={resetOverrides.isPending}
                                 title={
                                   override.has_official_price === false
@@ -1938,7 +1956,9 @@ export default function BillingPage() {
                                     variant="ghost"
                                     size="icon"
                                     className="h-8 w-8 shrink-0"
-                                    onClick={() => openResetDialog([item.model])}
+                                    onClick={(event) =>
+                                      openResetDialog([item.model], event.currentTarget)
+                                    }
                                     disabled={resetOverrides.isPending}
                                     title={t("priceCatalogResetToOfficial")}
                                   >
@@ -2474,7 +2494,9 @@ export default function BillingPage() {
                                           variant="ghost"
                                           size="icon"
                                           className="h-8 w-8"
-                                          onClick={() => openResetDialog([override.model])}
+                                          onClick={(event) =>
+                                            openResetDialog([override.model], event.currentTarget)
+                                          }
                                           disabled={resetOverrides.isPending}
                                           title={
                                             override.has_official_price === false
@@ -3309,7 +3331,9 @@ export default function BillingPage() {
                                             variant="ghost"
                                             size="icon"
                                             className="h-8 w-8"
-                                            onClick={() => openResetDialog([item.model])}
+                                            onClick={(event) =>
+                                              openResetDialog([item.model], event.currentTarget)
+                                            }
                                             disabled={resetOverrides.isPending}
                                             title={t("priceCatalogResetToOfficial")}
                                           >
@@ -3670,7 +3694,7 @@ export default function BillingPage() {
       </div>
 
       <AlertDialog open={!!resetDialogTargets} onOpenChange={(v) => !v && closeResetDialog()}>
-        <AlertDialogContent>
+        <AlertDialogContent morph={canMorph} morphName="morph-billing-override-reset">
           <AlertDialogHeader>
             <AlertDialogTitle>{t("priceCatalogResetDialogTitle")}</AlertDialogTitle>
             <AlertDialogDescription>

--- a/src/app/[locale]/(dashboard)/system/cliproxy/page.tsx
+++ b/src/app/[locale]/(dashboard)/system/cliproxy/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Topbar } from "@/components/admin/topbar";
@@ -16,6 +16,7 @@ import { CliproxyPoolUpstreamDialog } from "@/components/admin/cliproxy-pool-ups
 import { CliproxyLinkedUpstreamsPanel } from "@/components/admin/cliproxy-linked-upstreams-panel";
 import { CliproxyInstanceLogsPanel } from "@/components/admin/cliproxy-instance-logs-panel";
 import { useCliproxyInstances } from "@/hooks/use-cliproxy";
+import { useContainerMorph } from "@/hooks/use-container-morph";
 import type { CliproxyInstance } from "@/types/cliproxy";
 
 export default function CliproxyPage() {
@@ -28,6 +29,11 @@ export default function CliproxyPage() {
   const [testInstance, setTestInstance] = useState<CliproxyInstance | null>(null);
   const [poolUpstreamInstance, setPoolUpstreamInstance] = useState<CliproxyInstance | null>(null);
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | null>(null);
+
+  // 容器变形动画：新建按钮 / 实例行作为源，编辑与删除从同一实例展开、关闭收回。
+  // 同一时刻只开一个实例弹窗，共用单个 view-transition-name。
+  const { startMorph, canMorph } = useContainerMorph();
+  const morphSourceRef = useRef<HTMLElement | null>(null);
 
   const selectedInstance =
     instances?.find((instance) => instance.id === selectedInstanceId) ?? null;
@@ -44,7 +50,17 @@ export default function CliproxyPage() {
                 <h2 className="type-title-medium text-foreground">{t("instancesTitle")}</h2>
                 <p className="type-body-small text-muted-foreground">{t("pageDescription")}</p>
               </div>
-              <Button onClick={() => setCreateOpen(true)}>
+              <Button
+                onClick={(event) => {
+                  const source = event.currentTarget;
+                  morphSourceRef.current = source;
+                  startMorph(() => setCreateOpen(true), {
+                    source,
+                    name: "morph-cliproxy-instance",
+                    mode: "enter",
+                  });
+                }}
+              >
                 <Plus className="mr-2 h-4 w-4" />
                 {t("addInstance")}
               </Button>
@@ -69,10 +85,24 @@ export default function CliproxyPage() {
                 instances={instances}
                 selectedInstanceId={selectedInstanceId}
                 onSelect={(instance) => setSelectedInstanceId(instance.id)}
-                onEdit={setEditInstance}
+                onEdit={(instance, source) => {
+                  morphSourceRef.current = source;
+                  startMorph(() => setEditInstance(instance), {
+                    source,
+                    name: "morph-cliproxy-instance",
+                    mode: "enter",
+                  });
+                }}
                 onTest={setTestInstance}
                 onCreatePoolUpstream={setPoolUpstreamInstance}
-                onDelete={setDeleteInstance}
+                onDelete={(instance, source) => {
+                  morphSourceRef.current = source;
+                  startMorph(() => setDeleteInstance(instance), {
+                    source,
+                    name: "morph-cliproxy-instance",
+                    mode: "enter",
+                  });
+                }}
               />
             )}
           </CardContent>
@@ -96,19 +126,48 @@ export default function CliproxyPage() {
       </div>
 
       {createOpen && (
-        <CliproxyInstanceFormDialog open onOpenChange={(open) => !open && setCreateOpen(false)} />
+        <CliproxyInstanceFormDialog
+          open
+          onOpenChange={(open) =>
+            !open &&
+            startMorph(() => setCreateOpen(false), {
+              source: morphSourceRef.current,
+              name: "morph-cliproxy-instance",
+              mode: "exit",
+            })
+          }
+          morph={canMorph}
+          morphName="morph-cliproxy-instance"
+        />
       )}
       {editInstance && (
         <CliproxyInstanceFormDialog
           instance={editInstance}
           open
-          onOpenChange={(open) => !open && setEditInstance(null)}
+          onOpenChange={(open) =>
+            !open &&
+            startMorph(() => setEditInstance(null), {
+              source: morphSourceRef.current,
+              name: "morph-cliproxy-instance",
+              mode: "exit",
+            })
+          }
+          morph={canMorph}
+          morphName="morph-cliproxy-instance"
         />
       )}
       <DeleteCliproxyInstanceDialog
         instance={deleteInstance}
         open={Boolean(deleteInstance)}
-        onClose={() => setDeleteInstance(null)}
+        onClose={() =>
+          startMorph(() => setDeleteInstance(null), {
+            source: morphSourceRef.current,
+            name: "morph-cliproxy-instance",
+            mode: "exit",
+          })
+        }
+        morph={canMorph}
+        morphName="morph-cliproxy-instance"
       />
       {testInstance && (
         <CliproxyConnectionTestDialog

--- a/src/app/[locale]/(dashboard)/system/header-compensation/page.tsx
+++ b/src/app/[locale]/(dashboard)/system/header-compensation/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { ArrowLeftRight, GripVertical, Pencil, Plus, Trash2, X, Check } from "lucide-react";
 import { toast } from "sonner";
@@ -44,6 +44,7 @@ import {
   useUpdateCompensationRule,
   useDeleteCompensationRule,
 } from "@/hooks/use-compensation-rules";
+import { useContainerMorph } from "@/hooks/use-container-morph";
 import { ROUTE_CAPABILITY_DEFINITIONS } from "@/lib/route-capabilities";
 import type { RouteCapability } from "@/lib/route-capabilities";
 import type { CompensationRule, CompensationRuleCreate, CompensationRuleUpdate } from "@/types/api";
@@ -191,9 +192,11 @@ interface RuleFormDialogProps {
   open: boolean;
   onClose: () => void;
   initial?: CompensationRule;
+  /** 启用容器变形动画（View Transition）。 */
+  morph?: boolean;
 }
 
-function RuleFormDialog({ open, onClose, initial }: RuleFormDialogProps) {
+function RuleFormDialog({ open, onClose, initial, morph = false }: RuleFormDialogProps) {
   const t = useTranslations("compensation");
   const createMutation = useCreateCompensationRule();
   const updateMutation = useUpdateCompensationRule();
@@ -248,7 +251,7 @@ function RuleFormDialog({ open, onClose, initial }: RuleFormDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg" morph={morph} morphName="morph-compensation-form">
         <DialogHeader>
           <DialogTitle className="text-sm tracking-wider">
             {isEditing ? t("ruleName") : t("addRule")}
@@ -320,8 +323,8 @@ function RuleFormDialog({ open, onClose, initial }: RuleFormDialogProps) {
 
 interface RuleCardProps {
   rule: CompensationRule;
-  onEdit: (rule: CompensationRule) => void;
-  onDelete: (rule: CompensationRule) => void;
+  onEdit: (rule: CompensationRule, source: HTMLElement | null) => void;
+  onDelete: (rule: CompensationRule, source: HTMLElement | null) => void;
 }
 
 function RuleCard({ rule, onEdit, onDelete }: RuleCardProps) {
@@ -335,7 +338,10 @@ function RuleCard({ rule, onEdit, onDelete }: RuleCardProps) {
   };
 
   return (
-    <div className="rounded-cf-sm border border-divider bg-surface-300/55 shadow-[var(--vr-shadow-xs)]">
+    <div
+      data-morph-source
+      className="rounded-cf-sm border border-divider bg-surface-300/55 shadow-[var(--vr-shadow-xs)]"
+    >
       <div className="flex items-center gap-3 border-b border-divider/80 bg-surface-200/70 px-3 py-2">
         <ArrowLeftRight className="h-3.5 w-3.5 shrink-0 text-amber-500" />
         <span className="flex-1 truncate text-xs font-medium text-foreground">{rule.name}</span>
@@ -427,7 +433,9 @@ function RuleCard({ rule, onEdit, onDelete }: RuleCardProps) {
               variant="ghost"
               size="icon"
               className="h-6 w-6 text-muted-foreground hover:text-foreground"
-              onClick={() => onEdit(rule)}
+              onClick={(event) =>
+                onEdit(rule, event.currentTarget.closest<HTMLElement>("[data-morph-source]"))
+              }
               title="Edit"
             >
               <Pencil className="h-3 w-3" />
@@ -438,7 +446,9 @@ function RuleCard({ rule, onEdit, onDelete }: RuleCardProps) {
               variant="ghost"
               size="icon"
               className="h-6 w-6 text-muted-foreground hover:text-status-error"
-              onClick={() => onDelete(rule)}
+              onClick={(event) =>
+                onDelete(rule, event.currentTarget.closest<HTMLElement>("[data-morph-source]"))
+              }
               title={t("deleteRule")}
             >
               <Trash2 className="h-3 w-3" />
@@ -544,18 +554,59 @@ export default function HeaderCompensationPage() {
   const [editTarget, setEditTarget] = useState<CompensationRule | undefined>();
   const [deleteTarget, setDeleteTarget] = useState<CompensationRule | undefined>();
 
+  // 容器变形动画：记录触发弹窗的源卡片（创建按钮 / 规则卡片），关闭时收回同一元素。
+  const { startMorph, canMorph } = useContainerMorph();
+  const morphSourceRef = useRef<HTMLElement | null>(null);
+
   const rules = data ?? [];
   const builtinRules = rules.filter((rule) => rule.is_builtin);
   const customRules = rules.filter((rule) => !rule.is_builtin);
 
-  const openCreate = () => {
-    setEditTarget(undefined);
-    setFormOpen(true);
+  const openCreate = (source: HTMLElement | null) => {
+    morphSourceRef.current = source;
+    startMorph(
+      () => {
+        setEditTarget(undefined);
+        setFormOpen(true);
+      },
+      { source, name: "morph-compensation-form", mode: "enter" }
+    );
   };
 
-  const openEdit = (rule: CompensationRule) => {
-    setEditTarget(rule);
-    setFormOpen(true);
+  const openEdit = (rule: CompensationRule, source: HTMLElement | null) => {
+    morphSourceRef.current = source;
+    startMorph(
+      () => {
+        setEditTarget(rule);
+        setFormOpen(true);
+      },
+      { source, name: "morph-compensation-form", mode: "enter" }
+    );
+  };
+
+  const openDelete = (rule: CompensationRule, source: HTMLElement | null) => {
+    morphSourceRef.current = source;
+    startMorph(() => setDeleteTarget(rule), {
+      source,
+      name: "morph-compensation-delete",
+      mode: "enter",
+    });
+  };
+
+  const closeForm = () => {
+    startMorph(() => setFormOpen(false), {
+      source: morphSourceRef.current,
+      name: "morph-compensation-form",
+      mode: "exit",
+    });
+  };
+
+  const closeDelete = () => {
+    startMorph(() => setDeleteTarget(undefined), {
+      source: morphSourceRef.current,
+      name: "morph-compensation-delete",
+      mode: "exit",
+    });
   };
 
   const confirmDelete = async () => {
@@ -576,7 +627,11 @@ export default function HeaderCompensationPage() {
             </h2>
             <p className="mt-0.5 text-xs text-muted-foreground">{t("managementDesc")}</p>
           </div>
-          <Button size="sm" onClick={openCreate} className="gap-1.5">
+          <Button
+            size="sm"
+            onClick={(event) => openCreate(event.currentTarget)}
+            className="gap-1.5"
+          >
             <Plus className="h-3.5 w-3.5" />
             {t("addRule")}
           </Button>
@@ -615,12 +670,7 @@ export default function HeaderCompensationPage() {
               ) : (
                 <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
                   {builtinRules.map((rule) => (
-                    <RuleCard
-                      key={rule.id}
-                      rule={rule}
-                      onEdit={openEdit}
-                      onDelete={setDeleteTarget}
-                    />
+                    <RuleCard key={rule.id} rule={rule} onEdit={openEdit} onDelete={openDelete} />
                   ))}
                 </div>
               )}
@@ -642,12 +692,7 @@ export default function HeaderCompensationPage() {
               ) : (
                 <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
                   {customRules.map((rule) => (
-                    <RuleCard
-                      key={rule.id}
-                      rule={rule}
-                      onEdit={openEdit}
-                      onDelete={setDeleteTarget}
-                    />
+                    <RuleCard key={rule.id} rule={rule} onEdit={openEdit} onDelete={openDelete} />
                   ))}
                 </div>
               )}
@@ -659,11 +704,11 @@ export default function HeaderCompensationPage() {
       </main>
 
       {formOpen && (
-        <RuleFormDialog open={formOpen} onClose={() => setFormOpen(false)} initial={editTarget} />
+        <RuleFormDialog open={formOpen} onClose={closeForm} initial={editTarget} morph={canMorph} />
       )}
 
-      <AlertDialog open={!!deleteTarget} onOpenChange={(v) => !v && setDeleteTarget(undefined)}>
-        <AlertDialogContent>
+      <AlertDialog open={!!deleteTarget} onOpenChange={(v) => !v && closeDelete()}>
+        <AlertDialogContent morph={canMorph} morphName="morph-compensation-delete">
           <AlertDialogHeader>
             <AlertDialogTitle>{t("deleteRuleTitle")}</AlertDialogTitle>
             <AlertDialogDescription>{t("deleteRuleDesc")}</AlertDialogDescription>

--- a/src/app/[locale]/(dashboard)/system/users/page.tsx
+++ b/src/app/[locale]/(dashboard)/system/users/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Users } from "lucide-react";
 
@@ -16,6 +16,7 @@ import { UsersTable } from "@/components/admin/users-table";
 import { UserUpstreamsDialog } from "@/components/admin/user-upstreams-dialog";
 import { Card } from "@/components/ui/card";
 import { useUsers } from "@/hooks/use-users";
+import { useContainerMorph } from "@/hooks/use-container-morph";
 import { useAuth } from "@/providers/auth-provider";
 import type { User } from "@/types/api";
 
@@ -26,6 +27,11 @@ export default function UsersPage() {
   const pageSize = 10;
   const [activeUser, setActiveUser] = useState<User | null>(null);
   const [dialog, setDialog] = useState<UserDialog>(null);
+
+  // 容器变形动画：所有用户操作都从该行的下拉菜单触发，统一以行元素为变形源，
+  // 同一时刻只会打开一个弹窗，故共用单个 view-transition-name。
+  const { startMorph, canMorph } = useContainerMorph();
+  const morphSourceRef = useRef<HTMLElement | null>(null);
 
   const t = useTranslations("users");
   const tCommon = useTranslations("common");
@@ -42,11 +48,23 @@ export default function UsersPage() {
   const isLastActiveAdmin = (user: User) =>
     !bypassLastAdminGuard && user.role === "admin" && user.is_active && activeAdminCount <= 1;
 
-  const openDialog = (type: Exclude<UserDialog, null>) => (user: User) => {
-    setActiveUser(user);
-    setDialog(type);
+  const openDialog = (type: Exclude<UserDialog, null>, user: User, source: HTMLElement | null) => {
+    morphSourceRef.current = source;
+    startMorph(
+      () => {
+        setActiveUser(user);
+        setDialog(type);
+      },
+      { source, name: "morph-user-row", mode: "enter" }
+    );
   };
-  const closeDialog = () => setDialog(null);
+  const closeDialog = () => {
+    startMorph(() => setDialog(null), {
+      source: morphSourceRef.current,
+      name: "morph-user-row",
+      mode: "exit",
+    });
+  };
 
   return (
     <>
@@ -71,12 +89,12 @@ export default function UsersPage() {
               users={users}
               activeAdminCount={activeAdminCount}
               bypassLastAdminGuard={bypassLastAdminGuard}
-              onEdit={openDialog("edit")}
-              onChangeUsername={openDialog("username")}
-              onResetPassword={openDialog("password")}
-              onConfigureUpstreams={openDialog("upstreams")}
-              onAssignKeys={openDialog("keys")}
-              onDelete={openDialog("delete")}
+              onEdit={(user, source) => openDialog("edit", user, source)}
+              onChangeUsername={(user, source) => openDialog("username", user, source)}
+              onResetPassword={(user, source) => openDialog("password", user, source)}
+              onConfigureUpstreams={(user, source) => openDialog("upstreams", user, source)}
+              onAssignKeys={(user, source) => openDialog("keys", user, source)}
+              onDelete={(user, source) => openDialog("delete", user, source)}
             />
 
             {data && data.total_pages > 1 && (
@@ -101,28 +119,38 @@ export default function UsersPage() {
             open={dialog === "edit"}
             onOpenChange={(open) => !open && closeDialog()}
             isLastActiveAdmin={isLastActiveAdmin(activeUser)}
+            morph={canMorph}
           />
           <ChangeUsernameDialog
             user={activeUser}
             open={dialog === "username"}
             onOpenChange={(open) => !open && closeDialog()}
+            morph={canMorph}
           />
           <ResetPasswordDialog
             user={activeUser}
             open={dialog === "password"}
             onOpenChange={(open) => !open && closeDialog()}
+            morph={canMorph}
           />
           <UserUpstreamsDialog
             user={activeUser}
             open={dialog === "upstreams"}
             onOpenChange={(open) => !open && closeDialog()}
+            morph={canMorph}
           />
           <AssignUserKeysDialog
             user={activeUser}
             open={dialog === "keys"}
             onOpenChange={(open) => !open && closeDialog()}
+            morph={canMorph}
           />
-          <DeleteUserDialog user={activeUser} open={dialog === "delete"} onClose={closeDialog} />
+          <DeleteUserDialog
+            user={activeUser}
+            open={dialog === "delete"}
+            onClose={closeDialog}
+            morph={canMorph}
+          />
         </>
       )}
     </>

--- a/src/app/[locale]/(dashboard)/upstreams/page.tsx
+++ b/src/app/[locale]/(dashboard)/upstreams/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { useTranslations } from "next-intl";
 import {
   Filter,
@@ -31,6 +31,7 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { useAllUpstreams, useUpstreams, useTestUpstream } from "@/hooks/use-upstreams";
+import { useContainerMorph } from "@/hooks/use-container-morph";
 import type { RouteCapability, Upstream } from "@/types/api";
 import { ROUTE_CAPABILITY_DEFINITIONS } from "@/lib/route-capabilities";
 import { ROUTE_CAPABILITY_ICON_META } from "@/components/admin/route-capability-badges";
@@ -102,6 +103,10 @@ export default function UpstreamsPage() {
   const [capabilityFilter, setCapabilityFilter] = useState<RouteCapability | "all">("all");
   const [includeInactive, setIncludeInactive] = useState(true);
   const [workbenchDensity, setWorkbenchDensity] = useState<WorkbenchDensity>("compact");
+
+  // 容器变形动画：记录触发弹窗的源元素，关闭时收回同一元素。
+  const { startMorph, canMorph } = useContainerMorph();
+  const morphSourceRef = useRef<HTMLElement | null>(null);
 
   const pageSize = 10;
   const t = useTranslations("upstreams");
@@ -203,7 +208,15 @@ export default function UpstreamsPage() {
               </div>
 
               <Button
-                onClick={() => setCreateDialogOpen(true)}
+                onClick={(event) => {
+                  const source = event.currentTarget;
+                  morphSourceRef.current = source;
+                  startMorph(() => setCreateDialogOpen(true), {
+                    source,
+                    name: "morph-upstream-form",
+                    mode: "enter",
+                  });
+                }}
                 variant="primary"
                 className="w-full gap-2 sm:w-auto"
               >
@@ -373,8 +386,22 @@ export default function UpstreamsPage() {
           <div className="space-y-4 animate-in fade-in-0 slide-in-from-top-1 duration-300">
             <UpstreamsTable
               upstreams={filteredUpstreams}
-              onEdit={setEditUpstream}
-              onDelete={setDeleteUpstream}
+              onEdit={(upstream, source) => {
+                morphSourceRef.current = source;
+                startMorph(() => setEditUpstream(upstream), {
+                  source,
+                  name: "morph-upstream-form",
+                  mode: "enter",
+                });
+              }}
+              onDelete={(upstream, source) => {
+                morphSourceRef.current = source;
+                startMorph(() => setDeleteUpstream(upstream), {
+                  source,
+                  name: "morph-upstream-delete",
+                  mode: "enter",
+                });
+              }}
               onTest={setTestUpstream}
               density={workbenchDensity}
               hasActiveFilters={hasActiveFilters}
@@ -398,18 +425,50 @@ export default function UpstreamsPage() {
         )}
       </div>
 
-      <UpstreamFormDialog open={createDialogOpen} onOpenChange={setCreateDialogOpen} />
+      <UpstreamFormDialog
+        open={createDialogOpen}
+        onOpenChange={(open) => {
+          if (open) {
+            setCreateDialogOpen(true);
+          } else {
+            startMorph(() => setCreateDialogOpen(false), {
+              source: morphSourceRef.current,
+              name: "morph-upstream-form",
+              mode: "exit",
+            });
+          }
+        }}
+        morph={canMorph}
+        morphName="morph-upstream-form"
+      />
 
       <UpstreamFormDialog
         upstream={editUpstream}
         open={!!editUpstream}
-        onOpenChange={(open) => !open && setEditUpstream(null)}
+        onOpenChange={(open) => {
+          if (!open) {
+            startMorph(() => setEditUpstream(null), {
+              source: morphSourceRef.current,
+              name: "morph-upstream-form",
+              mode: "exit",
+            });
+          }
+        }}
+        morph={canMorph}
+        morphName="morph-upstream-form"
       />
 
       <DeleteUpstreamDialog
         upstream={deleteUpstream}
         open={!!deleteUpstream}
-        onClose={() => setDeleteUpstream(null)}
+        onClose={() => {
+          startMorph(() => setDeleteUpstream(null), {
+            source: morphSourceRef.current,
+            name: "morph-upstream-delete",
+            mode: "exit",
+          });
+        }}
+        morph={canMorph}
       />
 
       <TestUpstreamDialog

--- a/src/app/[locale]/(portal)/portal/keys/page.tsx
+++ b/src/app/[locale]/(portal)/portal/keys/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Key, Plus } from "lucide-react";
 
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { usePortalKeys } from "@/hooks/use-portal-keys";
+import { useContainerMorph } from "@/hooks/use-container-morph";
 import type { APIKey } from "@/types/api";
 
 export default function PortalKeysPage() {
@@ -24,6 +25,10 @@ export default function PortalKeysPage() {
   const [editingKey, setEditingKey] = useState<APIKey | null>(null);
   const [revokeKey, setRevokeKey] = useState<APIKey | null>(null);
   const pageSize = 10;
+
+  // 容器变形动画：记录触发弹窗的源元素（创建按钮 / 表格行），关闭时收回同一元素。
+  const { startMorph, canMorph } = useContainerMorph();
+  const morphSourceRef = useRef<HTMLElement | null>(null);
 
   const { data, isLoading } = usePortalKeys(page, pageSize);
 
@@ -39,7 +44,18 @@ export default function PortalKeysPage() {
               {t("keys.managementDesc")}
             </span>
           </div>
-          <Button type="button" onClick={() => setCreateOpen(true)}>
+          <Button
+            type="button"
+            onClick={(event) => {
+              const source = event.currentTarget;
+              morphSourceRef.current = source;
+              startMorph(() => setCreateOpen(true), {
+                source,
+                name: "morph-portal-key-create",
+                mode: "enter",
+              });
+            }}
+          >
             <Plus className="mr-2 h-4 w-4" />
             {tKeys("createKey")}
           </Button>
@@ -61,8 +77,22 @@ export default function PortalKeysPage() {
           <>
             <PortalKeysTable
               keys={data?.items ?? []}
-              onEdit={setEditingKey}
-              onRevoke={setRevokeKey}
+              onEdit={(key, source) => {
+                morphSourceRef.current = source;
+                startMorph(() => setEditingKey(key), {
+                  source,
+                  name: "morph-portal-key-edit",
+                  mode: "enter",
+                });
+              }}
+              onRevoke={(key, source) => {
+                morphSourceRef.current = source;
+                startMorph(() => setRevokeKey(key), {
+                  source,
+                  name: "morph-portal-key-revoke",
+                  mode: "enter",
+                });
+              }}
             />
 
             {data && data.total_pages > 1 && (
@@ -80,19 +110,52 @@ export default function PortalKeysPage() {
         )}
       </div>
 
-      <PortalKeyDialog mode="create" open={createOpen} onOpenChange={setCreateOpen} />
+      <PortalKeyDialog
+        mode="create"
+        open={createOpen}
+        onOpenChange={(open) => {
+          if (open) {
+            setCreateOpen(true);
+          } else {
+            startMorph(() => setCreateOpen(false), {
+              source: morphSourceRef.current,
+              name: "morph-portal-key-create",
+              mode: "exit",
+            });
+          }
+        }}
+        morph={canMorph}
+        morphName="morph-portal-key-create"
+      />
 
       <PortalKeyDialog
         mode="edit"
         apiKey={editingKey}
         open={!!editingKey}
-        onOpenChange={(open) => !open && setEditingKey(null)}
+        onOpenChange={(open) => {
+          if (!open) {
+            startMorph(() => setEditingKey(null), {
+              source: morphSourceRef.current,
+              name: "morph-portal-key-edit",
+              mode: "exit",
+            });
+          }
+        }}
+        morph={canMorph}
+        morphName="morph-portal-key-edit"
       />
 
       <PortalRevokeKeyDialog
         apiKey={revokeKey}
         open={!!revokeKey}
-        onClose={() => setRevokeKey(null)}
+        onClose={() => {
+          startMorph(() => setRevokeKey(null), {
+            source: morphSourceRef.current,
+            name: "morph-portal-key-revoke",
+            mode: "exit",
+          });
+        }}
+        morph={canMorph}
       />
     </>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -817,7 +817,8 @@ html.theme-switching::before {
 ::view-transition-group(morph-compensation-delete),
 ::view-transition-group(morph-user-row),
 ::view-transition-group(morph-cliproxy-instance),
-::view-transition-group(morph-cliproxy-account) {
+::view-transition-group(morph-cliproxy-account),
+::view-transition-group(morph-billing-override-reset) {
   animation-duration: var(--vr-motion-normal);
   animation-timing-function: var(--vr-easing-standard);
 }
@@ -845,7 +846,9 @@ html.theme-switching::before {
 ::view-transition-old(morph-cliproxy-instance),
 ::view-transition-new(morph-cliproxy-instance),
 ::view-transition-old(morph-cliproxy-account),
-::view-transition-new(morph-cliproxy-account) {
+::view-transition-new(morph-cliproxy-account),
+::view-transition-old(morph-billing-override-reset),
+::view-transition-new(morph-billing-override-reset) {
   animation-duration: var(--vr-motion-normal);
   animation-timing-function: var(--vr-easing-standard);
   /* 源元素（小卡片 / 图标按钮）与弹窗长宽比差异大，用 cover 避免内容被拉伸变形 */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -809,7 +809,10 @@ html.theme-switching::before {
 ::view-transition-group(morph-upstream-form),
 ::view-transition-group(morph-upstream-delete),
 ::view-transition-group(morph-key-form),
-::view-transition-group(morph-key-revoke) {
+::view-transition-group(morph-key-revoke),
+::view-transition-group(morph-portal-key-create),
+::view-transition-group(morph-portal-key-edit),
+::view-transition-group(morph-portal-key-revoke) {
   animation-duration: var(--vr-motion-normal);
   animation-timing-function: var(--vr-easing-standard);
 }
@@ -821,7 +824,13 @@ html.theme-switching::before {
 ::view-transition-old(morph-key-form),
 ::view-transition-new(morph-key-form),
 ::view-transition-old(morph-key-revoke),
-::view-transition-new(morph-key-revoke) {
+::view-transition-new(morph-key-revoke),
+::view-transition-old(morph-portal-key-create),
+::view-transition-new(morph-portal-key-create),
+::view-transition-old(morph-portal-key-edit),
+::view-transition-new(morph-portal-key-edit),
+::view-transition-old(morph-portal-key-revoke),
+::view-transition-new(morph-portal-key-revoke) {
   animation-duration: var(--vr-motion-normal);
   animation-timing-function: var(--vr-easing-standard);
   /* 源元素（小卡片 / 图标按钮）与弹窗长宽比差异大，用 cover 避免内容被拉伸变形 */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -815,7 +815,9 @@ html.theme-switching::before {
 ::view-transition-group(morph-portal-key-revoke),
 ::view-transition-group(morph-compensation-form),
 ::view-transition-group(morph-compensation-delete),
-::view-transition-group(morph-user-row) {
+::view-transition-group(morph-user-row),
+::view-transition-group(morph-cliproxy-instance),
+::view-transition-group(morph-cliproxy-account) {
   animation-duration: var(--vr-motion-normal);
   animation-timing-function: var(--vr-easing-standard);
 }
@@ -839,7 +841,11 @@ html.theme-switching::before {
 ::view-transition-old(morph-compensation-delete),
 ::view-transition-new(morph-compensation-delete),
 ::view-transition-old(morph-user-row),
-::view-transition-new(morph-user-row) {
+::view-transition-new(morph-user-row),
+::view-transition-old(morph-cliproxy-instance),
+::view-transition-new(morph-cliproxy-instance),
+::view-transition-old(morph-cliproxy-account),
+::view-transition-new(morph-cliproxy-account) {
   animation-duration: var(--vr-motion-normal);
   animation-timing-function: var(--vr-easing-standard);
   /* 源元素（小卡片 / 图标按钮）与弹窗长宽比差异大，用 cover 避免内容被拉伸变形 */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -797,3 +797,36 @@ html.theme-switching::before {
     --vr-text-muted: var(--vr-text);
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * 容器变形（container transform）弹窗过渡
+ *
+ * 弹窗经由 useContainerMorph + DialogContent 的 morph 开关，给源元素（卡片 / 按钮）
+ * 和弹窗挂上同一个 view-transition-name，浏览器在两者之间插值位置、尺寸、圆角，并对
+ * 内容做 crossfade。这里把过渡时长与缓动对齐项目 motion 令牌；只对具名过渡设样式，
+ * 避免影响整页 root 快照。
+ * ------------------------------------------------------------------------- */
+::view-transition-group(morph-upstream-form),
+::view-transition-group(morph-upstream-delete) {
+  animation-duration: var(--vr-motion-normal);
+  animation-timing-function: var(--vr-easing-standard);
+}
+
+::view-transition-old(morph-upstream-form),
+::view-transition-new(morph-upstream-form),
+::view-transition-old(morph-upstream-delete),
+::view-transition-new(morph-upstream-delete) {
+  animation-duration: var(--vr-motion-normal);
+  animation-timing-function: var(--vr-easing-standard);
+  /* 源元素（小卡片 / 图标按钮）与弹窗长宽比差异大，用 cover 避免内容被拉伸变形 */
+  object-fit: cover;
+}
+
+/* 减少动态效果：直接关闭所有 View Transition 动画（hook 已会跳过 VT，此处双保险）。 */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -807,7 +807,9 @@ html.theme-switching::before {
  * 避免影响整页 root 快照。
  * ------------------------------------------------------------------------- */
 ::view-transition-group(morph-upstream-form),
-::view-transition-group(morph-upstream-delete) {
+::view-transition-group(morph-upstream-delete),
+::view-transition-group(morph-key-form),
+::view-transition-group(morph-key-revoke) {
   animation-duration: var(--vr-motion-normal);
   animation-timing-function: var(--vr-easing-standard);
 }
@@ -815,7 +817,11 @@ html.theme-switching::before {
 ::view-transition-old(morph-upstream-form),
 ::view-transition-new(morph-upstream-form),
 ::view-transition-old(morph-upstream-delete),
-::view-transition-new(morph-upstream-delete) {
+::view-transition-new(morph-upstream-delete),
+::view-transition-old(morph-key-form),
+::view-transition-new(morph-key-form),
+::view-transition-old(morph-key-revoke),
+::view-transition-new(morph-key-revoke) {
   animation-duration: var(--vr-motion-normal);
   animation-timing-function: var(--vr-easing-standard);
   /* 源元素（小卡片 / 图标按钮）与弹窗长宽比差异大，用 cover 避免内容被拉伸变形 */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -814,7 +814,8 @@ html.theme-switching::before {
 ::view-transition-group(morph-portal-key-edit),
 ::view-transition-group(morph-portal-key-revoke),
 ::view-transition-group(morph-compensation-form),
-::view-transition-group(morph-compensation-delete) {
+::view-transition-group(morph-compensation-delete),
+::view-transition-group(morph-user-row) {
   animation-duration: var(--vr-motion-normal);
   animation-timing-function: var(--vr-easing-standard);
 }
@@ -836,7 +837,9 @@ html.theme-switching::before {
 ::view-transition-old(morph-compensation-form),
 ::view-transition-new(morph-compensation-form),
 ::view-transition-old(morph-compensation-delete),
-::view-transition-new(morph-compensation-delete) {
+::view-transition-new(morph-compensation-delete),
+::view-transition-old(morph-user-row),
+::view-transition-new(morph-user-row) {
   animation-duration: var(--vr-motion-normal);
   animation-timing-function: var(--vr-easing-standard);
   /* 源元素（小卡片 / 图标按钮）与弹窗长宽比差异大，用 cover 避免内容被拉伸变形 */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -812,7 +812,9 @@ html.theme-switching::before {
 ::view-transition-group(morph-key-revoke),
 ::view-transition-group(morph-portal-key-create),
 ::view-transition-group(morph-portal-key-edit),
-::view-transition-group(morph-portal-key-revoke) {
+::view-transition-group(morph-portal-key-revoke),
+::view-transition-group(morph-compensation-form),
+::view-transition-group(morph-compensation-delete) {
   animation-duration: var(--vr-motion-normal);
   animation-timing-function: var(--vr-easing-standard);
 }
@@ -830,7 +832,11 @@ html.theme-switching::before {
 ::view-transition-old(morph-portal-key-edit),
 ::view-transition-new(morph-portal-key-edit),
 ::view-transition-old(morph-portal-key-revoke),
-::view-transition-new(morph-portal-key-revoke) {
+::view-transition-new(morph-portal-key-revoke),
+::view-transition-old(morph-compensation-form),
+::view-transition-new(morph-compensation-form),
+::view-transition-old(morph-compensation-delete),
+::view-transition-new(morph-compensation-delete) {
   animation-duration: var(--vr-motion-normal);
   animation-timing-function: var(--vr-easing-standard);
   /* 源元素（小卡片 / 图标按钮）与弹窗长宽比差异大，用 cover 避免内容被拉伸变形 */

--- a/src/components/admin/assign-user-keys-dialog.tsx
+++ b/src/components/admin/assign-user-keys-dialog.tsx
@@ -21,12 +21,22 @@ interface AssignUserKeysDialogProps {
   user: User;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** 启用容器变形动画（View Transition）。 */
+  morph?: boolean;
+  /** 容器变形使用的 view-transition-name，须与 CSS 具名过渡对应。 */
+  morphName?: string;
 }
 
 /**
  * 分配密钥对话框：把已有 API 密钥的归属人设置为该用户。分配生效后用户列表的密钥数随之更新。
  */
-export function AssignUserKeysDialog({ user, open, onOpenChange }: AssignUserKeysDialogProps) {
+export function AssignUserKeysDialog({
+  user,
+  open,
+  onOpenChange,
+  morph = false,
+  morphName = "morph-user-row",
+}: AssignUserKeysDialogProps) {
   const { data, isLoading } = useAPIKeys(1, 100);
   const assignMutation = useAssignApiKeyOwner();
   const t = useTranslations("users");
@@ -52,7 +62,7 @@ export function AssignUserKeysDialog({ user, open, onOpenChange }: AssignUserKey
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg" morph={morph} morphName={morphName}>
         <DialogHeader>
           <DialogTitle>{t("assignKeysTitle")}</DialogTitle>
           <DialogDescription>{t("assignKeysDesc")}</DialogDescription>

--- a/src/components/admin/change-username-dialog.tsx
+++ b/src/components/admin/change-username-dialog.tsx
@@ -31,12 +31,22 @@ interface ChangeUsernameDialogProps {
   user: User;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** 启用容器变形动画（View Transition）。 */
+  morph?: boolean;
+  /** 容器变形使用的 view-transition-name，须与 CSS 具名过渡对应。 */
+  morphName?: string;
 }
 
 /**
  * 修改用户名对话框：为用户设置新的登录用户名，唯一性冲突由服务端返回 409 提示。
  */
-export function ChangeUsernameDialog({ user, open, onOpenChange }: ChangeUsernameDialogProps) {
+export function ChangeUsernameDialog({
+  user,
+  open,
+  onOpenChange,
+  morph = false,
+  morphName = "morph-user-row",
+}: ChangeUsernameDialogProps) {
   const mutation = useChangeUsername();
   const t = useTranslations("users");
   const tCommon = useTranslations("common");
@@ -66,7 +76,7 @@ export function ChangeUsernameDialog({ user, open, onOpenChange }: ChangeUsernam
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md" morph={morph} morphName={morphName}>
         <DialogHeader>
           <DialogTitle>{t("changeUsernameTitle")}</DialogTitle>
           <DialogDescription>{t("changeUsernameDesc")}</DialogDescription>

--- a/src/components/admin/cliproxy-account-detail-dialog.tsx
+++ b/src/components/admin/cliproxy-account-detail-dialog.tsx
@@ -17,6 +17,9 @@ interface CliproxyAccountDetailDialogProps {
   account: CliproxyAuthAccount;
   open: boolean;
   onClose: () => void;
+  /** 启用容器变形动画时，由调用方传入与源元素一致的 view-transition-name。 */
+  morph?: boolean;
+  morphName?: string;
 }
 
 /** 将可空字符串渲染为占位符。 */
@@ -43,6 +46,8 @@ export function CliproxyAccountDetailDialog({
   account,
   open,
   onClose,
+  morph,
+  morphName = "morph-cliproxy-account",
 }: CliproxyAccountDetailDialogProps) {
   const t = useTranslations("cliproxy");
   const tCommon = useTranslations("common");
@@ -55,7 +60,7 @@ export function CliproxyAccountDetailDialog({
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-2xl" morph={morph} morphName={morphName}>
         <DialogHeader>
           <DialogTitle>{t("accountDetailDialogTitle")}</DialogTitle>
           <DialogDescription>

--- a/src/components/admin/cliproxy-account-fields-dialog.tsx
+++ b/src/components/admin/cliproxy-account-fields-dialog.tsx
@@ -32,6 +32,9 @@ interface CliproxyAccountFieldsDialogProps {
   account: CliproxyAuthAccount;
   open: boolean;
   onClose: () => void;
+  /** 启用容器变形动画时，由调用方传入与源元素一致的 view-transition-name。 */
+  morph?: boolean;
+  morphName?: string;
 }
 
 interface FieldsForm {
@@ -51,6 +54,8 @@ export function CliproxyAccountFieldsDialog({
   account,
   open,
   onClose,
+  morph,
+  morphName = "morph-cliproxy-account",
 }: CliproxyAccountFieldsDialogProps) {
   const t = useTranslations("cliproxy");
   const tCommon = useTranslations("common");
@@ -101,7 +106,7 @@ export function CliproxyAccountFieldsDialog({
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg" morph={morph} morphName={morphName}>
         <DialogHeader>
           <DialogTitle>{t("editAccountFieldsTitle")}</DialogTitle>
           <DialogDescription>

--- a/src/components/admin/cliproxy-accounts-panel.tsx
+++ b/src/components/admin/cliproxy-accounts-panel.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { LogIn, RefreshCw, Upload } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useContainerMorph } from "@/hooks/use-container-morph";
 import {
   useCliproxyAuthAccounts,
   useDownloadCliproxyAuthFile,
@@ -44,6 +45,11 @@ export function CliproxyAccountsPanel({ instance }: CliproxyAccountsPanelProps) 
   const [mapAccount, setMapAccount] = useState<CliproxyAuthAccount | null>(null);
   const [oauthOpen, setOauthOpen] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);
+
+  // 容器变形动画：查看详情 / 编辑字段 / 删除从账号行展开、关闭收回。
+  // 三者互斥（同一时刻只开一个），共用单个 view-transition-name。
+  const { startMorph, canMorph } = useContainerMorph();
+  const morphSourceRef = useRef<HTMLElement | null>(null);
 
   const handleToggleStatus = (account: CliproxyAuthAccount) => {
     statusMutation.mutate({
@@ -105,12 +111,33 @@ export function CliproxyAccountsPanel({ instance }: CliproxyAccountsPanelProps) 
           <CliproxyAccountsTable
             accounts={accounts}
             onToggleStatus={handleToggleStatus}
-            onEditFields={setEditAccount}
+            onEditFields={(account, source) => {
+              morphSourceRef.current = source;
+              startMorph(() => setEditAccount(account), {
+                source,
+                name: "morph-cliproxy-account",
+                mode: "enter",
+              });
+            }}
             onMapUpstream={setMapAccount}
-            onViewDetail={setDetailAccount}
+            onViewDetail={(account, source) => {
+              morphSourceRef.current = source;
+              startMorph(() => setDetailAccount(account), {
+                source,
+                name: "morph-cliproxy-account",
+                mode: "enter",
+              });
+            }}
             onViewModels={setModelsAccount}
             onDownload={handleDownload}
-            onDelete={setDeleteAccount}
+            onDelete={(account, source) => {
+              morphSourceRef.current = source;
+              startMorph(() => setDeleteAccount(account), {
+                source,
+                name: "morph-cliproxy-account",
+                mode: "enter",
+              });
+            }}
           />
         )}
       </CardContent>
@@ -120,14 +147,30 @@ export function CliproxyAccountsPanel({ instance }: CliproxyAccountsPanelProps) 
           instanceId={instance.id}
           account={editAccount}
           open
-          onClose={() => setEditAccount(null)}
+          onClose={() =>
+            startMorph(() => setEditAccount(null), {
+              source: morphSourceRef.current,
+              name: "morph-cliproxy-account",
+              mode: "exit",
+            })
+          }
+          morph={canMorph}
+          morphName="morph-cliproxy-account"
         />
       )}
       {detailAccount && (
         <CliproxyAccountDetailDialog
           account={detailAccount}
           open
-          onClose={() => setDetailAccount(null)}
+          onClose={() =>
+            startMorph(() => setDetailAccount(null), {
+              source: morphSourceRef.current,
+              name: "morph-cliproxy-account",
+              mode: "exit",
+            })
+          }
+          morph={canMorph}
+          morphName="morph-cliproxy-account"
         />
       )}
       {modelsAccount && (
@@ -163,7 +206,15 @@ export function CliproxyAccountsPanel({ instance }: CliproxyAccountsPanelProps) 
       <CliproxyDeleteAuthFileDialog
         instanceId={instance.id}
         account={deleteAccount}
-        onClose={() => setDeleteAccount(null)}
+        onClose={() =>
+          startMorph(() => setDeleteAccount(null), {
+            source: morphSourceRef.current,
+            name: "morph-cliproxy-account",
+            mode: "exit",
+          })
+        }
+        morph={canMorph}
+        morphName="morph-cliproxy-account"
       />
     </Card>
   );

--- a/src/components/admin/cliproxy-accounts-table.tsx
+++ b/src/components/admin/cliproxy-accounts-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import {
   Boxes,
   Download,
@@ -34,12 +35,12 @@ import type { CliproxyAuthAccount } from "@/types/cliproxy";
 interface CliproxyAccountsTableProps {
   accounts: CliproxyAuthAccount[];
   onToggleStatus: (account: CliproxyAuthAccount) => void;
-  onEditFields: (account: CliproxyAuthAccount) => void;
+  onEditFields: (account: CliproxyAuthAccount, source: HTMLElement | null) => void;
   onMapUpstream: (account: CliproxyAuthAccount) => void;
-  onViewDetail: (account: CliproxyAuthAccount) => void;
+  onViewDetail: (account: CliproxyAuthAccount, source: HTMLElement | null) => void;
   onViewModels: (account: CliproxyAuthAccount) => void;
   onDownload: (account: CliproxyAuthAccount) => void;
-  onDelete: (account: CliproxyAuthAccount) => void;
+  onDelete: (account: CliproxyAuthAccount, source: HTMLElement | null) => void;
 }
 
 /**
@@ -60,6 +61,11 @@ export function CliproxyAccountsTable({
 }: CliproxyAccountsTableProps) {
   const t = useTranslations("cliproxy");
 
+  // 操作入口在 DropdownMenu（内容经 Portal 挂到 body，closest 取不到行），
+  // 按账号 id 收集行元素，作为查看详情/编辑字段/删除弹窗的容器变形源。
+  const rowRefs = useRef<Map<string, HTMLTableRowElement>>(new Map());
+  const rowSource = (id: string) => rowRefs.current.get(id) ?? null;
+
   return (
     <Table>
       <TableHeader>
@@ -75,7 +81,17 @@ export function CliproxyAccountsTable({
       </TableHeader>
       <TableBody>
         {accounts.map((account) => (
-          <TableRow key={account.id}>
+          <TableRow
+            key={account.id}
+            data-morph-source
+            ref={(el) => {
+              if (el) {
+                rowRefs.current.set(account.id, el);
+              } else {
+                rowRefs.current.delete(account.id);
+              }
+            }}
+          >
             <TableCell className="font-medium">{account.auth_file_name}</TableCell>
             <TableCell>
               <Badge variant="info">{account.provider}</Badge>
@@ -122,7 +138,7 @@ export function CliproxyAccountsTable({
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={() => onViewDetail(account)}>
+                  <DropdownMenuItem onClick={() => onViewDetail(account, rowSource(account.id))}>
                     <Info className="mr-2 h-4 w-4" />
                     {t("actionViewDetail")}
                   </DropdownMenuItem>
@@ -138,7 +154,7 @@ export function CliproxyAccountsTable({
                     )}
                     {account.disabled ? t("actionEnable") : t("actionDisable")}
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => onEditFields(account)}>
+                  <DropdownMenuItem onClick={() => onEditFields(account, rowSource(account.id))}>
                     <Pencil className="mr-2 h-4 w-4" />
                     {t("actionEditFields")}
                   </DropdownMenuItem>
@@ -151,7 +167,7 @@ export function CliproxyAccountsTable({
                     {t("actionDownload")}
                   </DropdownMenuItem>
                   <DropdownMenuItem
-                    onClick={() => onDelete(account)}
+                    onClick={() => onDelete(account, rowSource(account.id))}
                     className={cn("text-destructive focus:text-destructive")}
                   >
                     <Trash2 className="mr-2 h-4 w-4" />

--- a/src/components/admin/cliproxy-delete-auth-file-dialog.tsx
+++ b/src/components/admin/cliproxy-delete-auth-file-dialog.tsx
@@ -17,6 +17,9 @@ interface CliproxyDeleteAuthFileDialogProps {
   instanceId: string;
   account: CliproxyAuthAccount | null;
   onClose: () => void;
+  /** 启用容器变形动画时，由调用方传入与源元素一致的 view-transition-name。 */
+  morph?: boolean;
+  morphName?: string;
 }
 
 /**
@@ -27,6 +30,8 @@ export function CliproxyDeleteAuthFileDialog({
   instanceId,
   account,
   onClose,
+  morph,
+  morphName = "morph-cliproxy-account",
 }: CliproxyDeleteAuthFileDialogProps) {
   const t = useTranslations("cliproxy");
   const tCommon = useTranslations("common");
@@ -47,7 +52,7 @@ export function CliproxyDeleteAuthFileDialog({
 
   return (
     <Dialog open={Boolean(account)} onOpenChange={(next) => !next && onClose()}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md" morph={morph} morphName={morphName}>
         <DialogHeader>
           <DialogTitle>{t("deleteAuthFileTitle")}</DialogTitle>
           <DialogDescription>{t("deleteAuthFileDescription")}</DialogDescription>

--- a/src/components/admin/cliproxy-instance-form-dialog.tsx
+++ b/src/components/admin/cliproxy-instance-form-dialog.tsx
@@ -54,6 +54,9 @@ interface CliproxyInstanceFormDialogProps {
   instance?: CliproxyInstance | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** 启用容器变形动画时，由调用方传入与源元素一致的 view-transition-name。 */
+  morph?: boolean;
+  morphName?: string;
 }
 
 interface FormValues {
@@ -89,6 +92,8 @@ export function CliproxyInstanceFormDialog({
   instance,
   open,
   onOpenChange,
+  morph,
+  morphName = "morph-cliproxy-instance",
 }: CliproxyInstanceFormDialogProps) {
   const t = useTranslations("cliproxy");
   const tCommon = useTranslations("common");
@@ -173,7 +178,11 @@ export function CliproxyInstanceFormDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[calc(100vh-2rem)] max-w-xl flex-col overflow-hidden p-0">
+      <DialogContent
+        className="flex max-h-[calc(100vh-2rem)] max-w-xl flex-col overflow-hidden p-0"
+        morph={morph}
+        morphName={morphName}
+      >
         <DialogHeader className="shrink-0 px-6 pb-0 pr-12 pt-6">
           <DialogTitle>{isEdit ? t("editInstanceTitle") : t("createInstanceTitle")}</DialogTitle>
           <DialogDescription>{t("pageDescription")}</DialogDescription>

--- a/src/components/admin/cliproxy-instances-table.tsx
+++ b/src/components/admin/cliproxy-instances-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import { Boxes, MoreHorizontal, Pencil, PlugZap, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
@@ -27,10 +28,10 @@ interface CliproxyInstancesTableProps {
   instances: CliproxyInstance[];
   selectedInstanceId: string | null;
   onSelect: (instance: CliproxyInstance) => void;
-  onEdit: (instance: CliproxyInstance) => void;
+  onEdit: (instance: CliproxyInstance, source: HTMLElement | null) => void;
   onTest: (instance: CliproxyInstance) => void;
   onCreatePoolUpstream: (instance: CliproxyInstance) => void;
-  onDelete: (instance: CliproxyInstance) => void;
+  onDelete: (instance: CliproxyInstance, source: HTMLElement | null) => void;
 }
 
 /**
@@ -49,6 +50,11 @@ export function CliproxyInstancesTable({
   const t = useTranslations("cliproxy");
   const toggleEnabled = useToggleCliproxyInstanceEnabled();
 
+  // 操作入口在 DropdownMenu（内容经 Portal 挂到 body，closest 取不到行），
+  // 按实例 id 收集行元素，作为编辑/删除弹窗的容器变形源。
+  const rowRefs = useRef<Map<string, HTMLTableRowElement>>(new Map());
+  const rowSource = (id: string) => rowRefs.current.get(id) ?? null;
+
   return (
     <Table>
       <TableHeader>
@@ -64,6 +70,14 @@ export function CliproxyInstancesTable({
         {instances.map((instance) => (
           <TableRow
             key={instance.id}
+            data-morph-source
+            ref={(el) => {
+              if (el) {
+                rowRefs.current.set(instance.id, el);
+              } else {
+                rowRefs.current.delete(instance.id);
+              }
+            }}
             onClick={() => onSelect(instance)}
             data-state={selectedInstanceId === instance.id ? "selected" : undefined}
             className="cursor-pointer"
@@ -115,12 +129,12 @@ export function CliproxyInstancesTable({
                     <Boxes className="mr-2 h-4 w-4" />
                     {t("actionCreatePoolUpstream")}
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => onEdit(instance)}>
+                  <DropdownMenuItem onClick={() => onEdit(instance, rowSource(instance.id))}>
                     <Pencil className="mr-2 h-4 w-4" />
                     {t("actionEdit")}
                   </DropdownMenuItem>
                   <DropdownMenuItem
-                    onClick={() => onDelete(instance)}
+                    onClick={() => onDelete(instance, rowSource(instance.id))}
                     className={cn("text-destructive focus:text-destructive")}
                   >
                     <Trash2 className="mr-2 h-4 w-4" />

--- a/src/components/admin/delete-cliproxy-instance-dialog.tsx
+++ b/src/components/admin/delete-cliproxy-instance-dialog.tsx
@@ -18,6 +18,9 @@ interface DeleteCliproxyInstanceDialogProps {
   instance: CliproxyInstance | null;
   open: boolean;
   onClose: () => void;
+  /** 启用容器变形动画时，由调用方传入与源元素一致的 view-transition-name。 */
+  morph?: boolean;
+  morphName?: string;
 }
 
 /**
@@ -27,6 +30,8 @@ export function DeleteCliproxyInstanceDialog({
   instance,
   open,
   onClose,
+  morph,
+  morphName = "morph-cliproxy-instance",
 }: DeleteCliproxyInstanceDialogProps) {
   const t = useTranslations("cliproxy");
   const tCommon = useTranslations("common");
@@ -50,7 +55,7 @@ export function DeleteCliproxyInstanceDialog({
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md" morph={morph} morphName={morphName}>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <AlertTriangle className="h-5 w-5 text-amber-500" aria-hidden />

--- a/src/components/admin/delete-upstream-dialog.tsx
+++ b/src/components/admin/delete-upstream-dialog.tsx
@@ -18,12 +18,19 @@ interface DeleteUpstreamDialogProps {
   upstream: Upstream | null;
   open: boolean;
   onClose: () => void;
+  /** 启用容器变形动画（View Transition）。 */
+  morph?: boolean;
 }
 
 /**
  * M3 Delete Upstream Confirmation Dialog
  */
-export function DeleteUpstreamDialog({ upstream, open, onClose }: DeleteUpstreamDialogProps) {
+export function DeleteUpstreamDialog({
+  upstream,
+  open,
+  onClose,
+  morph = false,
+}: DeleteUpstreamDialogProps) {
   const deleteMutation = useDeleteUpstream();
   const t = useTranslations("upstreams");
   const tCommon = useTranslations("common");
@@ -49,7 +56,7 @@ export function DeleteUpstreamDialog({ upstream, open, onClose }: DeleteUpstream
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md" morph={morph} morphName="morph-upstream-delete">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-3">
             <div className="w-10 h-10 rounded-[var(--shape-corner-medium)] bg-[rgb(var(--md-sys-color-error-container))] flex items-center justify-center">

--- a/src/components/admin/delete-user-dialog.tsx
+++ b/src/components/admin/delete-user-dialog.tsx
@@ -19,12 +19,22 @@ interface DeleteUserDialogProps {
   user: User | null;
   open: boolean;
   onClose: () => void;
+  /** 启用容器变形动画（View Transition）。 */
+  morph?: boolean;
+  /** 容器变形使用的 view-transition-name，须与 CSS 具名过渡对应。 */
+  morphName?: string;
 }
 
 /**
  * 删除用户确认对话框：删除后其名下密钥被解除归属但保留，最后一个启用管理员由服务端兜底拒绝。
  */
-export function DeleteUserDialog({ user, open, onClose }: DeleteUserDialogProps) {
+export function DeleteUserDialog({
+  user,
+  open,
+  onClose,
+  morph = false,
+  morphName = "morph-user-row",
+}: DeleteUserDialogProps) {
   const mutation = useDeleteUser();
   const t = useTranslations("users");
   const tCommon = useTranslations("common");
@@ -43,7 +53,7 @@ export function DeleteUserDialog({ user, open, onClose }: DeleteUserDialogProps)
 
   return (
     <AlertDialog open={open} onOpenChange={(next) => !next && onClose()}>
-      <AlertDialogContent>
+      <AlertDialogContent morph={morph} morphName={morphName}>
         <AlertDialogHeader>
           <AlertDialogTitle>{t("deleteUserTitle")}</AlertDialogTitle>
           <AlertDialogDescription>

--- a/src/components/admin/edit-key-dialog.tsx
+++ b/src/components/admin/edit-key-dialog.tsx
@@ -65,12 +65,22 @@ interface EditKeyDialogProps {
   apiKey: APIKeyResponse;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** 启用容器变形动画（View Transition）。 */
+  morph?: boolean;
+  /** 容器变形使用的 view-transition-name，须与 CSS 具名过渡对应。 */
+  morphName?: string;
 }
 
 /**
  * Edit API Key Dialog
  */
-export function EditKeyDialog({ apiKey, open, onOpenChange }: EditKeyDialogProps) {
+export function EditKeyDialog({
+  apiKey,
+  open,
+  onOpenChange,
+  morph = false,
+  morphName = "morph-key-form",
+}: EditKeyDialogProps) {
   const updateMutation = useUpdateAPIKey();
   const [upstreamSearchQuery, setUpstreamSearchQuery] = useState("");
   const [spendingRuleDrafts, setSpendingRuleDrafts] = useState<Record<string, string>>({});
@@ -276,6 +286,8 @@ export function EditKeyDialog({ apiKey, open, onOpenChange }: EditKeyDialogProps
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         className="flex max-h-[calc(100vh-2rem)] max-w-2xl flex-col overflow-hidden p-0"
+        morph={morph}
+        morphName={morphName}
         onOpenAutoFocus={(event) => {
           event.preventDefault();
           (event.currentTarget as HTMLElement).focus();

--- a/src/components/admin/edit-user-dialog.tsx
+++ b/src/components/admin/edit-user-dialog.tsx
@@ -41,6 +41,10 @@ interface EditUserDialogProps {
   onOpenChange: (open: boolean) => void;
   /** 该用户是当前可见数据中唯一启用的管理员时，锁定角色与启用状态以避免误操作。 */
   isLastActiveAdmin?: boolean;
+  /** 启用容器变形动画（View Transition）。 */
+  morph?: boolean;
+  /** 容器变形使用的 view-transition-name，须与 CSS 具名过渡对应。 */
+  morphName?: string;
 }
 
 /**
@@ -51,6 +55,8 @@ export function EditUserDialog({
   open,
   onOpenChange,
   isLastActiveAdmin = false,
+  morph = false,
+  morphName = "morph-user-row",
 }: EditUserDialogProps) {
   const updateMutation = useUpdateUser();
   const t = useTranslations("users");
@@ -92,7 +98,7 @@ export function EditUserDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md" morph={morph} morphName={morphName}>
         <DialogHeader>
           <DialogTitle>{t("editUserTitle")}</DialogTitle>
           <DialogDescription>{t("editUserDesc")}</DialogDescription>

--- a/src/components/admin/keys-table.tsx
+++ b/src/components/admin/keys-table.tsx
@@ -25,8 +25,8 @@ import { cn } from "@/lib/utils";
 
 interface KeysTableProps {
   keys: APIKey[];
-  onRevoke: (key: APIKey) => void;
-  onEdit: (key: APIKey) => void;
+  onRevoke: (key: APIKey, source: HTMLElement | null) => void;
+  onEdit: (key: APIKey, source: HTMLElement | null) => void;
 }
 
 function formatAccessModeLabel(key: APIKey, t: ReturnType<typeof useTranslations>): string {
@@ -366,6 +366,7 @@ export function KeysTable({ keys, onRevoke, onEdit }: KeysTableProps) {
           {filteredKeys.map((key) => (
             <div
               key={key.id}
+              data-morph-source
               className="space-y-3 rounded-cf-md border border-divider bg-surface-200/70 p-3"
             >
               <div className="flex items-start justify-between gap-2">
@@ -494,7 +495,9 @@ export function KeysTable({ keys, onRevoke, onEdit }: KeysTableProps) {
                     size="icon"
                     type="button"
                     className="h-8 w-8"
-                    onClick={() => onEdit(key)}
+                    onClick={(event) =>
+                      onEdit(key, event.currentTarget.closest<HTMLElement>("[data-morph-source]"))
+                    }
                     aria-label={`${t("editKey")}: ${key.name} (mobile)`}
                   >
                     <Pencil className="h-4 w-4" aria-hidden="true" />
@@ -504,7 +507,9 @@ export function KeysTable({ keys, onRevoke, onEdit }: KeysTableProps) {
                     size="icon"
                     type="button"
                     className="h-8 w-8 text-status-error hover:bg-status-error-muted"
-                    onClick={() => onRevoke(key)}
+                    onClick={(event) =>
+                      onRevoke(key, event.currentTarget.closest<HTMLElement>("[data-morph-source]"))
+                    }
                     aria-label={`${t("revokeKey")}: ${key.name} (mobile)`}
                   >
                     <Trash2 className="h-4 w-4" aria-hidden="true" />
@@ -538,7 +543,10 @@ export function KeysTable({ keys, onRevoke, onEdit }: KeysTableProps) {
                 const isExpanded = expandedKeys.has(key.id);
                 return (
                   <Fragment key={key.id}>
-                    <TableRow className={cn(hasQuota && isExpanded && "[&>td]:border-b-0")}>
+                    <TableRow
+                      data-morph-source
+                      className={cn(hasQuota && isExpanded && "[&>td]:border-b-0")}
+                    >
                       <TableCell
                         className={cn("max-w-[200px] font-medium", hasQuota && "cursor-pointer")}
                         onClick={() => hasQuota && toggleExpand(key.id)}
@@ -675,7 +683,12 @@ export function KeysTable({ keys, onRevoke, onEdit }: KeysTableProps) {
                             size="icon"
                             type="button"
                             className="h-8 w-8"
-                            onClick={() => onEdit(key)}
+                            onClick={(event) =>
+                              onEdit(
+                                key,
+                                event.currentTarget.closest<HTMLElement>("[data-morph-source]")
+                              )
+                            }
                             aria-label={`${t("editKey")}: ${key.name}`}
                           >
                             <Pencil className="h-4 w-4" aria-hidden="true" />
@@ -685,7 +698,12 @@ export function KeysTable({ keys, onRevoke, onEdit }: KeysTableProps) {
                             size="icon"
                             type="button"
                             className="h-8 w-8 text-status-error hover:bg-status-error-muted"
-                            onClick={() => onRevoke(key)}
+                            onClick={(event) =>
+                              onRevoke(
+                                key,
+                                event.currentTarget.closest<HTMLElement>("[data-morph-source]")
+                              )
+                            }
                             aria-label={`${t("revokeKey")}: ${key.name}`}
                           >
                             <Trash2 className="h-4 w-4" aria-hidden="true" />

--- a/src/components/admin/reset-password-dialog.tsx
+++ b/src/components/admin/reset-password-dialog.tsx
@@ -31,12 +31,22 @@ interface ResetPasswordDialogProps {
   user: User;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** 启用容器变形动画（View Transition）。 */
+  morph?: boolean;
+  /** 容器变形使用的 view-transition-name，须与 CSS 具名过渡对应。 */
+  morphName?: string;
 }
 
 /**
  * 重置密码对话框：管理员为用户设置新密码，用户在下次登录时使用。
  */
-export function ResetPasswordDialog({ user, open, onOpenChange }: ResetPasswordDialogProps) {
+export function ResetPasswordDialog({
+  user,
+  open,
+  onOpenChange,
+  morph = false,
+  morphName = "morph-user-row",
+}: ResetPasswordDialogProps) {
   const mutation = useResetUserPassword();
   const t = useTranslations("users");
   const tCommon = useTranslations("common");
@@ -67,7 +77,7 @@ export function ResetPasswordDialog({ user, open, onOpenChange }: ResetPasswordD
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md" morph={morph} morphName={morphName}>
         <DialogHeader>
           <DialogTitle>{t("resetPasswordTitle")}</DialogTitle>
           <DialogDescription>{t("resetPasswordDesc")}</DialogDescription>

--- a/src/components/admin/revoke-key-dialog.tsx
+++ b/src/components/admin/revoke-key-dialog.tsx
@@ -18,12 +18,14 @@ interface RevokeKeyDialogProps {
   apiKey: APIKey | null;
   open: boolean;
   onClose: () => void;
+  /** 启用容器变形动画（View Transition）。 */
+  morph?: boolean;
 }
 
 /**
  * M3 Revoke API Key Confirmation Dialog
  */
-export function RevokeKeyDialog({ apiKey, open, onClose }: RevokeKeyDialogProps) {
+export function RevokeKeyDialog({ apiKey, open, onClose, morph = false }: RevokeKeyDialogProps) {
   const revokeMutation = useRevokeAPIKey();
   const t = useTranslations("keys");
   const tCommon = useTranslations("common");
@@ -49,7 +51,7 @@ export function RevokeKeyDialog({ apiKey, open, onClose }: RevokeKeyDialogProps)
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md" morph={morph} morphName="morph-key-revoke">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-3">
             <div className="w-10 h-10 rounded-[var(--shape-corner-medium)] bg-[rgb(var(--md-sys-color-error-container))] flex items-center justify-center">

--- a/src/components/admin/upstream-failure-rules-editor.tsx
+++ b/src/components/admin/upstream-failure-rules-editor.tsx
@@ -267,9 +267,9 @@ export function UpstreamFailureRulesEditor({
   scope = "upstream",
 }: UpstreamFailureRulesEditorProps) {
   const t = useTranslations("upstreams");
-  const tErrorType = useTranslations("requestLogs.retryErrorType");
+  const tErrorType = useTranslations("logs");
   const getErrorTypeLabel = useCallback(
-    (type: FailoverErrorType) => tErrorType(type),
+    (type: FailoverErrorType) => tErrorType(`retryErrorType.${type}`),
     [tErrorType]
   );
   const unknownTooltip = t("failureRuleErrorTypeUnknownTooltip");

--- a/src/components/admin/upstream-form-dialog.tsx
+++ b/src/components/admin/upstream-form-dialog.tsx
@@ -123,6 +123,10 @@ interface UpstreamFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   trigger?: React.ReactNode;
+  /** 启用容器变形动画（View Transition）。 */
+  morph?: boolean;
+  /** 容器变形使用的 view-transition-name，需与触发它的源元素一致。 */
+  morphName?: string;
 }
 
 // Circuit breaker config schema
@@ -1072,6 +1076,8 @@ export function UpstreamFormDialog({
   open,
   onOpenChange,
   trigger,
+  morph = false,
+  morphName = "morph-upstream-form",
 }: UpstreamFormDialogProps) {
   const isEdit = !!upstream;
   const activeSchema = isEdit ? editUpstreamFormSchema : createUpstreamFormSchema;
@@ -2019,6 +2025,8 @@ export function UpstreamFormDialog({
   const dialogContent = (
     <DialogContent
       className="h-[92vh] max-w-6xl overflow-hidden p-0"
+      morph={morph}
+      morphName={morphName}
       onOpenAutoFocus={(event) => {
         event.preventDefault();
         (event.currentTarget as HTMLElement).focus();

--- a/src/components/admin/upstreams-table.tsx
+++ b/src/components/admin/upstreams-table.tsx
@@ -23,8 +23,8 @@ import { RouteCapabilityBadges } from "@/components/admin/route-capability-badge
 
 interface UpstreamsTableProps {
   upstreams: Upstream[];
-  onEdit: (upstream: Upstream) => void;
-  onDelete: (upstream: Upstream) => void;
+  onEdit: (upstream: Upstream, source: HTMLElement | null) => void;
+  onDelete: (upstream: Upstream, source: HTMLElement | null) => void;
   onTest: (upstream: Upstream) => void;
   density?: "comfortable" | "compact";
   hasActiveFilters?: boolean;
@@ -586,6 +586,7 @@ export function UpstreamsTable({
                     return (
                       <article
                         key={upstream.id}
+                        data-morph-source
                         className={cn(
                           "w-full min-w-0 max-w-full overflow-hidden rounded-cf-md border bg-card shadow-[var(--vr-shadow-sm)]",
                           "transition-[transform,box-shadow,border-color,opacity,filter] duration-300 ease-cf-standard",
@@ -689,7 +690,12 @@ export function UpstreamsTable({
                                 "border-divider bg-surface-200",
                                 isCompactDensity ? "h-7 w-7" : "h-8 w-8"
                               )}
-                              onClick={() => onEdit(upstream)}
+                              onClick={(event) =>
+                                onEdit(
+                                  upstream,
+                                  event.currentTarget.closest<HTMLElement>("[data-morph-source]")
+                                )
+                              }
                               aria-label={`${tCommon("edit")}: ${upstream.name}`}
                             >
                               <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
@@ -724,7 +730,12 @@ export function UpstreamsTable({
                                 "border-status-error/45 bg-status-error-muted text-status-error",
                                 isCompactDensity ? "h-7 w-7" : "h-8 w-8"
                               )}
-                              onClick={() => onDelete(upstream)}
+                              onClick={(event) =>
+                                onDelete(
+                                  upstream,
+                                  event.currentTarget.closest<HTMLElement>("[data-morph-source]")
+                                )
+                              }
                               aria-label={`${tCommon("delete")}: ${upstream.name}`}
                             >
                               <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />

--- a/src/components/admin/user-upstreams-dialog.tsx
+++ b/src/components/admin/user-upstreams-dialog.tsx
@@ -23,12 +23,22 @@ interface UserUpstreamsDialogProps {
   user: User;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** 启用容器变形动画（View Transition）。 */
+  morph?: boolean;
+  /** 容器变形使用的 view-transition-name，须与 CSS 具名过渡对应。 */
+  morphName?: string;
 }
 
 /**
  * 配置可用上游对话框：选择该用户的密钥允许路由到的上游集合，整体替换保存。
  */
-export function UserUpstreamsDialog({ user, open, onOpenChange }: UserUpstreamsDialogProps) {
+export function UserUpstreamsDialog({
+  user,
+  open,
+  onOpenChange,
+  morph = false,
+  morphName = "morph-user-row",
+}: UserUpstreamsDialogProps) {
   const { data: currentUpstreams, isLoading: currentLoading } = useUserUpstreams(user.id, open);
   const { data: allUpstreams, isLoading: allLoading } = useAllUpstreams();
   const setMutation = useSetUserUpstreams();
@@ -79,7 +89,7 @@ export function UserUpstreamsDialog({ user, open, onOpenChange }: UserUpstreamsD
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg" morph={morph} morphName={morphName}>
         <DialogHeader>
           <DialogTitle>{t("configureUpstreamsTitle")}</DialogTitle>
           <DialogDescription>{t("configureUpstreamsDesc")}</DialogDescription>

--- a/src/components/admin/users-table.tsx
+++ b/src/components/admin/users-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import { formatDistanceToNow } from "date-fns";
 import { useLocale, useTranslations } from "next-intl";
 import {
@@ -42,12 +43,12 @@ interface UsersTableProps {
   activeAdminCount: number;
   /** 调用者是否为 ADMIN_TOKEN 超级令牌；为真时豁免“最后一个启用管理员”的禁用。 */
   bypassLastAdminGuard?: boolean;
-  onEdit: (user: User) => void;
-  onChangeUsername: (user: User) => void;
-  onResetPassword: (user: User) => void;
-  onConfigureUpstreams: (user: User) => void;
-  onAssignKeys: (user: User) => void;
-  onDelete: (user: User) => void;
+  onEdit: (user: User, source: HTMLElement | null) => void;
+  onChangeUsername: (user: User, source: HTMLElement | null) => void;
+  onResetPassword: (user: User, source: HTMLElement | null) => void;
+  onConfigureUpstreams: (user: User, source: HTMLElement | null) => void;
+  onAssignKeys: (user: User, source: HTMLElement | null) => void;
+  onDelete: (user: User, source: HTMLElement | null) => void;
 }
 
 /**
@@ -70,6 +71,11 @@ export function UsersTable({
   const t = useTranslations("users");
   const locale = useLocale();
   const dateLocale = getDateLocale(locale);
+
+  // 操作入口都在 DropdownMenu 内（菜单内容经 Portal 挂到 body，无法用 closest 取到行），
+  // 因此按 user.id 收集每一行元素，作为容器变形动画的源元素。
+  const rowRefs = useRef<Map<string, HTMLTableRowElement>>(new Map());
+  const rowSource = (id: string) => rowRefs.current.get(id) ?? null;
 
   const isLastActiveAdmin = (user: User) =>
     !bypassLastAdminGuard && user.role === "admin" && user.is_active && activeAdminCount <= 1;
@@ -116,7 +122,17 @@ export function UsersTable({
           {users.map((user) => {
             const lastAdmin = isLastActiveAdmin(user);
             return (
-              <TableRow key={user.id}>
+              <TableRow
+                key={user.id}
+                data-morph-source
+                ref={(el) => {
+                  if (el) {
+                    rowRefs.current.set(user.id, el);
+                  } else {
+                    rowRefs.current.delete(user.id);
+                  }
+                }}
+              >
                 <TableCell className="font-medium">{user.username}</TableCell>
                 <TableCell>{user.display_name}</TableCell>
                 <TableCell>
@@ -168,29 +184,31 @@ export function UsersTable({
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end" className="w-52">
-                      <DropdownMenuItem onClick={() => onEdit(user)}>
+                      <DropdownMenuItem onClick={() => onEdit(user, rowSource(user.id))}>
                         <Pencil className="mr-2 h-4 w-4" aria-hidden="true" />
                         {t("edit")}
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => onChangeUsername(user)}>
+                      <DropdownMenuItem onClick={() => onChangeUsername(user, rowSource(user.id))}>
                         <UserCog className="mr-2 h-4 w-4" aria-hidden="true" />
                         {t("changeUsername")}
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => onResetPassword(user)}>
+                      <DropdownMenuItem onClick={() => onResetPassword(user, rowSource(user.id))}>
                         <KeyRound className="mr-2 h-4 w-4" aria-hidden="true" />
                         {t("resetPassword")}
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => onConfigureUpstreams(user)}>
+                      <DropdownMenuItem
+                        onClick={() => onConfigureUpstreams(user, rowSource(user.id))}
+                      >
                         <Server className="mr-2 h-4 w-4" aria-hidden="true" />
                         {t("configureUpstreams")}
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => onAssignKeys(user)}>
+                      <DropdownMenuItem onClick={() => onAssignKeys(user, rowSource(user.id))}>
                         <Link2 className="mr-2 h-4 w-4" aria-hidden="true" />
                         {t("assignKeys")}
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
-                        onClick={() => onDelete(user)}
+                        onClick={() => onDelete(user, rowSource(user.id))}
                         disabled={lastAdmin}
                         className="text-status-error focus:text-status-error"
                       >

--- a/src/components/portal/portal-key-dialog.tsx
+++ b/src/components/portal/portal-key-dialog.tsx
@@ -47,6 +47,10 @@ interface PortalKeyDialogProps {
   apiKey?: APIKey | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** 启用容器变形动画（View Transition）。 */
+  morph?: boolean;
+  /** 容器变形使用的 view-transition-name，须与 CSS 具名过渡对应。 */
+  morphName?: string;
 }
 
 function toSpendingRuleDrafts(rules: APIKeySpendingRule[] | null | undefined): SpendingRuleDraft[] {
@@ -63,13 +67,24 @@ function toSpendingRuleDrafts(rules: APIKeySpendingRule[] | null | undefined): S
  * admin-granted set, and spending rules can only be tightened (the server
  * rejects any relaxation).
  */
-export function PortalKeyDialog({ mode, apiKey, open, onOpenChange }: PortalKeyDialogProps) {
+export function PortalKeyDialog({
+  mode,
+  apiKey,
+  open,
+  onOpenChange,
+  morph = false,
+  morphName = "morph-portal-key-form",
+}: PortalKeyDialogProps) {
   const [createdKey, setCreatedKey] = useState<APIKeyCreateResponse | null>(null);
 
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="flex max-h-[calc(100vh-2rem)] max-w-xl flex-col overflow-hidden p-0">
+        <DialogContent
+          className="flex max-h-[calc(100vh-2rem)] max-w-xl flex-col overflow-hidden p-0"
+          morph={morph}
+          morphName={morphName}
+        >
           {/* Remounting the body per open/key resets the form without effects. */}
           {open && (
             <PortalKeyDialogBody

--- a/src/components/portal/portal-keys-table.tsx
+++ b/src/components/portal/portal-keys-table.tsx
@@ -22,8 +22,8 @@ import type { APIKey } from "@/types/api";
 
 interface PortalKeysTableProps {
   keys: APIKey[];
-  onEdit: (key: APIKey) => void;
-  onRevoke: (key: APIKey) => void;
+  onEdit: (key: APIKey, source: HTMLElement | null) => void;
+  onRevoke: (key: APIKey, source: HTMLElement | null) => void;
 }
 
 function maskKeyPrefix(keyPrefix: string): string {
@@ -76,7 +76,7 @@ export function PortalKeysTable({ keys, onEdit, onRevoke }: PortalKeysTableProps
       </TableHeader>
       <TableBody>
         {keys.map((key) => (
-          <TableRow key={key.id}>
+          <TableRow key={key.id} data-morph-source>
             <TableCell>
               <div className="min-w-0">
                 <p className="truncate type-body-medium text-foreground">{key.name}</p>
@@ -146,7 +146,9 @@ export function PortalKeysTable({ keys, onEdit, onRevoke }: PortalKeysTableProps
                   type="button"
                   variant="ghost"
                   size="icon"
-                  onClick={() => onEdit(key)}
+                  onClick={(event) =>
+                    onEdit(key, event.currentTarget.closest<HTMLElement>("[data-morph-source]"))
+                  }
                   aria-label={t("editKey")}
                   title={t("editKey")}
                 >
@@ -157,7 +159,9 @@ export function PortalKeysTable({ keys, onEdit, onRevoke }: PortalKeysTableProps
                   variant="ghost"
                   size="icon"
                   className="text-destructive hover:text-destructive"
-                  onClick={() => onRevoke(key)}
+                  onClick={(event) =>
+                    onRevoke(key, event.currentTarget.closest<HTMLElement>("[data-morph-source]"))
+                  }
                   aria-label={t("revokeKey")}
                   title={t("revokeKey")}
                 >

--- a/src/components/portal/portal-revoke-key-dialog.tsx
+++ b/src/components/portal/portal-revoke-key-dialog.tsx
@@ -19,12 +19,19 @@ interface PortalRevokeKeyDialogProps {
   apiKey: APIKey | null;
   open: boolean;
   onClose: () => void;
+  /** 启用容器变形动画（View Transition）。 */
+  morph?: boolean;
 }
 
 /**
  * Confirmation dialog for deleting one of the caller's own API keys.
  */
-export function PortalRevokeKeyDialog({ apiKey, open, onClose }: PortalRevokeKeyDialogProps) {
+export function PortalRevokeKeyDialog({
+  apiKey,
+  open,
+  onClose,
+  morph = false,
+}: PortalRevokeKeyDialogProps) {
   const t = useTranslations("keys");
   const tCommon = useTranslations("common");
   const deleteMutation = useDeletePortalKey();
@@ -42,7 +49,7 @@ export function PortalRevokeKeyDialog({ apiKey, open, onClose }: PortalRevokeKey
 
   return (
     <AlertDialog open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
-      <AlertDialogContent>
+      <AlertDialogContent morph={morph} morphName="morph-portal-key-revoke">
         <AlertDialogHeader>
           <AlertDialogTitle>{t("revokeKeyTitle")}</AlertDialogTitle>
           <AlertDialogDescription>{t("revokeKeyDesc")}</AlertDialogDescription>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -31,8 +31,11 @@ AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content> & {
+    morph?: boolean;
+    morphName?: string;
+  }
+>(({ className, morph = false, morphName = "morph-alert-dialog", style, ...props }, ref) => (
   <AlertDialogPortal>
     <AlertDialogOverlay />
     <AlertDialogPrimitive.Content
@@ -42,13 +45,17 @@ const AlertDialogContent = React.forwardRef<
         "gap-6 p-6 rounded-cf-sm",
         "bg-surface-300 border-2 border-amber-500 shadow-cf-glow-subtle",
         "duration-cf-normal ease-cf-standard",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out",
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
-        "data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%]",
-        "data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+        // 走容器变形（View Transition）时关闭默认 zoom/slide 进出场，运动交给 VT 接管
+        !morph && [
+          "data-[state=open]:animate-in data-[state=closed]:animate-out",
+          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          "data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%]",
+          "data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+        ],
         className
       )}
+      style={morph ? { viewTransitionName: morphName, ...style } : style}
       {...props}
     />
   </AlertDialogPortal>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -33,8 +33,11 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => {
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    morph?: boolean;
+    morphName?: string;
+  }
+>(({ className, children, morph = false, morphName = "morph-dialog", style, ...props }, ref) => {
   warnIfForbiddenVisualStyle("DialogContent", className);
   return (
     <DialogPortal>
@@ -45,13 +48,17 @@ const DialogContent = React.forwardRef<
           "fixed left-1/2 top-1/2 z-50 grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2",
           "gap-5 rounded-cf-md border border-border bg-card p-6 text-foreground shadow-[var(--vr-shadow-lg)]",
           "duration-cf-normal ease-cf-standard",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out",
-          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-          "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
-          "data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%]",
-          "data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+          // 走容器变形（View Transition）时关闭默认 zoom/slide 进出场，运动交给 VT 接管
+          !morph && [
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+            "data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%]",
+            "data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+          ],
           className
         )}
+        style={morph ? { viewTransitionName: morphName, ...style } : style}
         {...props}
       >
         {children}

--- a/src/hooks/use-container-morph.ts
+++ b/src/hooks/use-container-morph.ts
@@ -1,0 +1,138 @@
+"use client";
+
+import * as React from "react";
+import { flushSync } from "react-dom";
+
+/**
+ * 容器变形（container transform）动画 hook。
+ *
+ * 基于浏览器原生 View Transitions API（`document.startViewTransition`），
+ * 让弹窗从触发它的源元素（卡片 / 按钮）「变形」展开、关闭时再「收」回该元素，
+ * 类似手机上点开应用图标展开成全屏的效果。不依赖任何 JS 动画库。
+ *
+ * 核心约束是 `view-transition-name` 的快照时序唯一性：
+ * `startViewTransition(cb)` 在调用瞬间捕获「旧」快照、在 cb 执行完捕获「新」快照，
+ * 同一帧里每个 name 必须唯一。弹窗的 name 由 `DialogContent` 渲染时自带，
+ * 源元素的 name 由本 hook 临时挂载，两者不能在同一帧同时带同名，
+ * 因此 enter / exit 两个方向需要分别编排 name 的设置时机（见 startMorph）。
+ */
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+const VIEW_TRANSITION_NAME_PROPERTY = "view-transition-name";
+
+/** 浏览器原生 ViewTransition 的最小子集，避免依赖 TS DOM lib 版本。 */
+interface ViewTransitionLike {
+  finished: Promise<void>;
+  ready: Promise<void>;
+  updateCallbackDone: Promise<void>;
+  skipTransition(): void;
+}
+
+type DocumentWithViewTransition = Document & {
+  startViewTransition?: (callback: () => void) => ViewTransitionLike;
+};
+
+function subscribeToReducedMotion(callback: () => void) {
+  const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+  mediaQuery.addEventListener("change", callback);
+  return () => mediaQuery.removeEventListener("change", callback);
+}
+
+function getReducedMotionSnapshot() {
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+/** enter：源元素 → 弹窗；exit：弹窗 → 源元素。 */
+export type MorphMode = "enter" | "exit";
+
+export interface StartMorphOptions {
+  /** enter 时为触发弹窗的源元素、exit 时为收回的目标元素（通常是同一张卡片 / 同一个按钮）。 */
+  source?: HTMLElement | null;
+  /** 与目标弹窗 `DialogContent` 的 `morphName` 一致的 `view-transition-name`。 */
+  name: string;
+  /** 决定 name 在 `startViewTransition` 回调内外的设置时机。 */
+  mode: MorphMode;
+}
+
+export function useContainerMorph() {
+  const prefersReducedMotion = React.useSyncExternalStore(
+    subscribeToReducedMotion,
+    getReducedMotionSnapshot,
+    getServerSnapshot
+  );
+
+  // 记录当前临时挂了 view-transition-name 的源元素，确保任何出口都能清理，杜绝 name 泄漏。
+  const taggedElementRef = React.useRef<HTMLElement | null>(null);
+
+  const clearSourceName = React.useCallback(() => {
+    const element = taggedElementRef.current;
+    if (element) {
+      element.style.removeProperty(VIEW_TRANSITION_NAME_PROPERTY);
+      taggedElementRef.current = null;
+    }
+  }, []);
+
+  const setSourceName = React.useCallback(
+    (source: HTMLElement | null | undefined, name: string) => {
+      clearSourceName();
+      if (source) {
+        source.style.setProperty(VIEW_TRANSITION_NAME_PROPERTY, name);
+        taggedElementRef.current = source;
+      }
+    },
+    [clearSourceName]
+  );
+
+  const canMorph =
+    !prefersReducedMotion &&
+    typeof document !== "undefined" &&
+    typeof (document as DocumentWithViewTransition).startViewTransition === "function";
+
+  const startMorph = React.useCallback(
+    (apply: () => void, options: StartMorphOptions) => {
+      const doc = typeof document !== "undefined" ? (document as DocumentWithViewTransition) : null;
+
+      // 不支持 View Transitions 或用户偏好减少动态效果：直接同步应用，无动画。
+      if (!doc?.startViewTransition || prefersReducedMotion) {
+        apply();
+        return;
+      }
+
+      const { source, name, mode } = options;
+
+      if (mode === "enter") {
+        // enter：旧快照里只有源元素带 name（弹窗尚未挂载）。
+        setSourceName(source, name);
+      } else {
+        // exit：旧快照里 name 在弹窗上，源元素此刻不能带同名，先清掉任何残留。
+        clearSourceName();
+      }
+
+      const transition = doc.startViewTransition(() => {
+        flushSync(apply);
+        // flushSync 之后、新快照之前，把 name 调整到正确的一端：
+        if (mode === "enter") {
+          // 弹窗已挂载并自带 name；源元素必须放弃 name，避免新快照里出现双 name。
+          clearSourceName();
+        } else {
+          // 弹窗已卸载（name 随之消失）；把 name 交给源元素作为新快照端点。
+          setSourceName(source, name);
+        }
+      });
+
+      transition.finished.finally(() => {
+        clearSourceName();
+      });
+    },
+    [clearSourceName, prefersReducedMotion, setSourceName]
+  );
+
+  // 组件卸载时兜底清理。
+  React.useEffect(() => clearSourceName, [clearSourceName]);
+
+  return { startMorph, canMorph } as const;
+}

--- a/tests/components/cliproxy-accounts-table.test.tsx
+++ b/tests/components/cliproxy-accounts-table.test.tsx
@@ -117,6 +117,20 @@ describe("CliproxyAccountsTable", () => {
     expect(handlers.onDelete).toHaveBeenCalledTimes(1);
   });
 
+  it("查看详情 / 编辑字段 / 删除回调附带行元素作为容器变形源", () => {
+    const handlers = setup();
+
+    fireEvent.click(screen.getByText("actionViewDetail"));
+    fireEvent.click(screen.getByText("actionEditFields"));
+    fireEvent.click(screen.getByText("actionDelete"));
+
+    for (const handler of [handlers.onViewDetail, handlers.onEditFields, handlers.onDelete]) {
+      expect(handler).toHaveBeenCalledWith(expect.anything(), expect.any(HTMLElement));
+      const source = handler.mock.calls[0][1] as HTMLElement;
+      expect(source.hasAttribute("data-morph-source")).toBe(true);
+    }
+  });
+
   it("禁用状态下菜单展示 actionEnable", () => {
     setup({ disabled: true });
     expect(screen.getByText("actionEnable")).toBeInTheDocument();

--- a/tests/components/keys-table.test.tsx
+++ b/tests/components/keys-table.test.tsx
@@ -349,7 +349,10 @@ describe("KeysTable", () => {
       const deleteButton = screen.getByLabelText("revokeKey: Test API Key");
       fireEvent.click(deleteButton);
 
-      expect(mockOnRevoke).toHaveBeenCalledWith(mockKey);
+      expect(mockOnRevoke).toHaveBeenCalledWith(mockKey, expect.any(HTMLElement));
+      // 容器变形动画需要源元素：表格行须带 data-morph-source 供按钮 closest 取到。
+      const source = mockOnRevoke.mock.calls[0][1] as HTMLElement;
+      expect(source.hasAttribute("data-morph-source")).toBe(true);
     });
   });
 
@@ -405,7 +408,10 @@ describe("KeysTable", () => {
       const editButton = screen.getByLabelText("editKey: Test API Key");
       fireEvent.click(editButton);
 
-      expect(mockOnEdit).toHaveBeenCalledWith(mockKey);
+      expect(mockOnEdit).toHaveBeenCalledWith(mockKey, expect.any(HTMLElement));
+      // 容器变形动画需要源元素：表格行须带 data-morph-source 供按钮 closest 取到。
+      const source = mockOnEdit.mock.calls[0][1] as HTMLElement;
+      expect(source.hasAttribute("data-morph-source")).toBe(true);
     });
   });
 

--- a/tests/components/portal/portal-keys-table.test.tsx
+++ b/tests/components/portal/portal-keys-table.test.tsx
@@ -70,10 +70,14 @@ describe("PortalKeysTable", () => {
     render(<PortalKeysTable keys={[key]} onEdit={onEdit} onRevoke={onRevoke} />);
 
     fireEvent.click(screen.getByRole("button", { name: "keys.editKey" }));
-    expect(onEdit).toHaveBeenCalledWith(key);
+    expect(onEdit).toHaveBeenCalledWith(key, expect.any(HTMLElement));
 
     fireEvent.click(screen.getByRole("button", { name: "keys.revokeKey" }));
-    expect(onRevoke).toHaveBeenCalledWith(key);
+    expect(onRevoke).toHaveBeenCalledWith(key, expect.any(HTMLElement));
+
+    // 容器变形动画需要源元素：表格行须带 data-morph-source 供按钮 closest 取到。
+    const editSource = onEdit.mock.calls[0][1] as HTMLElement;
+    expect(editSource.hasAttribute("data-morph-source")).toBe(true);
   });
 
   it("toggles the active state through the portal mutation", () => {

--- a/tests/components/upstream-failure-rules-editor.test.tsx
+++ b/tests/components/upstream-failure-rules-editor.test.tsx
@@ -170,7 +170,9 @@ describe("UpstreamFailureRulesEditor", () => {
     expect(screen.getByText("failureRuleStatusCodes")).toBeInTheDocument();
     expect(screen.getByText("502, 503")).toBeInTheDocument();
     expect(screen.getByText("failureRuleErrorTypes")).toBeInTheDocument();
-    expect(screen.getByText("timeout")).toBeInTheDocument();
+    // getErrorTypeLabel 走 logs.retryErrorType.<type>；mock 直接回显 key 路径，
+    // 生产环境下经真实 next-intl 解析为本地化文案（如「超时」/「timeout」）。
+    expect(screen.getByText("retryErrorType.timeout")).toBeInTheDocument();
     expect(screen.getByText("failureRuleBodyPattern")).toBeInTheDocument();
     expect(screen.getByText("/overloaded/")).toBeInTheDocument();
     expect(screen.getByText("failureRuleHeaderPattern")).toBeInTheDocument();

--- a/tests/components/upstreams-table.test.tsx
+++ b/tests/components/upstreams-table.test.tsx
@@ -374,7 +374,10 @@ describe("UpstreamsTable", () => {
 
     expect(screen.queryByLabelText("test: OpenAI Main")).not.toBeInTheDocument();
     expect(onTest).not.toHaveBeenCalled();
-    expect(onEdit).toHaveBeenCalledWith(baseUpstream);
+    expect(onEdit).toHaveBeenCalledWith(baseUpstream, expect.any(HTMLElement));
+    // 容器变形动画的源元素应锚定到卡片（带 data-morph-source）
+    const [, editSource] = onEdit.mock.calls[0];
+    expect(editSource).toHaveAttribute("data-morph-source");
   });
 
   it("supports delete action directly", async () => {
@@ -390,8 +393,11 @@ describe("UpstreamsTable", () => {
     fireEvent.click(screen.getByLabelText("delete: OpenAI Main"));
 
     await waitFor(() => {
-      expect(onDelete).toHaveBeenCalledWith(baseUpstream);
+      expect(onDelete).toHaveBeenCalledWith(baseUpstream, expect.any(HTMLElement));
     });
+    // 删除确认弹窗同样从卡片变形展开
+    const [, deleteSource] = onDelete.mock.calls[0];
+    expect(deleteSource).toHaveAttribute("data-morph-source");
   });
 
   it("shows circuit recover action when circuit is open", async () => {

--- a/tests/components/users-table.test.tsx
+++ b/tests/components/users-table.test.tsx
@@ -139,9 +139,13 @@ describe("UsersTable", () => {
     render(<UsersTable users={[user]} activeAdminCount={0} {...handlers} />);
 
     fireEvent.click(screen.getByRole("button", { name: "edit" }));
-    expect(handlers.onEdit).toHaveBeenCalledWith(user);
+    expect(handlers.onEdit).toHaveBeenCalledWith(user, expect.any(HTMLElement));
 
     fireEvent.click(screen.getByRole("button", { name: "deleteUser" }));
-    expect(handlers.onDelete).toHaveBeenCalledWith(user);
+    expect(handlers.onDelete).toHaveBeenCalledWith(user, expect.any(HTMLElement));
+
+    // 容器变形动画需要源元素：下拉操作以所在行（带 data-morph-source）为变形源。
+    const source = handlers.onEdit.mock.calls[0][1] as HTMLElement;
+    expect(source.hasAttribute("data-morph-source")).toBe(true);
   });
 });

--- a/tests/unit/hooks/use-container-morph.test.ts
+++ b/tests/unit/hooks/use-container-morph.test.ts
@@ -1,0 +1,137 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useContainerMorph } from "@/hooks/use-container-morph";
+
+const NAME_PROP = "view-transition-name";
+
+type StartViewTransition = (callback: () => void) => {
+  finished: Promise<void>;
+  ready: Promise<void>;
+  updateCallbackDone: Promise<void>;
+  skipTransition: () => void;
+};
+
+interface DocumentWithViewTransition extends Document {
+  startViewTransition?: StartViewTransition;
+}
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+/** 注入一个同步执行回调的 startViewTransition 桩，返回该桩的 spy。 */
+function stubViewTransition(finished: Promise<void> = Promise.resolve()) {
+  const start = vi.fn((callback: () => void) => {
+    callback();
+    return {
+      finished,
+      ready: Promise.resolve(),
+      updateCallbackDone: Promise.resolve(),
+      skipTransition: vi.fn(),
+    };
+  });
+  (document as DocumentWithViewTransition).startViewTransition = start as StartViewTransition;
+  return start;
+}
+
+describe("useContainerMorph", () => {
+  let originalMatchMedia: typeof window.matchMedia;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    delete (document as DocumentWithViewTransition).startViewTransition;
+    vi.restoreAllMocks();
+  });
+
+  function setReducedMotion(matches: boolean) {
+    window.matchMedia = ((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+  }
+
+  it("无 startViewTransition 时降级为同步执行，且不残留 view-transition-name", () => {
+    // jsdom 默认没有 document.startViewTransition
+    const { result } = renderHook(() => useContainerMorph());
+    expect(result.current.canMorph).toBe(false);
+
+    const source = document.createElement("div");
+    const apply = vi.fn();
+    act(() => {
+      result.current.startMorph(apply, { source, name: "morph-test", mode: "enter" });
+    });
+
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(source.style.getPropertyValue(NAME_PROP)).toBe("");
+  });
+
+  it("enter：调用 startViewTransition 并应用变更，新快照前已清除源元素 name", () => {
+    const start = stubViewTransition();
+    const { result } = renderHook(() => useContainerMorph());
+    expect(result.current.canMorph).toBe(true);
+
+    const source = document.createElement("div");
+    const apply = vi.fn();
+    act(() => {
+      result.current.startMorph(apply, { source, name: "morph-test", mode: "enter" });
+    });
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledTimes(1);
+    // enter 下弹窗挂载后自带 name，源元素必须在新快照前放弃 name，避免双 name 冲突。
+    expect(source.style.getPropertyValue(NAME_PROP)).toBe("");
+  });
+
+  it("exit：回调执行后源元素带 name 作为新快照端点，finished 后清除", async () => {
+    const deferred = createDeferred();
+    const start = stubViewTransition(deferred.promise);
+    const { result } = renderHook(() => useContainerMorph());
+
+    const source = document.createElement("div");
+    const apply = vi.fn();
+    act(() => {
+      result.current.startMorph(apply, { source, name: "morph-test", mode: "exit" });
+    });
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledTimes(1);
+    // finished 尚未 resolve：exit 下源元素应带 name（弹窗已卸载，name 交给源元素）。
+    expect(source.style.getPropertyValue(NAME_PROP)).toBe("morph-test");
+
+    await act(async () => {
+      deferred.resolve();
+    });
+    await waitFor(() => expect(source.style.getPropertyValue(NAME_PROP)).toBe(""));
+  });
+
+  it("reduced-motion 时 canMorph 为 false 且跳过 View Transition", () => {
+    setReducedMotion(true);
+    const start = stubViewTransition();
+    const { result } = renderHook(() => useContainerMorph());
+    expect(result.current.canMorph).toBe(false);
+
+    const source = document.createElement("div");
+    const apply = vi.fn();
+    act(() => {
+      result.current.startMorph(apply, { source, name: "morph-test", mode: "enter" });
+    });
+
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(start).not.toHaveBeenCalled();
+    expect(source.style.getPropertyValue(NAME_PROP)).toBe("");
+  });
+});

--- a/tests/unit/i18n/failover-error-type-labels.test.tsx
+++ b/tests/unit/i18n/failover-error-type-labels.test.tsx
@@ -1,0 +1,58 @@
+import { render } from "@testing-library/react";
+import { NextIntlClientProvider, useTranslations } from "next-intl";
+import { describe, expect, it } from "vitest";
+
+import enMessages from "@/messages/en.json";
+import zhCNMessages from "@/messages/zh-CN.json";
+import { FAILOVER_ERROR_TYPES } from "@/lib/constants/failover-error-types";
+import type { FailoverErrorType } from "@/types/api";
+
+const LOCALES = [
+  { locale: "en", messages: enMessages },
+  { locale: "zh-CN", messages: zhCNMessages },
+] as const;
+
+/**
+ * 复刻 `upstream-failure-rules-editor.tsx` 中 `getErrorTypeLabel` 的确切调用形态：
+ * `useTranslations("logs")` + `t(`retryErrorType.${type}`)`。
+ *
+ * editor 自身的组件测试 mock 了 next-intl，无法暴露 namespace 写错（曾误用不存在的
+ * `requestLogs` 顶层 namespace、且这个 next-intl 版本不支持 namespace 内含点号）。
+ * 这里用真实的 next-intl + 真实消息文件做契约测试，确保每个故障类型在两种语言下都能
+ * 解析出真实译文，而不是回退成原始 key 路径。
+ */
+function ErrorTypeLabels() {
+  const t = useTranslations("logs");
+  return (
+    <ul>
+      {FAILOVER_ERROR_TYPES.map((type: FailoverErrorType) => (
+        <li key={type} data-testid={`label-${type}`}>
+          {t(`retryErrorType.${type}`)}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+describe("故障类型标签的 i18n 解析", () => {
+  for (const { locale, messages } of LOCALES) {
+    it(`在 ${locale} 下每个 FAILOVER_ERROR_TYPES 都解析为真实译文`, () => {
+      const retryErrorType = (messages as { logs: { retryErrorType: Record<string, string> } }).logs
+        .retryErrorType;
+
+      const { getByTestId } = render(
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <ErrorTypeLabels />
+        </NextIntlClientProvider>
+      );
+
+      for (const type of FAILOVER_ERROR_TYPES) {
+        const rendered = getByTestId(`label-${type}`).textContent;
+        // 与消息文件中的取值逐一对齐：既验证 namespace 解析正确，也验证译文完整。
+        expect(rendered).toBe(retryErrorType[type]);
+        // 防回退：不得渲染成原始 key 路径（namespace 写错时 next-intl 的回退形态）。
+        expect(rendered).not.toBe(`retryErrorType.${type}`);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary

给管理后台的「从卡片 / 列表行点开的 编辑·查看·删除·新建」弹窗接入「容器变形」（container transform）动画：点某张卡片的编辑，弹窗从那张卡片的位置和形状「长」出来；关闭时再「收」回原处——动画从哪儿来就回哪儿去，类似手机上点开应用图标展开成全屏的效果。

实现基于浏览器原生 **View Transitions API**（`document.startViewTransition` + `flushSync` + CSS `view-transition-name`），**不引入任何 JS 动画库**，契合本项目刻意保持的零 JS 动画库栈。不支持 View Transitions 的浏览器或开启「减少动态效果」时，自动回退到现有 zoom/slide 动画，而非瞬时弹出。

## Related Issue

无（UI 体验增强，无关联 issue）。

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Tests (adding or updating tests)

## Changes

**基础设施**

- 新增 `useContainerMorph` hook（`src/hooks/use-container-morph.ts`）：暴露 `startMorph(apply, { source, name, mode })` 与 `canMorph`。按 `view-transition-name` 快照时序唯一性约束，分别编排 enter（源元素→弹窗）与 exit（弹窗→源元素）两个方向 name 的设置/清除时机，并用 `transition.finished.finally` + 卸载 effect 三重兜底杜绝 name 泄漏。reduced-motion 检测复用项目已验证的 `useSyncExternalStore` + `matchMedia` 模式，SSR / jsdom 安全。
- `Dialog` / `AlertDialog` 原语（`src/components/ui/dialog.tsx`、`alert-dialog.tsx`）新增可选 `morph` / `morphName`：开启时去掉默认 `animate-in/out` + `zoom` + `slide` 运动类（保留布局与居中、把运动交给 VT），并在 style 上设 `view-transition-name`。默认关闭，现有 30+ 处调用零行为变化。

**接入域**（弹窗 state 承载页 + 触发表格/卡片 + 弹窗组件三层接线）

- 上游 upstreams（编辑 / 新建 / 删除 / 测试连接，作为完整样板）
- API 密钥 keys（编辑 / 撤销）
- 会员门户 portal 密钥（新建 / 编辑 / 撤销）
- 头部补偿规则 header-compensation（新建 / 编辑 / 删除）
- 用户管理 users（编辑 / 改用户名 / 重置密码 / 配置上游 / 分配密钥 / 删除）
- CLIProxyAPI cliproxy（实例新建/编辑/删除、账号查看详情/编辑字段/删除）
- 计费 billing（价格覆盖重置/删除确认）

直接位于行 / 卡片内的按钮用 `event.currentTarget.closest("[data-morph-source]")` 取源；操作入口在 DropdownMenu（内容经 Radix Portal 挂到 `<body>`，closest 取不到行）的域（users、cliproxy）改用按实体 id 收集行元素的 ref-map 取源。同一页面同一时刻只开一个弹窗，故多个互斥弹窗共用单个 `view-transition-name`。

**判定边界**：仅接入「从某个实体的行/卡片点开、针对该实体本身的 编辑/查看/删除/新建」弹窗；连接测试、OAuth 登录、上传文件、上游映射、模型列表、批量操作、登出确认等流程/操作类弹窗不接入。

**i18n 顺带修复**：故障规则编辑器把 `useTranslations("requestLogs.retryErrorType")` 改为 `useTranslations("logs")` + `t("retryErrorType.${type}")`，修正 `MISSING_MESSAGE` 控制台报错（`requestLogs` 顶层 namespace 不存在，且 next-intl 不支持带点号的 namespace），并补真实 next-intl + 真实 messages 的契约回归测试。

- `src/app/globals.css`：为各具名过渡配置时长/缓动（对齐项目 motion 令牌），对源元素与大表单长宽比差异用 `object-fit: cover` 避免内容拉伸；reduced-motion 下整体关闭 VT 动画兜底。

## Test Plan

- [x] 全量单元/组件测试通过（`pnpm test:run`）：196 个测试文件、3001 passed / 1 skipped
- [x] 类型检查通过（`pnpm exec tsc --noEmit`）
- [x] Lint / 格式通过（改动文件 `eslint` + `prettier --check` 全绿；提交均经 pre-commit 的 prettier/eslint/tsc 钩子）
- [x] 手动测试：上游域样板已在浏览器确认手感（卡片→弹窗变形展开、关闭收回原位），其余域复用同一 hook 与同一接线模式

新增/更新测试：`use-container-morph` hook 单测、各表格组件回调附带源元素的回归断言、`failover-error-type-labels` i18n 契约测试、upstream-morph E2E。

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [ ] Documentation has been updated (if applicable)（纯 UI 行为增强，无需文档变更）
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Additional Notes

- 选用原生 View Transitions 而非 framer-motion `layoutId` 的关键原因：VT 在全页面快照层面工作，源卡片在列表里、弹窗经 Radix Portal 挂在 `<body>`，二者不在同一 DOM 树也能 morph，恰好绕开 Radix Portal 这一最大障碍；且零运行时依赖。
- 降级路径已覆盖：`morph={canMorph}` 透传，不支持 VT 或 reduced-motion 时保留现有 zoom/slide 动画。
