### PR TITLE
fix(docker): healthcheck 改用 127.0.0.1 避免容器内 localhost 解析到 IPv6

### DIFF
--- a/docker-compose.cliproxy.yml
+++ b/docker-compose.cliproxy.yml
@@ -32,7 +32,7 @@ services:
       # 运行日志目录，named volume 持久化。
       - cliproxy-logs:/CLIProxyAPI/logs
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:${CLIPROXY_PORT:-8317}/healthz"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:${CLIPROXY_PORT:-8317}/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     volumes:
       - autorouter-data:/app/data
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

修复容器 healthcheck 因 `localhost` 在容器内解析到 IPv6 而持续误报 `unhealthy` 的问题。应用本身完全正常，坏的只是 Docker 的探测命令。

## Related Issue

无（部署 v0.8.0 时在生产上排查发现）。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI (changes to build system or CI configuration)

## Changes

- `docker-compose.yml`：app healthcheck 的探测地址 `http://localhost:3000/api/health` → `http://127.0.0.1:3000/api/health`
- `docker-compose.cliproxy.yml`：cliproxy sidecar healthcheck 存在同样的坑，`localhost` → `127.0.0.1` 一并修正

**根因**：Next.js 16 只监听 IPv4 `0.0.0.0`（运行日志 `Network: http://0.0.0.0:3000`）。容器内 `localhost` 优先解析到 IPv6 `::1`，`wget` 探测被拒（`Connection refused`），FailingStreak 持续累积、容器被标记 `unhealthy`；而宿主机经端口映射（IPv4）访问 `/api/health` 一直返回 200，实际服务不受影响。此写法自最初 CD workflow 建立（`6e46473`）就存在，非近期回归——历次部署容器均为该 unhealthy 状态。显式改用 `127.0.0.1` 绕开 IPv6 解析。

## Test Plan

生产容器内实测（v0.8.0 运行中）：

- `wget -q --spider http://localhost:3000/api/health` → `Connection refused`（exit 1）
- `wget -q --spider http://127.0.0.1:3000/api/health` → 成功（exit 0）
- 宿主机 `curl http://127.0.0.1:3331/api/health` → 200

改动仅涉及 compose 探测地址，无代码/类型/lint 影响；本仓库不含 compose 的自动化测试。修复在下次部署重建容器后生效。

- [ ] Local tests pass (`pnpm test:run`) — 不适用（纯 compose 配置改动）
- [ ] Type check passes — 不适用
- [ ] Lint passes — 不适用
- [x] Manual testing completed（生产容器内复现 + 验证，见上）

## Checklist

- [x] Code follows the project's coding standards
- [ ] Tests have been added where necessary — 不适用（compose 探测地址无单元测试载体）
- [ ] Documentation has been updated (if applicable) — 无需
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Additional Notes

需下次部署（重建容器加载新 compose）后 `unhealthy` 才会消除；当前 v0.8.0 生产容器服务正常，可随后续任一次部署一并生效，无需为此单独紧急发版。