### PR TITLE
fix(responsive): 修复弹层矮屏、落地页 Hero、平板宽表与排行榜窄屏溢出

### DIFF
--- a/src/app/[locale]/(dashboard)/system/traffic-recording/page.tsx
+++ b/src/app/[locale]/(dashboard)/system/traffic-recording/page.tsx
@@ -190,6 +190,61 @@ export default function TrafficRecordingPage() {
     setSelectedId((current) => (current === recordingId ? null : current));
   };
 
+  // 表格行与窄屏卡片共用同一套操作按钮（查看详情 / 跳源日志 / 删除含二次确认），避免重复实现
+  const renderRecordingActions = (recording: TrafficRecordingResponse) => (
+    <>
+      <Button size="sm" variant="outline" onClick={() => handleSelect(recording)}>
+        <FileJson className="h-4 w-4" />
+        {selectedId === recording.id ? t("hideDetail") : t("viewDetail")}
+      </Button>
+      {recording.request_log_id ? (
+        <Button asChild size="sm" variant="outline">
+          <Link href={`/logs?focus=${encodeURIComponent(recording.request_log_id)}`}>
+            <ExternalLink className="h-4 w-4" />
+            {t("openSourceLog")}
+          </Link>
+        </Button>
+      ) : null}
+      {confirmingDeleteId === recording.id ? (
+        <div className="inline-flex animate-in items-center gap-1.5 duration-200 fade-in-0 zoom-in-95 motion-reduce:animate-none">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setConfirmingDeleteId(null)}
+            disabled={deleteRecording.isPending}
+          >
+            {tCommon("cancel")}
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={() => handleConfirmDelete(recording.id)}
+            disabled={deleteRecording.isPending}
+            className="min-w-[6.25rem]"
+          >
+            {deleteRecording.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Trash2 className="h-4 w-4" />
+            )}
+            {deleteRecording.isPending ? tCommon("loading") : t("deleteConfirmAction")}
+          </Button>
+        </div>
+      ) : (
+        <Button
+          size="sm"
+          variant="destructive"
+          onClick={() => setConfirmingDeleteId(recording.id)}
+          disabled={deleteRecording.isPending}
+          className="transition-[transform,opacity] duration-200 ease-cf-standard"
+        >
+          <Trash2 className="h-4 w-4" />
+          {t("delete")}
+        </Button>
+      )}
+    </>
+  );
+
   return (
     <>
       <Topbar title={t("pageTitle")} />
@@ -380,111 +435,103 @@ export default function TrafficRecordingPage() {
             ) : rows.length === 0 ? (
               <div className="py-10 text-center text-sm text-muted-foreground">{t("empty")}</div>
             ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>{t("tableTime")}</TableHead>
-                    <TableHead>{t("tableStatus")}</TableHead>
-                    <TableHead>{t("tableModel")}</TableHead>
-                    <TableHead>{t("tablePath")}</TableHead>
-                    <TableHead className="text-right">{t("tableSize")}</TableHead>
-                    <TableHead>{t("tableRedaction")}</TableHead>
-                    <TableHead className="text-right">{t("tableActions")}</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
+              <>
+                {/* lg 以上宽表，lg 以下转卡片，避免 7 列窄屏横滚够不到操作按钮（与 background-sync 面板一致） */}
+                <div className="hidden lg:block">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>{t("tableTime")}</TableHead>
+                        <TableHead>{t("tableStatus")}</TableHead>
+                        <TableHead>{t("tableModel")}</TableHead>
+                        <TableHead>{t("tablePath")}</TableHead>
+                        <TableHead className="text-right">{t("tableSize")}</TableHead>
+                        <TableHead>{t("tableRedaction")}</TableHead>
+                        <TableHead className="text-right">{t("tableActions")}</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {rows.map((recording) => (
+                        <TableRow
+                          key={recording.id}
+                          className={cn(selectedId === recording.id && "bg-surface-300/55")}
+                        >
+                          <TableCell className="font-mono text-xs">
+                            {formatDate(recording.created_at)}
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant={getStatusVariant(recording.status_code)}>
+                              {recording.status_code ?? recording.outcome}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="max-w-[14rem] truncate font-mono text-xs">
+                            {recording.model ?? "-"}
+                          </TableCell>
+                          <TableCell className="max-w-[18rem] truncate font-mono text-xs">
+                            {recording.method ?? "-"} {recording.path ?? ""}
+                          </TableCell>
+                          <TableCell className="text-right font-mono text-xs">
+                            {formatBytes(recording.fixture_size_bytes)}
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant={recording.redacted ? "success" : "warning"}>
+                              {recording.redacted ? t("redacted") : t("notRedacted")}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex justify-end gap-2">
+                              {renderRecordingActions(recording)}
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+
+                <div className="space-y-3 lg:hidden">
                   {rows.map((recording) => (
-                    <TableRow
+                    <div
                       key={recording.id}
-                      className={cn(selectedId === recording.id && "bg-surface-300/55")}
+                      className={cn(
+                        "rounded-cf-sm border border-divider p-3",
+                        selectedId === recording.id && "bg-surface-300/55"
+                      )}
                     >
-                      <TableCell className="font-mono text-xs">
-                        {formatDate(recording.created_at)}
-                      </TableCell>
-                      <TableCell>
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 space-y-1">
+                          <p className="font-mono text-xs text-muted-foreground">
+                            {formatDate(recording.created_at)}
+                          </p>
+                          <p className="truncate font-mono text-sm text-foreground">
+                            {recording.model ?? "-"}
+                          </p>
+                        </div>
                         <Badge variant={getStatusVariant(recording.status_code)}>
                           {recording.status_code ?? recording.outcome}
                         </Badge>
-                      </TableCell>
-                      <TableCell className="max-w-[14rem] truncate font-mono text-xs">
-                        {recording.model ?? "-"}
-                      </TableCell>
-                      <TableCell className="max-w-[18rem] truncate font-mono text-xs">
+                      </div>
+
+                      <p className="mt-2 break-all font-mono text-xs text-muted-foreground">
                         {recording.method ?? "-"} {recording.path ?? ""}
-                      </TableCell>
-                      <TableCell className="text-right font-mono text-xs">
-                        {formatBytes(recording.fixture_size_bytes)}
-                      </TableCell>
-                      <TableCell>
+                      </p>
+
+                      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+                        <span className="font-mono text-muted-foreground">
+                          {formatBytes(recording.fixture_size_bytes)}
+                        </span>
                         <Badge variant={recording.redacted ? "success" : "warning"}>
                           {recording.redacted ? t("redacted") : t("notRedacted")}
                         </Badge>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex justify-end gap-2">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => handleSelect(recording)}
-                          >
-                            <FileJson className="h-4 w-4" />
-                            {selectedId === recording.id ? t("hideDetail") : t("viewDetail")}
-                          </Button>
-                          {recording.request_log_id ? (
-                            <Button asChild size="sm" variant="outline">
-                              <Link
-                                href={`/logs?focus=${encodeURIComponent(recording.request_log_id)}`}
-                              >
-                                <ExternalLink className="h-4 w-4" />
-                                {t("openSourceLog")}
-                              </Link>
-                            </Button>
-                          ) : null}
-                          {confirmingDeleteId === recording.id ? (
-                            <div className="inline-flex animate-in items-center gap-1.5 duration-200 fade-in-0 zoom-in-95 motion-reduce:animate-none">
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                onClick={() => setConfirmingDeleteId(null)}
-                                disabled={deleteRecording.isPending}
-                              >
-                                {tCommon("cancel")}
-                              </Button>
-                              <Button
-                                size="sm"
-                                variant="destructive"
-                                onClick={() => handleConfirmDelete(recording.id)}
-                                disabled={deleteRecording.isPending}
-                                className="min-w-[6.25rem]"
-                              >
-                                {deleteRecording.isPending ? (
-                                  <Loader2 className="h-4 w-4 animate-spin" />
-                                ) : (
-                                  <Trash2 className="h-4 w-4" />
-                                )}
-                                {deleteRecording.isPending
-                                  ? tCommon("loading")
-                                  : t("deleteConfirmAction")}
-                              </Button>
-                            </div>
-                          ) : (
-                            <Button
-                              size="sm"
-                              variant="destructive"
-                              onClick={() => setConfirmingDeleteId(recording.id)}
-                              disabled={deleteRecording.isPending}
-                              className="transition-[transform,opacity] duration-200 ease-cf-standard"
-                            >
-                              <Trash2 className="h-4 w-4" />
-                              {t("delete")}
-                            </Button>
-                          )}
-                        </div>
-                      </TableCell>
-                    </TableRow>
+                      </div>
+
+                      <div className="mt-3 flex flex-wrap justify-end gap-2">
+                        {renderRecordingActions(recording)}
+                      </div>
+                    </div>
                   ))}
-                </TableBody>
-              </Table>
+                </div>
+              </>
             )}
 
             {recordings.data && recordings.data.total_pages > 1 ? (

--- a/src/app/[locale]/(portal)/layout.tsx
+++ b/src/app/[locale]/(portal)/layout.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 
 import { Sidebar } from "@/components/admin/sidebar";
 import { AppShell } from "@/components/layout/app-shell";
+import { MobileAccountMenu } from "@/components/layout/mobile-account-menu";
 import { useRouter } from "@/i18n/navigation";
 import { useAuth } from "@/providers/auth-provider";
 
@@ -35,6 +36,7 @@ export default function PortalLayout({ children }: { children: React.ReactNode }
       )}
       mobileRootRoutes={MOBILE_ROOT_ROUTES}
       getMobileBackHref={() => "/portal"}
+      mobileHeaderRight={<MobileAccountMenu />}
     >
       {children}
     </AppShell>

--- a/src/components/admin/background-sync-tasks-panel.tsx
+++ b/src/components/admin/background-sync-tasks-panel.tsx
@@ -259,7 +259,7 @@ export function BackgroundSyncTasksPanel() {
         </div>
       </div>
 
-      <div className="hidden md:block">
+      <div className="hidden lg:block">
         <Table className="min-w-[1182px] table-fixed" containerClassName="rounded-cf-sm">
           <TableHeader>
             <TableRow>
@@ -328,7 +328,7 @@ export function BackgroundSyncTasksPanel() {
         </Table>
       </div>
 
-      <div className="space-y-3 md:hidden">
+      <div className="space-y-3 lg:hidden">
         {rows.map((task) => (
           <div key={task.task_name} className="rounded-cf-sm border border-divider p-3">
             <div className="flex items-start justify-between gap-3">

--- a/src/components/admin/cliproxy-instance-form-dialog.tsx
+++ b/src/components/admin/cliproxy-instance-form-dialog.tsx
@@ -179,7 +179,7 @@ export function CliproxyInstanceFormDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="flex max-h-[calc(100vh-2rem)] max-w-xl flex-col overflow-hidden p-0"
+        className="flex max-h-[calc(100dvh-2rem)] max-w-xl flex-col overflow-hidden p-0"
         morph={morph}
         morphName={morphName}
       >

--- a/src/components/admin/create-key-dialog.tsx
+++ b/src/components/admin/create-key-dialog.tsx
@@ -263,7 +263,7 @@ export function CreateKeyDialog() {
             {t("createKey")}
           </Button>
         </DialogTrigger>
-        <DialogContent className="flex max-h-[calc(100vh-2rem)] max-w-2xl flex-col overflow-hidden p-0">
+        <DialogContent className="flex max-h-[calc(100dvh-2rem)] max-w-2xl flex-col overflow-hidden p-0">
           <DialogHeader className="shrink-0 px-6 pb-0 pr-12 pt-6">
             <DialogTitle>{t("createKeyTitle")}</DialogTitle>
             <DialogDescription>{t("createKeyDesc")}</DialogDescription>

--- a/src/components/admin/edit-key-dialog.tsx
+++ b/src/components/admin/edit-key-dialog.tsx
@@ -285,7 +285,7 @@ export function EditKeyDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="flex max-h-[calc(100vh-2rem)] max-w-2xl flex-col overflow-hidden p-0"
+        className="flex max-h-[calc(100dvh-2rem)] max-w-2xl flex-col overflow-hidden p-0"
         morph={morph}
         morphName={morphName}
         onOpenAutoFocus={(event) => {

--- a/src/components/dashboard/leaderboard-section.tsx
+++ b/src/components/dashboard/leaderboard-section.tsx
@@ -40,8 +40,10 @@ function getTtftClass(ttftMs: number): string {
   return "text-status-success";
 }
 
+// <lg 垂直堆叠：名称行在上、指标网格全宽在下，避免窄屏下固定宽度名称块挤压指标导致数值被截断；
+// lg+ 恢复横向单行（含右侧饼图），与桌面信息密度保持一致。
 const RANK_ROW_BASE =
-  "flex items-center gap-3 rounded-cf-sm border-l-2 px-2.5 py-1.5 transition-colors bg-surface-300/42 hover:bg-surface-400/55";
+  "flex flex-col items-stretch gap-2 rounded-cf-sm border-l-2 px-2.5 py-2 transition-colors bg-surface-300/42 hover:bg-surface-400/55 lg:flex-row lg:items-center lg:gap-3 lg:py-1.5";
 
 function getRankRowClass(index: number): string {
   if (index < RANK_LEFT_BORDERS.length) {
@@ -217,16 +219,18 @@ export function LeaderboardSection({ data, isLoading }: LeaderboardSectionProps)
             <div className="space-y-2">
               {data.upstreams.map((item, index) => (
                 <div key={item.id} className={getRankRowClass(index)}>
-                  <RankBadge rank={index + 1} />
+                  <div className="flex items-center gap-3 lg:contents">
+                    <RankBadge rank={index + 1} />
 
-                  <div className="w-[120px] shrink-0">
-                    <p className="type-body-small truncate text-foreground">{item.name}</p>
-                    <p className="type-caption truncate text-muted-foreground">
-                      {item.provider_type}
-                    </p>
+                    <div className="min-w-0 flex-1 lg:w-[120px] lg:flex-none lg:shrink-0">
+                      <p className="type-body-small truncate text-foreground">{item.name}</p>
+                      <p className="type-caption truncate text-muted-foreground">
+                        {item.provider_type}
+                      </p>
+                    </div>
                   </div>
 
-                  <div className="ml-2 grid flex-1 grid-cols-3 gap-x-4 gap-y-1 sm:grid-cols-6">
+                  <div className="grid grid-cols-2 gap-x-4 gap-y-1 sm:grid-cols-3 lg:ml-2 lg:grid-cols-6 lg:flex-1">
                     <MetricCell
                       label={t("stats.requests")}
                       value={formatNumber(item.request_count)}
@@ -254,7 +258,7 @@ export function LeaderboardSection({ data, isLoading }: LeaderboardSectionProps)
                     />
                   </div>
 
-                  <div className="hidden shrink-0 sm:block">
+                  <div className="hidden shrink-0 lg:block">
                     <MiniPieChart
                       data={item.model_distribution}
                       label={t("stats.modelDistribution")}
@@ -291,13 +295,15 @@ export function LeaderboardSection({ data, isLoading }: LeaderboardSectionProps)
             <div className="space-y-2">
               {data.models.map((item, index) => (
                 <div key={item.model} className={getRankRowClass(index)}>
-                  <RankBadge rank={index + 1} />
+                  <div className="flex items-center gap-3 lg:contents">
+                    <RankBadge rank={index + 1} />
 
-                  <div className="w-[160px] shrink-0">
-                    <p className="type-body-small truncate text-foreground">{item.model}</p>
+                    <div className="min-w-0 flex-1 lg:w-[160px] lg:flex-none lg:shrink-0">
+                      <p className="type-body-small truncate text-foreground">{item.model}</p>
+                    </div>
                   </div>
 
-                  <div className="ml-2 grid flex-1 grid-cols-2 gap-x-4 gap-y-1 sm:grid-cols-4">
+                  <div className="grid grid-cols-2 gap-x-4 gap-y-1 lg:ml-2 lg:grid-cols-4 lg:flex-1">
                     <MetricCell
                       label={t("stats.tokens")}
                       value={`${formatNumber(item.total_tokens)} tok`}
@@ -317,7 +323,7 @@ export function LeaderboardSection({ data, isLoading }: LeaderboardSectionProps)
                     />
                   </div>
 
-                  <div className="hidden shrink-0 sm:block">
+                  <div className="hidden shrink-0 lg:block">
                     <MiniPieChart
                       data={item.upstream_distribution}
                       label={t("stats.upstreamDistribution")}
@@ -354,16 +360,18 @@ export function LeaderboardSection({ data, isLoading }: LeaderboardSectionProps)
             <div className="space-y-2">
               {data.api_keys.map((item, index) => (
                 <div key={item.id} className={getRankRowClass(index)}>
-                  <RankBadge rank={index + 1} />
+                  <div className="flex items-center gap-3 lg:contents">
+                    <RankBadge rank={index + 1} />
 
-                  <div className="w-[140px] shrink-0">
-                    <p className="type-body-small truncate text-foreground">{item.name}</p>
-                    <p className="type-caption truncate font-mono text-muted-foreground">
-                      {item.key_prefix}
-                    </p>
+                    <div className="min-w-0 flex-1 lg:w-[140px] lg:flex-none lg:shrink-0">
+                      <p className="type-body-small truncate text-foreground">{item.name}</p>
+                      <p className="type-caption truncate font-mono text-muted-foreground">
+                        {item.key_prefix}
+                      </p>
+                    </div>
                   </div>
 
-                  <div className="ml-2 grid flex-1 grid-cols-2 gap-x-4 gap-y-1 sm:grid-cols-3">
+                  <div className="grid grid-cols-2 gap-x-4 gap-y-1 lg:ml-2 lg:grid-cols-3 lg:flex-1">
                     <MetricCell
                       label={t("stats.requests")}
                       value={formatNumber(item.request_count)}
@@ -378,7 +386,7 @@ export function LeaderboardSection({ data, isLoading }: LeaderboardSectionProps)
                     />
                   </div>
 
-                  <div className="hidden shrink-0 sm:block">
+                  <div className="hidden shrink-0 lg:block">
                     <MiniPieChart
                       data={item.model_distribution}
                       label={t("stats.modelDistribution")}

--- a/src/components/landing/hero-terminal.tsx
+++ b/src/components/landing/hero-terminal.tsx
@@ -88,7 +88,8 @@ export function HeroTerminal() {
         </div>
 
         {/* 实时指标带（升级点）：LIVE 呼吸点 + 实时数字 + 跳动 sparkline */}
-        <div className="flex items-center gap-2.5 border-t border-border/60 px-4 py-2.5 font-mono text-[11px] text-muted-foreground">
+        {/* 窄屏 flex-wrap 换行，避免被外层 overflow-hidden 永久裁切（与上方路由结果条一致） */}
+        <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5 border-t border-border/60 px-4 py-2.5 font-mono text-[11px] text-muted-foreground">
           <span className="inline-flex items-center gap-1.5 text-amber-500">
             <span
               className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-500"

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -19,6 +19,8 @@ interface AppShellProps {
   getMobileBackHref: (pathname: string) => string;
   // Optional center slot of the mobile header (the dashboard mounts its pulse strip here).
   mobileHeaderCenter?: React.ReactNode;
+  // Optional right slot of the mobile header (the portal mounts its account menu here).
+  mobileHeaderRight?: React.ReactNode;
   children: React.ReactNode;
 }
 
@@ -34,6 +36,7 @@ export function AppShell({
   mobileRootRoutes,
   getMobileBackHref,
   mobileHeaderCenter,
+  mobileHeaderRight,
   children,
 }: AppShellProps) {
   const router = useRouter();
@@ -132,7 +135,9 @@ export function AppShell({
               )}
             </div>
             {mobileHeaderCenter ?? <span aria-hidden="true" />}
-            <span aria-hidden="true" />
+            <div className="flex min-w-0 items-center justify-end">
+              {mobileHeaderRight ?? <span aria-hidden="true" />}
+            </div>
           </div>
         </header>
         {children}

--- a/src/components/layout/mobile-account-menu.tsx
+++ b/src/components/layout/mobile-account-menu.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { useSearchParams } from "next/navigation";
+import { useTheme } from "next-themes";
+import { Check, Globe, LogOut, Menu, Monitor, Moon, Sun } from "lucide-react";
+
+import { locales, localeNames, type Locale } from "@/i18n/config";
+import { usePathname, useRouter } from "@/i18n/navigation";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { useAuth } from "@/providers/auth-provider";
+
+const radioItemClass = cn(
+  "cursor-pointer justify-between border border-transparent",
+  "data-[state=checked]:border-amber-500/35 data-[state=checked]:bg-surface-300"
+);
+
+/**
+ * Compact account/controls overflow menu for the mobile header. The member
+ * portal has no settings page and its bottom navigation is fixed at four
+ * entries, so language switching, theme toggling, and logout live here on
+ * small screens — mirroring the controls already present in the desktop
+ * sidebar footer.
+ */
+export function MobileAccountMenu() {
+  const tNav = useTranslations("nav");
+  const tCommon = useTranslations("common");
+  const tLanguage = useTranslations("language");
+  const tTheme = useTranslations("theme");
+
+  const locale = useLocale() as Locale;
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const { theme, setTheme } = useTheme();
+  const selectedTheme = theme ?? "system";
+
+  const { logout } = useAuth();
+  const [showLogoutDialog, setShowLogoutDialog] = useState(false);
+
+  const handleLocaleChange = (nextLocale: Locale) => {
+    if (nextLocale === locale) {
+      return;
+    }
+    const query = searchParams.toString();
+    const targetPath = query ? `${pathname}?${query}` : pathname;
+    router.replace(targetPath, { locale: nextLocale });
+  };
+
+  const confirmLogout = () => {
+    setShowLogoutDialog(false);
+    logout();
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 px-0 text-muted-foreground hover:text-foreground"
+            aria-label={tCommon("menu")}
+          >
+            <Menu className="h-4 w-4" aria-hidden="true" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-44">
+          <DropdownMenuLabel className="flex items-center gap-2 text-muted-foreground">
+            <Globe className="h-4 w-4" aria-hidden="true" />
+            {tLanguage("switch")}
+          </DropdownMenuLabel>
+          <DropdownMenuRadioGroup
+            value={locale}
+            onValueChange={(value) => handleLocaleChange(value as Locale)}
+          >
+            {locales.map((nextLocale) => (
+              <DropdownMenuRadioItem key={nextLocale} value={nextLocale} className={radioItemClass}>
+                <span>{localeNames[nextLocale]}</span>
+                {nextLocale === locale && <Check className="h-4 w-4 text-amber-500" aria-hidden />}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+
+          <DropdownMenuSeparator />
+
+          <DropdownMenuLabel className="flex items-center gap-2 text-muted-foreground">
+            <Sun className="h-4 w-4" aria-hidden="true" />
+            {tTheme("toggle")}
+          </DropdownMenuLabel>
+          <DropdownMenuRadioGroup value={selectedTheme} onValueChange={setTheme}>
+            <DropdownMenuRadioItem value="light" className={radioItemClass}>
+              <span className="flex items-center gap-2">
+                <Sun className="h-4 w-4 text-muted-foreground" />
+                <span>{tTheme("light")}</span>
+              </span>
+              {selectedTheme === "light" && (
+                <Check className="h-4 w-4 text-amber-500" aria-hidden />
+              )}
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="dark" className={radioItemClass}>
+              <span className="flex items-center gap-2">
+                <Moon className="h-4 w-4 text-muted-foreground" />
+                <span>{tTheme("dark")}</span>
+              </span>
+              {selectedTheme === "dark" && <Check className="h-4 w-4 text-amber-500" aria-hidden />}
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="system" className={radioItemClass}>
+              <span className="flex items-center gap-2">
+                <Monitor className="h-4 w-4 text-muted-foreground" />
+                <span>{tTheme("system")}</span>
+              </span>
+              {selectedTheme === "system" && (
+                <Check className="h-4 w-4 text-amber-500" aria-hidden />
+              )}
+            </DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+
+          <DropdownMenuSeparator />
+
+          <DropdownMenuItem
+            className="cursor-pointer text-status-error focus:text-status-error"
+            onSelect={(event) => {
+              event.preventDefault();
+              setShowLogoutDialog(true);
+            }}
+          >
+            <LogOut className="h-4 w-4" aria-hidden="true" />
+            {tNav("logout")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialog open={showLogoutDialog} onOpenChange={setShowLogoutDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{tNav("logout")}</AlertDialogTitle>
+            <AlertDialogDescription>{tNav("logoutConfirm")}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{tCommon("cancel")}</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmLogout}>{tNav("logout")}</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -41,7 +41,9 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%]",
+        "fixed left-[50%] top-[50%] z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%]",
+        // 与 dialog.tsx 同根因：矮视口（软键盘 / 横屏 / 小屏）下限高 + 内滚，避免标题与确认按钮被推出视口
+        "max-h-[calc(100dvh-2rem)] overflow-y-auto",
         "gap-6 p-6 rounded-cf-sm",
         "bg-surface-300 border-2 border-amber-500 shadow-cf-glow-subtle",
         "duration-cf-normal ease-cf-standard",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -46,6 +46,9 @@ const DialogContent = React.forwardRef<
         ref={ref}
         className={cn(
           "fixed left-1/2 top-1/2 z-50 grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2",
+          // 矮视口（软键盘弹起 / 横屏 / 小屏）下限制高度并允许内容自身纵向滚动，
+          // 避免标题与操作按钮被推出视口；已显式设置 max-h/overflow 的对话框会经 twMerge 覆盖这里的默认值
+          "max-h-[calc(100dvh-2rem)] overflow-y-auto",
           "gap-5 rounded-cf-md border border-border bg-card p-6 text-foreground shadow-[var(--vr-shadow-lg)]",
           "duration-cf-normal ease-cf-standard",
           // 走容器变形（View Transition）时关闭默认 zoom/slide 进出场，运动交给 VT 接管

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -28,6 +28,9 @@ const PopoverContent = React.forwardRef<
       className={cn(
         // Layout
         "z-50 w-72 p-4",
+        // 矮视口下限制高度为 Radix 计算出的可用高度并允许面板自身滚动，
+        // 让日期选择器等长内容（月份导航、底部按钮）始终可滚到
+        "max-h-[var(--radix-popover-content-available-height)] overflow-y-auto",
         // Cassette Futurism styling
         "rounded-cf-sm border-2 border-amber-500 bg-surface-300",
         "shadow-cf-glow-subtle",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -93,7 +93,8 @@
     "collapse": "Collapse",
     "showSensitiveInput": "Show input value",
     "hideSensitiveInput": "Hide input value",
-    "logout": "Sign out of your account"
+    "logout": "Sign out of your account",
+    "menu": "Menu"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -93,7 +93,8 @@
     "collapse": "收起",
     "showSensitiveInput": "显示输入内容",
     "hideSensitiveInput": "隐藏输入内容",
-    "logout": "退出当前账户"
+    "logout": "退出当前账户",
+    "menu": "菜单"
   },
   "nav": {
     "dashboard": "仪表盘",

--- a/tests/components/traffic-recording-page.test.tsx
+++ b/tests/components/traffic-recording-page.test.tsx
@@ -220,9 +220,11 @@ describe("TrafficRecordingPage", () => {
     expect(screen.getByText("dashboard.timeRange.7d")).toBeInTheDocument();
     expect(screen.getByText("dashboard.timeRange.30d")).toBeInTheDocument();
     expect(screen.getByText("dashboard.timeRange.custom")).toBeInTheDocument();
-    expect(screen.getByText("gpt-4.1")).toBeInTheDocument();
+    expect(screen.getAllByText("gpt-4.1").length).toBeGreaterThan(0);
 
-    fireEvent.click(screen.getByRole("button", { name: /trafficRecording.viewDetail/i }));
+    // 宽表（hidden lg:block）与窄屏卡片（lg:hidden）各渲染一份操作按钮，jsdom 不应用 CSS 隐藏，
+    // 故同名按钮成对出现；点击任一份即可，JSON 详情块与复制按钮在下方独立卡片只渲染一份。
+    fireEvent.click(screen.getAllByRole("button", { name: /trafficRecording.viewDetail/i })[0]);
     expect(screen.getByText('"meta":')).toBeInTheDocument();
     expect(screen.getByText('"requestId":')).toBeInTheDocument();
     expect(screen.getByText('"req-1"')).toBeInTheDocument();
@@ -232,20 +234,22 @@ describe("TrafficRecordingPage", () => {
       JSON.stringify({ meta: { requestId: "req-1" } }, null, 2)
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "trafficRecording.delete" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "trafficRecording.delete" })[0]);
     expect(deleteMutate).not.toHaveBeenCalled();
-    expect(screen.getByRole("button", { name: "common.cancel" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "common.cancel" }).length).toBeGreaterThan(0);
     expect(
-      screen.getByRole("button", { name: "trafficRecording.deleteConfirmAction" })
-    ).toBeInTheDocument();
+      screen.getAllByRole("button", { name: "trafficRecording.deleteConfirmAction" }).length
+    ).toBeGreaterThan(0);
 
-    fireEvent.click(screen.getByRole("button", { name: "common.cancel" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "common.cancel" })[0]);
     expect(
-      screen.queryByRole("button", { name: "trafficRecording.deleteConfirmAction" })
-    ).not.toBeInTheDocument();
+      screen.queryAllByRole("button", { name: "trafficRecording.deleteConfirmAction" })
+    ).toHaveLength(0);
 
-    fireEvent.click(screen.getByRole("button", { name: "trafficRecording.delete" }));
-    fireEvent.click(screen.getByRole("button", { name: "trafficRecording.deleteConfirmAction" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "trafficRecording.delete" })[0]);
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "trafficRecording.deleteConfirmAction" })[0]
+    );
     expect(deleteMutate).toHaveBeenCalledWith("recording-1");
   });
 
@@ -303,8 +307,12 @@ describe("TrafficRecordingPage", () => {
 
     render(<TrafficRecordingPage />);
 
+    // 宽表与窄屏卡片各渲染一份链接：含 request_log_id 的记录产生 2 个链接，无 log 的记录 0 个；
+    // 总数为 2（而非 4）即证明链接仅对存在源日志的记录渲染。
     const links = screen.getAllByRole("link", { name: /trafficRecording.openSourceLog/i });
-    expect(links).toHaveLength(1);
-    expect(links[0]).toHaveAttribute("href", "/logs?focus=log-1");
+    expect(links).toHaveLength(2);
+    for (const link of links) {
+      expect(link).toHaveAttribute("href", "/logs?focus=log-1");
+    }
   });
 });


### PR DESCRIPTION
## Summary

全面响应式审查后，修复确认的 P0/P1 与低成本 P2 问题。一处修原语覆盖整批"裸"对话框矮屏不可滚，落地页 Hero 与两张数据密集表的窄屏溢出，并补齐门户移动端账户菜单。桌面 1280 形态保持不变。

## Related Issue

无独立 issue，源自工作区「全面调查项目的响应式问题」审查任务（修复 1–4 + H 回归）。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes

**修复 1（P0+P1）弹层视口适配根因**
- `ui/dialog.tsx`、`ui/popover.tsx` 原语增加 `max-h`（`calc(100dvh-2rem)` / `var(--radix-popover-content-available-height)`）+ 内部纵向滚动，一处覆盖整批"裸"对话框矮屏标题/按钮不可达；顺带补 `ui/alert-dialog.tsx` 同隐患。
- `create-key`/`edit-key`/`cliproxy-instance-form` 等已自带 `max-h`+内滚的安全对话框 override 仍生效，无双滚动条、视觉不变。

**修复 2（P1·E-1）落地页 Hero**
- `landing/hero-terminal.tsx` LIVE 指标带加 `flex-wrap`，消除 375 永久裁切；宽屏单行无退化。

**修复 3（P1+P2）平板宽表 + 门户移动端导航**
- `admin/background-sync-tasks-panel.tsx` 断点 `md`→`lg`，768 走卡片不再因 `min-w` 强制横滚。
- 新增 `layout/mobile-account-menu.tsx`，门户移动端补登出/主题/语言入口；`app-shell.tsx` 增 `mobileHeaderRight` 插槽，`(portal)/layout.tsx` 接入（仅门户启用）。

**修复 4（P1）数据密集表窄屏溢出**
- `dashboard/leaderboard-section.tsx` rank 行 `<lg` 垂直堆叠 + `lg:contents` 还原横向，指标网格响应式列数，修 375 指标被截断（`40…`）。
- `system/traffic-recording/page.tsx` 复用项目既有「窄屏转卡片」回退（`lg` 断点），共享操作渲染。
- `tests/components/traffic-recording-page.test.tsx` 适配「表格+卡片」双渲染断言。

## Test Plan

- [x] Local tests pass (`pnpm test:run`) — 196 文件 / 3001 用例通过，1 skipped
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`) — 改动文件 eslint 0、prettier ok
- [x] Manual testing completed — :3002 dev server，Playwright `setViewportSize` 三视口实测：落地页 375 无裁切、对话框矮屏（560×380）可滚单滚动条、平板宽表 375/768 转卡片无页级横溢，截图存 `test-results/`（gitignore）

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [ ] Documentation has been updated (if applicable) — 纯布局兜底，无需文档
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Additional Notes

- 仅动布局兜底，不涉及表格数据逻辑、列含义、业务对话框内容结构。
- 调查期推翻项（F2/F3/F4/A6）经实测确认非问题；数据依赖型 P2 与 iOS 真机软键盘项为已知边界，留作后续数据/真机复测。
