### PR TITLE
feat(rankings): 排行榜页支持搜索与过滤

### DIFF
--- a/src/app/[locale]/(dashboard)/rankings/page.tsx
+++ b/src/app/[locale]/(dashboard)/rankings/page.tsx
@@ -6,7 +6,11 @@ import { useTranslations } from "next-intl";
 import { Cpu, Key, RotateCcw, Search, Server, Trophy, Users } from "lucide-react";
 
 import { Topbar } from "@/components/admin/topbar";
-import { RankingsTable, type RankingsLogsWindow } from "@/components/rankings/rankings-table";
+import {
+  itemKey,
+  RankingsTable,
+  type RankingsLogsWindow,
+} from "@/components/rankings/rankings-table";
 import {
   buildQuery,
   filterRankingsItems,
@@ -31,6 +35,11 @@ import { usePathname, useRouter } from "@/i18n/navigation";
 import { cn } from "@/lib/utils";
 import type { RankingsDimension, RankingsSortField } from "@/types/api";
 
+// Radix Select forbids empty item values, and a NUL byte can never appear in a
+// real upstream name — unlike a literal "all", which a user could name an
+// upstream after and make it unselectable.
+const ALL_UPSTREAMS = "\u0000all";
+
 const DIMENSIONS: Array<{ key: RankingsDimension; icon: typeof Server; labelKey: string }> = [
   { key: "upstreams", icon: Server, labelKey: "dimensions.upstreams" },
   { key: "models", icon: Cpu, labelKey: "dimensions.models" },
@@ -47,42 +56,26 @@ export default function RankingsPage() {
   const [state, setState] = useState<RankingsViewState>(() =>
     readStateFromUrl(new URLSearchParams(searchParams.toString()))
   );
-  // Local echo for the search input so typing stays responsive while the URL
-  // commit is debounced (same pattern as users-table).
-  const [searchInput, setSearchInput] = useState(state.query);
-  const searchDebounceRef = useRef<number | null>(null);
-  // Latest state for the debounced commit — a 300ms-old closure must not
-  // clobber a sort/dimension change made in between.
-  const stateRef = useRef(state);
+  // State updates immediately (typing filters the table live); only the URL
+  // write is debounced, in one place, so text/number keystrokes don't spam
+  // router.replace and a stale closure can never clobber a newer change.
+  const urlSyncRef = useRef<number | null>(null);
   useEffect(() => {
-    stateRef.current = state;
-  }, [state]);
-  useEffect(() => {
+    if (urlSyncRef.current != null) window.clearTimeout(urlSyncRef.current);
+    urlSyncRef.current = window.setTimeout(() => {
+      const query = buildQuery(state);
+      router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    }, 300);
     return () => {
-      if (searchDebounceRef.current != null) window.clearTimeout(searchDebounceRef.current);
+      if (urlSyncRef.current != null) window.clearTimeout(urlSyncRef.current);
     };
-  }, []);
+  }, [state, pathname, router]);
 
   function applyState(next: RankingsViewState) {
     setState(next);
-    const query = buildQuery(next);
-    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
-  }
-
-  function handleSearchInputChange(value: string) {
-    setSearchInput(value);
-    if (searchDebounceRef.current != null) window.clearTimeout(searchDebounceRef.current);
-    searchDebounceRef.current = window.setTimeout(() => {
-      const trimmed = value.trim();
-      if (trimmed !== stateRef.current.query) {
-        applyState({ ...stateRef.current, query: trimmed });
-      }
-    }, 300);
   }
 
   function handleResetFilters() {
-    if (searchDebounceRef.current != null) window.clearTimeout(searchDebounceRef.current);
-    setSearchInput("");
     applyState({ ...state, query: "", minRequests: 0, errorsOnly: false, upstream: "" });
   }
 
@@ -109,6 +102,14 @@ export default function RankingsPage() {
   const items = useMemo(() => data?.items ?? [], [data]);
   const filteredItems = useMemo(() => filterRankingsItems(items, state), [items, state]);
   const filtersActive = hasActiveFilters(state);
+
+  // Ranks computed over the unfiltered set so a filtered view keeps the true
+  // leaderboard positions (rank numbers, medals, prev_rank comparison).
+  const globalRanks = useMemo(() => {
+    const map = new Map<string, number>();
+    items.forEach((item, index) => map.set(itemKey(state.dimension, item), index + 1));
+    return map;
+  }, [items, state.dimension]);
 
   // Upstream filter options come from the current dataset itself (the
   // leaderboard returns the full aggregated set, no extra endpoint needed).
@@ -198,8 +199,8 @@ export default function RankingsPage() {
                 type="text"
                 aria-label={t("filters.searchPlaceholder")}
                 placeholder={t("filters.searchPlaceholder")}
-                value={searchInput}
-                onChange={(e) => handleSearchInputChange(e.target.value)}
+                value={state.query}
+                onChange={(e) => applyState({ ...state, query: e.target.value })}
                 className="pl-8"
               />
             </div>
@@ -220,21 +221,27 @@ export default function RankingsPage() {
             />
             {state.dimension === "models" && (
               <Select
-                value={state.upstream || "all"}
+                value={state.upstream || ALL_UPSTREAMS}
                 onValueChange={(value) =>
-                  applyState({ ...state, upstream: value === "all" ? "" : value })
+                  applyState({ ...state, upstream: value === ALL_UPSTREAMS ? "" : value })
                 }
               >
                 <SelectTrigger aria-label={t("filters.upstream")} className="w-full sm:w-[170px]">
                   <SelectValue placeholder={t("filters.upstream")} />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="all">{t("filters.allUpstreams")}</SelectItem>
+                  <SelectItem value={ALL_UPSTREAMS}>{t("filters.allUpstreams")}</SelectItem>
                   {upstreamOptions.map((name) => (
                     <SelectItem key={name} value={name}>
                       {name}
                     </SelectItem>
                   ))}
+                  {/* A URL-provided upstream absent from the current data still
+                      renders as an option, so the active filter stays visible
+                      (and clearable) instead of hiding behind the placeholder. */}
+                  {state.upstream && !upstreamOptions.includes(state.upstream) && (
+                    <SelectItem value={state.upstream}>{state.upstream}</SelectItem>
+                  )}
                 </SelectContent>
               </Select>
             )}
@@ -273,6 +280,7 @@ export default function RankingsPage() {
           onSortChange={handleSortChange}
           logsWindow={logsWindow}
           emptyLabel={filtersActive && items.length > 0 ? t("noMatch") : undefined}
+          ranks={globalRanks}
         />
       </div>
     </>

--- a/src/app/[locale]/(dashboard)/rankings/page.tsx
+++ b/src/app/[locale]/(dashboard)/rankings/page.tsx
@@ -1,19 +1,30 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { Cpu, Key, Server, Trophy, Users } from "lucide-react";
+import { Cpu, Key, RotateCcw, Search, Server, Trophy, Users } from "lucide-react";
 
 import { Topbar } from "@/components/admin/topbar";
 import { RankingsTable, type RankingsLogsWindow } from "@/components/rankings/rankings-table";
 import {
   buildQuery,
+  filterRankingsItems,
+  hasActiveFilters,
   readStateFromUrl,
   type RankingsViewState,
 } from "@/components/rankings/rankings-url-state";
 import { TimeRangeSelector } from "@/components/dashboard";
 import type { TimeRangeOrCustom } from "@/components/dashboard/time-range-selector";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useRankings } from "@/hooks/use-rankings";
 import type { CustomDateRange } from "@/hooks/use-dashboard-stats";
 import { usePathname, useRouter } from "@/i18n/navigation";
@@ -36,11 +47,43 @@ export default function RankingsPage() {
   const [state, setState] = useState<RankingsViewState>(() =>
     readStateFromUrl(new URLSearchParams(searchParams.toString()))
   );
+  // Local echo for the search input so typing stays responsive while the URL
+  // commit is debounced (same pattern as users-table).
+  const [searchInput, setSearchInput] = useState(state.query);
+  const searchDebounceRef = useRef<number | null>(null);
+  // Latest state for the debounced commit — a 300ms-old closure must not
+  // clobber a sort/dimension change made in between.
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+  useEffect(() => {
+    return () => {
+      if (searchDebounceRef.current != null) window.clearTimeout(searchDebounceRef.current);
+    };
+  }, []);
 
   function applyState(next: RankingsViewState) {
     setState(next);
     const query = buildQuery(next);
     router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }
+
+  function handleSearchInputChange(value: string) {
+    setSearchInput(value);
+    if (searchDebounceRef.current != null) window.clearTimeout(searchDebounceRef.current);
+    searchDebounceRef.current = window.setTimeout(() => {
+      const trimmed = value.trim();
+      if (trimmed !== stateRef.current.query) {
+        applyState({ ...stateRef.current, query: trimmed });
+      }
+    }, 300);
+  }
+
+  function handleResetFilters() {
+    if (searchDebounceRef.current != null) window.clearTimeout(searchDebounceRef.current);
+    setSearchInput("");
+    applyState({ ...state, query: "", minRequests: 0, errorsOnly: false, upstream: "" });
   }
 
   function handleSortChange(field: RankingsSortField) {
@@ -62,6 +105,23 @@ export default function RankingsPage() {
     order: state.order,
     customRange: state.customRange,
   });
+
+  const items = useMemo(() => data?.items ?? [], [data]);
+  const filteredItems = useMemo(() => filterRankingsItems(items, state), [items, state]);
+  const filtersActive = hasActiveFilters(state);
+
+  // Upstream filter options come from the current dataset itself (the
+  // leaderboard returns the full aggregated set, no extra endpoint needed).
+  const upstreamOptions = useMemo(() => {
+    if (state.dimension !== "models") return [];
+    const names = new Set<string>();
+    for (const item of items) {
+      if ("upstream_distribution" in item) {
+        for (const d of item.upstream_distribution) names.add(d.name);
+      }
+    }
+    return [...names].sort();
+  }, [items, state.dimension]);
 
   // Time window forwarded to the logs page from the "view logs" links.
   const logsWindow = useMemo<RankingsLogsWindow>(() => {
@@ -99,43 +159,120 @@ export default function RankingsPage() {
           />
         </div>
 
-        <div
-          className="inline-flex flex-wrap rounded-cf-sm border border-border bg-surface-200 p-1"
-          role="tablist"
-          aria-label={t("title")}
-        >
-          {DIMENSIONS.map(({ key, icon: Icon, labelKey }) => {
-            const active = state.dimension === key;
-            return (
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+          <div
+            className="inline-flex flex-wrap self-start rounded-cf-sm border border-border bg-surface-200 p-1"
+            role="tablist"
+            aria-label={t("title")}
+          >
+            {DIMENSIONS.map(({ key, icon: Icon, labelKey }) => {
+              const active = state.dimension === key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  // Switching dimension drops the dimension-specific upstream
+                  // filter; the generic filters (q/min/errors) carry over.
+                  onClick={() => applyState({ ...state, dimension: key, upstream: "" })}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-cf-sm px-3.5 py-1.5 type-label-medium transition-all duration-cf-fast ease-cf-standard",
+                    "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    active
+                      ? "bg-amber-500 text-primary-foreground shadow-cf-glow-subtle"
+                      : "text-muted-foreground hover:bg-surface-300 hover:text-foreground"
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5" />
+                  {t(labelKey)}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="relative w-full sm:w-[200px]">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                type="text"
+                aria-label={t("filters.searchPlaceholder")}
+                placeholder={t("filters.searchPlaceholder")}
+                value={searchInput}
+                onChange={(e) => handleSearchInputChange(e.target.value)}
+                className="pl-8"
+              />
+            </div>
+            <Input
+              type="number"
+              min={0}
+              aria-label={t("filters.minRequests")}
+              placeholder={t("filters.minRequests")}
+              value={state.minRequests > 0 ? state.minRequests : ""}
+              onChange={(e) => {
+                const parsed = Number.parseInt(e.target.value, 10);
+                applyState({
+                  ...state,
+                  minRequests: Number.isFinite(parsed) && parsed > 0 ? parsed : 0,
+                });
+              }}
+              className="w-full sm:w-[130px]"
+            />
+            {state.dimension === "models" && (
+              <Select
+                value={state.upstream || "all"}
+                onValueChange={(value) =>
+                  applyState({ ...state, upstream: value === "all" ? "" : value })
+                }
+              >
+                <SelectTrigger aria-label={t("filters.upstream")} className="w-full sm:w-[170px]">
+                  <SelectValue placeholder={t("filters.upstream")} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t("filters.allUpstreams")}</SelectItem>
+                  {upstreamOptions.map((name) => (
+                    <SelectItem key={name} value={name}>
+                      {name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            <label className="inline-flex cursor-pointer select-none items-center gap-1.5 type-label-medium text-muted-foreground">
+              <Checkbox
+                checked={state.errorsOnly}
+                onCheckedChange={(checked) =>
+                  applyState({ ...state, errorsOnly: checked === true })
+                }
+              />
+              {t("filters.errorsOnly")}
+            </label>
+            {filtersActive && (
               <button
-                key={key}
                 type="button"
-                role="tab"
-                aria-selected={active}
-                onClick={() => applyState({ ...state, dimension: key })}
+                onClick={handleResetFilters}
                 className={cn(
-                  "inline-flex items-center gap-1.5 rounded-cf-sm px-3.5 py-1.5 type-label-medium transition-all duration-cf-fast ease-cf-standard",
-                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                  active
-                    ? "bg-amber-500 text-primary-foreground shadow-cf-glow-subtle"
-                    : "text-muted-foreground hover:bg-surface-300 hover:text-foreground"
+                  "inline-flex items-center gap-1 rounded-cf-sm px-2 py-1.5 type-label-medium",
+                  "text-muted-foreground transition-colors hover:text-foreground",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 )}
               >
-                <Icon className="h-3.5 w-3.5" />
-                {t(labelKey)}
+                <RotateCcw className="h-3.5 w-3.5" />
+                {t("filters.reset")}
               </button>
-            );
-          })}
+            )}
+          </div>
         </div>
 
         <RankingsTable
           dimension={state.dimension}
-          items={data?.items ?? []}
+          items={filteredItems}
           isLoading={isLoading}
           sortBy={state.sortBy}
           order={state.order}
           onSortChange={handleSortChange}
           logsWindow={logsWindow}
+          emptyLabel={filtersActive && items.length > 0 ? t("noMatch") : undefined}
         />
       </div>
     </>

--- a/src/components/rankings/rankings-table.tsx
+++ b/src/components/rankings/rankings-table.tsx
@@ -37,6 +37,8 @@ interface RankingsTableProps {
   order: "asc" | "desc";
   onSortChange: (field: RankingsSortField) => void;
   logsWindow: RankingsLogsWindow;
+  /** Overrides the default empty-state text (e.g. "no match" while filters are active). */
+  emptyLabel?: string;
 }
 
 // One entry per metric: header label, raw value (ratio bar / sorting), and
@@ -246,6 +248,7 @@ export function RankingsTable({
   order,
   onSortChange,
   logsWindow,
+  emptyLabel,
 }: RankingsTableProps) {
   const t = useTranslations("rankings");
   const tCommon = useTranslations("common");
@@ -304,7 +307,7 @@ export function RankingsTable({
           ) : items.length === 0 ? (
             <TableRow>
               <TableCell colSpan={columnCount} className="py-10 text-center text-muted-foreground">
-                {t("empty")}
+                {emptyLabel ?? t("empty")}
               </TableCell>
             </TableRow>
           ) : (

--- a/src/components/rankings/rankings-table.tsx
+++ b/src/components/rankings/rankings-table.tsx
@@ -39,6 +39,13 @@ interface RankingsTableProps {
   logsWindow: RankingsLogsWindow;
   /** Overrides the default empty-state text (e.g. "no match" while filters are active). */
   emptyLabel?: string;
+  /**
+   * Global leaderboard rank per itemKey. When the caller filters `items`, pass
+   * the ranks computed over the unfiltered set so #rank, medals, and the
+   * prev_rank comparison keep their true positions instead of renumbering the
+   * filtered subset. Falls back to the list index when absent.
+   */
+  ranks?: ReadonlyMap<string, number>;
 }
 
 // One entry per metric: header label, raw value (ratio bar / sorting), and
@@ -103,7 +110,7 @@ function metricValue(item: RankingsItem, field: RankingsSortField): number {
 
 const RANK_COLORS = ["text-amber-500", "text-status-info", "text-status-success"];
 
-function itemKey(dimension: RankingsDimension, item: RankingsItem): string {
+export function itemKey(dimension: RankingsDimension, item: RankingsItem): string {
   return dimension === "models" && "model" in item ? item.model : (item as { id: string }).id;
 }
 
@@ -139,6 +146,8 @@ function errorRateClass(rate: number): string | undefined {
   return undefined;
 }
 
+// Keep in sync with itemSearchTexts in rankings-url-state.ts: whatever text
+// this cell renders must stay searchable there.
 function ItemName({ dimension, item }: { dimension: RankingsDimension; item: RankingsItem }) {
   if (dimension === "models" && "model" in item) {
     return <p className="type-body-small truncate text-foreground">{item.model}</p>;
@@ -249,6 +258,7 @@ export function RankingsTable({
   onSortChange,
   logsWindow,
   emptyLabel,
+  ranks,
 }: RankingsTableProps) {
   const t = useTranslations("rankings");
   const tCommon = useTranslations("common");
@@ -313,7 +323,7 @@ export function RankingsTable({
           ) : (
             items.map((item, index) => {
               const key = itemKey(dimension, item);
-              const rank = index + 1;
+              const rank = ranks?.get(key) ?? index + 1;
               const expanded = expandedKey === key;
               const sortValue = metricValue(item, sortBy);
               const barPct = maxSortValue > 0 ? (sortValue / maxSortValue) * 100 : 0;

--- a/src/components/rankings/rankings-url-state.ts
+++ b/src/components/rankings/rankings-url-state.ts
@@ -1,6 +1,6 @@
 import type { CustomDateRange } from "@/hooks/use-dashboard-stats";
 import { PRESET_RANGES, type TimeRangeOrCustom } from "@/components/dashboard/time-range-selector";
-import type { RankingsDimension, RankingsSortField, TimeRange } from "@/types/api";
+import type { RankingsDimension, RankingsItem, RankingsSortField, TimeRange } from "@/types/api";
 
 // Derived from Record keys so the compiler errors here whenever the unions in
 // types/api.ts gain or lose a member — a plain literal array would silently
@@ -26,7 +26,18 @@ export const RANKINGS_DIMENSIONS = Object.keys(DIMENSION_FLAGS) as RankingsDimen
 
 export const RANKINGS_SORT_FIELDS = Object.keys(SORT_FIELD_FLAGS) as RankingsSortField[];
 
-export interface RankingsViewState {
+export interface RankingsFilterState {
+  /** Case-insensitive substring match on the item name fields. */
+  query: string;
+  /** Hide items with fewer requests than this (0 = off). */
+  minRequests: number;
+  /** Only show items with a non-zero error rate. */
+  errorsOnly: boolean;
+  /** models dimension only: keep items served by this upstream ("" = off). */
+  upstream: string;
+}
+
+export interface RankingsViewState extends RankingsFilterState {
   dimension: RankingsDimension;
   range: TimeRangeOrCustom;
   sortBy: RankingsSortField;
@@ -39,6 +50,10 @@ export const DEFAULT_RANKINGS_STATE: RankingsViewState = {
   range: "7d",
   sortBy: "requests",
   order: "desc",
+  query: "",
+  minRequests: 0,
+  errorsOnly: false,
+  upstream: "",
 };
 
 // The view state lives in the URL (dim/range/sort/order/start/end) so that
@@ -58,6 +73,8 @@ export function readStateFromUrl(params: URLSearchParams): RankingsViewState {
     }
   }
 
+  const minRaw = Number.parseInt(params.get("min") ?? "", 10);
+
   return {
     dimension: dim && RANKINGS_DIMENSIONS.includes(dim) ? dim : DEFAULT_RANKINGS_STATE.dimension,
     range:
@@ -71,6 +88,10 @@ export function readStateFromUrl(params: URLSearchParams): RankingsViewState {
     sortBy: sort && RANKINGS_SORT_FIELDS.includes(sort) ? sort : DEFAULT_RANKINGS_STATE.sortBy,
     order: order === "asc" ? "asc" : "desc",
     customRange,
+    query: params.get("q") ?? "",
+    minRequests: Number.isFinite(minRaw) && minRaw > 0 ? minRaw : 0,
+    errorsOnly: params.get("errors") === "1",
+    upstream: params.get("upstream") ?? "",
   };
 }
 
@@ -84,5 +105,47 @@ export function buildQuery(state: RankingsViewState): string {
     params.set("start", state.customRange.start.toISOString());
     params.set("end", state.customRange.end.toISOString());
   }
+  if (state.query) params.set("q", state.query);
+  if (state.minRequests > 0) params.set("min", String(state.minRequests));
+  if (state.errorsOnly) params.set("errors", "1");
+  if (state.upstream) params.set("upstream", state.upstream);
   return params.toString();
+}
+
+function itemSearchTexts(item: RankingsItem): string[] {
+  if ("model" in item) return [item.model];
+  if ("provider_type" in item) return [item.name, item.provider_type];
+  if ("key_prefix" in item) return [item.name, item.key_prefix];
+  return [item.display_name, item.username];
+}
+
+// Pure client-side filtering: the leaderboard endpoint returns the full
+// aggregated set in one response, so search/threshold filters never need a
+// server round-trip. The upstream filter only applies to items that carry an
+// upstream_distribution (models dimension); other dimensions ignore it so a
+// stale `upstream` URL param can't blank out an unrelated view.
+export function filterRankingsItems(
+  items: RankingsItem[],
+  filters: RankingsFilterState
+): RankingsItem[] {
+  const query = filters.query.trim().toLowerCase();
+  return items.filter((item) => {
+    if (query && !itemSearchTexts(item).some((text) => text.toLowerCase().includes(query))) {
+      return false;
+    }
+    if (filters.minRequests > 0 && item.request_count < filters.minRequests) return false;
+    if (filters.errorsOnly && item.error_rate <= 0) return false;
+    if (
+      filters.upstream &&
+      "upstream_distribution" in item &&
+      !item.upstream_distribution.some((d) => d.name === filters.upstream)
+    ) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function hasActiveFilters(state: RankingsFilterState): boolean {
+  return Boolean(state.query || state.minRequests > 0 || state.errorsOnly || state.upstream);
 }

--- a/src/components/rankings/rankings-url-state.ts
+++ b/src/components/rankings/rankings-url-state.ts
@@ -74,9 +74,11 @@ export function readStateFromUrl(params: URLSearchParams): RankingsViewState {
   }
 
   const minRaw = Number.parseInt(params.get("min") ?? "", 10);
+  const dimension =
+    dim && RANKINGS_DIMENSIONS.includes(dim) ? dim : DEFAULT_RANKINGS_STATE.dimension;
 
   return {
-    dimension: dim && RANKINGS_DIMENSIONS.includes(dim) ? dim : DEFAULT_RANKINGS_STATE.dimension,
+    dimension,
     range:
       range === "custom"
         ? customRange
@@ -91,7 +93,10 @@ export function readStateFromUrl(params: URLSearchParams): RankingsViewState {
     query: params.get("q") ?? "",
     minRequests: Number.isFinite(minRaw) && minRaw > 0 ? minRaw : 0,
     errorsOnly: params.get("errors") === "1",
-    upstream: params.get("upstream") ?? "",
+    // The upstream filter only exists on the models dimension; dropping it here
+    // keeps a stale ?upstream= on other dimensions from becoming a ghost filter
+    // (Reset button shown with no visible control, dead param re-serialized).
+    upstream: dimension === "models" ? (params.get("upstream") ?? "") : "",
   };
 }
 
@@ -112,6 +117,8 @@ export function buildQuery(state: RankingsViewState): string {
   return params.toString();
 }
 
+// Keep in sync with ItemName in rankings-table.tsx: search must match exactly
+// the fields the name cell renders, or users can search visible text and miss.
 function itemSearchTexts(item: RankingsItem): string[] {
   if ("model" in item) return [item.model];
   if ("provider_type" in item) return [item.name, item.provider_type];

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -141,6 +141,15 @@
     },
     "newEntry": "New",
     "viewLogs": "View logs",
+    "filters": {
+      "searchPlaceholder": "Search name...",
+      "minRequests": "Min requests",
+      "errorsOnly": "Errors only",
+      "upstream": "Upstream",
+      "allUpstreams": "All upstreams",
+      "reset": "Reset filters"
+    },
+    "noMatch": "No matching entries",
     "empty": "No data in this time range",
     "noDistribution": "No breakdown data",
     "distribution": {

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -141,6 +141,15 @@
     },
     "newEntry": "新上榜",
     "viewLogs": "查看日志",
+    "filters": {
+      "searchPlaceholder": "搜索名称...",
+      "minRequests": "最少请求数",
+      "errorsOnly": "仅看有错误",
+      "upstream": "上游",
+      "allUpstreams": "全部上游",
+      "reset": "重置筛选"
+    },
+    "noMatch": "无匹配条目",
     "empty": "该时间范围内暂无数据",
     "noDistribution": "暂无构成数据",
     "distribution": {

--- a/tests/components/rankings/rankings-table.test.tsx
+++ b/tests/components/rankings/rankings-table.test.tsx
@@ -203,4 +203,22 @@ describe("RankingsTable", () => {
 
     expect(screen.getByText("empty")).toBeInTheDocument();
   });
+
+  it("prefers the emptyLabel override when provided", () => {
+    render(
+      <RankingsTable
+        dimension="users"
+        items={[]}
+        isLoading={false}
+        sortBy="requests"
+        order="desc"
+        onSortChange={vi.fn()}
+        logsWindow={defaultWindow}
+        emptyLabel="no-match-label"
+      />
+    );
+
+    expect(screen.getByText("no-match-label")).toBeInTheDocument();
+    expect(screen.queryByText("empty")).not.toBeInTheDocument();
+  });
 });

--- a/tests/components/rankings/rankings-table.test.tsx
+++ b/tests/components/rankings/rankings-table.test.tsx
@@ -188,6 +188,43 @@ describe("RankingsTable", () => {
     expect(within(rows[1]).getByText("newEntry")).toBeInTheDocument();
   });
 
+  it("keeps global ranks, medals, and rank deltas when a filtered subset is shown", () => {
+    // Simulates a filtered view: only the globally 2nd and 5th items remain.
+    const items = [
+      upstreamItem({
+        id: "up-2",
+        name: "Second",
+        request_count: 90,
+        comparison: { prev_rank: 4, prev_request_count: 45 },
+      }),
+      upstreamItem({ id: "up-5", name: "Fifth", request_count: 10 }),
+    ];
+    const ranks = new Map([
+      ["up-2", 2],
+      ["up-5", 5],
+    ]);
+
+    render(
+      <RankingsTable
+        dimension="upstreams"
+        items={items}
+        isLoading={false}
+        sortBy="requests"
+        order="desc"
+        onSortChange={vi.fn()}
+        logsWindow={defaultWindow}
+        ranks={ranks}
+      />
+    );
+
+    const rows = screen.getAllByTestId("rankings-row");
+    expect(within(rows[0]).getByText("#2")).toBeInTheDocument();
+    expect(within(rows[1]).getByText("#5")).toBeInTheDocument();
+    // prev_rank 4 → global rank 2 = moved up 2, not up 3 (filtered index).
+    expect(within(rows[0]).getByText("2")).toBeInTheDocument();
+    expect(within(rows[0]).getByText("+100.0%")).toBeInTheDocument();
+  });
+
   it("shows the empty state when there is no data", () => {
     render(
       <RankingsTable

--- a/tests/e2e/rankings.spec.ts
+++ b/tests/e2e/rankings.spec.ts
@@ -88,6 +88,8 @@ test.describe("Rankings page", () => {
     await expect(page).toHaveURL(/q=/);
     await expect(rows).toHaveCount(1);
     await expect(rows.first()).toContainText(UPSTREAM_COSTLY.name);
+    // 过滤视图保留全局排名：该上游是全量第 2 名，不因过滤变成 #1。
+    await expect(rows.first()).toContainText("#2");
 
     // 叠加请求数下限，超过唯一匹配项的请求数 → 空态显示「无匹配条目」。
     await page.getByRole("spinbutton", { name: "最少请求数" }).fill("999999");

--- a/tests/e2e/rankings.spec.ts
+++ b/tests/e2e/rankings.spec.ts
@@ -77,4 +77,50 @@ test.describe("Rankings page", () => {
     await expect(page).toHaveURL(/\/zh-CN\/rankings\?.*sort=cost/);
     await expect(page.getByTestId("rankings-row").first()).toContainText(UPSTREAM_COSTLY.name);
   });
+
+  test("filters by name search and min requests, then resets", async ({ page }) => {
+    await page.goto("/zh-CN/rankings");
+    const rows = page.getByTestId("rankings-row");
+    await expect(rows).toHaveCount(2);
+
+    // 名称搜索（300ms debounce 后进 URL）。
+    await page.getByRole("textbox", { name: "搜索名称..." }).fill(UPSTREAM_COSTLY.name);
+    await expect(page).toHaveURL(/q=/);
+    await expect(rows).toHaveCount(1);
+    await expect(rows.first()).toContainText(UPSTREAM_COSTLY.name);
+
+    // 叠加请求数下限，超过唯一匹配项的请求数 → 空态显示「无匹配条目」。
+    await page.getByRole("spinbutton", { name: "最少请求数" }).fill("999999");
+    await expect(page).toHaveURL(/min=999999/);
+    await expect(page.getByText("无匹配条目")).toBeVisible();
+
+    // 重置一键清空过滤并还原列表与 URL。
+    await page.getByRole("button", { name: "重置筛选" }).click();
+    await expect(rows).toHaveCount(2);
+    await expect(page).not.toHaveURL(/q=|min=/);
+  });
+
+  test("restores filters from a shared URL and filters models by upstream", async ({ page }) => {
+    // 直达带过滤的 URL：搜索词生效、输入框回填。
+    await page.goto(`/zh-CN/rankings?q=${UPSTREAM_COSTLY.name}`);
+    const rows = page.getByTestId("rankings-row");
+    await expect(rows).toHaveCount(1);
+    await expect(page.getByRole("textbox", { name: "搜索名称..." })).toHaveValue(
+      UPSTREAM_COSTLY.name
+    );
+
+    // models 维度的上游过滤：claude-3-opus 仅由第二个上游提供。
+    await page.goto("/zh-CN/rankings?dim=models");
+    await expect(rows).toHaveCount(2);
+    await page.getByRole("combobox", { name: "上游" }).click();
+    await page.getByRole("option", { name: UPSTREAM_COSTLY.name }).click();
+    await expect(page).toHaveURL(/upstream=/);
+    await expect(rows).toHaveCount(1);
+    await expect(rows.first()).toContainText("claude-3-opus");
+
+    // 切换维度丢弃维度特有的上游过滤。
+    await page.getByRole("tab", { name: "上游" }).click();
+    await expect(page).not.toHaveURL(/upstream=/);
+    await expect(rows).toHaveCount(2);
+  });
 });

--- a/tests/unit/rankings-url-state.test.ts
+++ b/tests/unit/rankings-url-state.test.ts
@@ -59,6 +59,12 @@ describe("rankings URL view state", () => {
     });
   });
 
+  it("drops the upstream param outside the models dimension", () => {
+    expect(readStateFromUrl(new URLSearchParams("dim=users&upstream=foo")).upstream).toBe("");
+    expect(readStateFromUrl(new URLSearchParams("upstream=foo")).upstream).toBe("");
+    expect(readStateFromUrl(new URLSearchParams("dim=models&upstream=foo")).upstream).toBe("foo");
+  });
+
   it("ignores invalid min values", () => {
     expect(readStateFromUrl(new URLSearchParams("min=-5")).minRequests).toBe(0);
     expect(readStateFromUrl(new URLSearchParams("min=abc")).minRequests).toBe(0);

--- a/tests/unit/rankings-url-state.test.ts
+++ b/tests/unit/rankings-url-state.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
   buildQuery,
+  filterRankingsItems,
+  hasActiveFilters,
   readStateFromUrl,
+  DEFAULT_RANKINGS_STATE,
   type RankingsViewState,
 } from "@/components/rankings/rankings-url-state";
+import type {
+  LeaderboardModelItem,
+  LeaderboardUpstreamItem,
+  LeaderboardUserItem,
+  RankingsItem,
+} from "@/types/api";
 
 describe("rankings URL view state", () => {
   it("returns defaults for an empty query", () => {
@@ -18,6 +27,7 @@ describe("rankings URL view state", () => {
 
   it("round-trips a non-default state through the query string", () => {
     const state: RankingsViewState = {
+      ...DEFAULT_RANKINGS_STATE,
       dimension: "models",
       range: "30d",
       sortBy: "error_rate",
@@ -27,8 +37,37 @@ describe("rankings URL view state", () => {
     expect(restored).toMatchObject(state);
   });
 
+  it("round-trips filter state (q/min/errors/upstream) through the query string", () => {
+    const state: RankingsViewState = {
+      ...DEFAULT_RANKINGS_STATE,
+      dimension: "models",
+      query: "gpt",
+      minRequests: 100,
+      errorsOnly: true,
+      upstream: "openai-primary",
+    };
+    const query = buildQuery(state);
+    expect(query).toContain("q=gpt");
+    expect(query).toContain("min=100");
+    expect(query).toContain("errors=1");
+    const restored = readStateFromUrl(new URLSearchParams(query));
+    expect(restored).toMatchObject({
+      query: "gpt",
+      minRequests: 100,
+      errorsOnly: true,
+      upstream: "openai-primary",
+    });
+  });
+
+  it("ignores invalid min values", () => {
+    expect(readStateFromUrl(new URLSearchParams("min=-5")).minRequests).toBe(0);
+    expect(readStateFromUrl(new URLSearchParams("min=abc")).minRequests).toBe(0);
+    expect(readStateFromUrl(new URLSearchParams("errors=yes")).errorsOnly).toBe(false);
+  });
+
   it("round-trips a custom range with start/end params", () => {
     const state: RankingsViewState = {
+      ...DEFAULT_RANKINGS_STATE,
       dimension: "api_keys",
       range: "custom",
       sortBy: "cost",
@@ -63,5 +102,140 @@ describe("rankings URL view state", () => {
 
   it("omits default values from the query string", () => {
     expect(buildQuery(readStateFromUrl(new URLSearchParams()))).toBe("");
+  });
+});
+
+function upstreamItem(overrides: Partial<LeaderboardUpstreamItem>): LeaderboardUpstreamItem {
+  return {
+    id: "up-1",
+    name: "OpenAI Primary",
+    provider_type: "openai",
+    request_count: 100,
+    total_tokens: 1000,
+    total_cost_usd: 1,
+    avg_ttft_ms: 500,
+    avg_tps: 40,
+    cache_hit_rate: 0,
+    error_rate: 0,
+    model_distribution: [],
+    ...overrides,
+  };
+}
+
+function modelItem(overrides: Partial<LeaderboardModelItem>): LeaderboardModelItem {
+  return {
+    model: "gpt-4.1",
+    request_count: 100,
+    total_tokens: 1000,
+    total_cost_usd: 1,
+    avg_ttft_ms: 500,
+    avg_tps: 40,
+    cache_hit_rate: 0,
+    error_rate: 0,
+    upstream_distribution: [],
+    ...overrides,
+  };
+}
+
+const NO_FILTERS = {
+  query: "",
+  minRequests: 0,
+  errorsOnly: false,
+  upstream: "",
+};
+
+describe("filterRankingsItems", () => {
+  it("matches the name fields of each dimension case-insensitively", () => {
+    const upstreams: RankingsItem[] = [
+      upstreamItem({ id: "a", name: "OpenAI Primary" }),
+      upstreamItem({ id: "b", name: "Claude Backup", provider_type: "anthropic" }),
+    ];
+    expect(filterRankingsItems(upstreams, { ...NO_FILTERS, query: "claude" })).toHaveLength(1);
+    // provider_type is part of the visible name cell, so it is searchable too.
+    expect(filterRankingsItems(upstreams, { ...NO_FILTERS, query: "anthropic" })).toHaveLength(1);
+
+    const models: RankingsItem[] = [modelItem({ model: "gpt-4.1" }), modelItem({ model: "o3" })];
+    expect(filterRankingsItems(models, { ...NO_FILTERS, query: "GPT" })).toHaveLength(1);
+
+    const user: LeaderboardUserItem = {
+      id: "u1",
+      username: "alice",
+      display_name: "Alice Zhang",
+      request_count: 10,
+      total_tokens: 100,
+      total_cost_usd: 1,
+      avg_ttft_ms: 0,
+      avg_tps: 0,
+      cache_hit_rate: 0,
+      error_rate: 0,
+      model_distribution: [],
+    };
+    expect(filterRankingsItems([user], { ...NO_FILTERS, query: "zhang" })).toHaveLength(1);
+    expect(filterRankingsItems([user], { ...NO_FILTERS, query: "bob" })).toHaveLength(0);
+  });
+
+  it("applies the min-requests threshold", () => {
+    const items = [
+      upstreamItem({ id: "a", request_count: 12000 }),
+      upstreamItem({ id: "b", request_count: 80 }),
+    ];
+    const result = filterRankingsItems(items, { ...NO_FILTERS, minRequests: 100 });
+    expect(result).toHaveLength(1);
+    expect((result[0] as LeaderboardUpstreamItem).id).toBe("a");
+  });
+
+  it("keeps only items with errors when errorsOnly is set", () => {
+    const items = [
+      upstreamItem({ id: "a", error_rate: 0 }),
+      upstreamItem({ id: "b", error_rate: 2.5 }),
+    ];
+    const result = filterRankingsItems(items, { ...NO_FILTERS, errorsOnly: true });
+    expect(result).toHaveLength(1);
+    expect((result[0] as LeaderboardUpstreamItem).id).toBe("b");
+  });
+
+  it("filters models by upstream and ignores the upstream filter for other dimensions", () => {
+    const models = [
+      modelItem({
+        model: "gpt-4.1",
+        upstream_distribution: [{ name: "openai-primary", count: 5 }],
+      }),
+      modelItem({ model: "claude-3", upstream_distribution: [{ name: "anthropic-hk", count: 3 }] }),
+    ];
+    const filtered = filterRankingsItems(models, { ...NO_FILTERS, upstream: "anthropic-hk" });
+    expect(filtered).toHaveLength(1);
+    expect((filtered[0] as LeaderboardModelItem).model).toBe("claude-3");
+
+    // A stale upstream param must not blank out dimensions without a distribution.
+    const upstreams = [upstreamItem({ id: "a" })];
+    expect(
+      filterRankingsItems(upstreams, { ...NO_FILTERS, upstream: "anthropic-hk" })
+    ).toHaveLength(1);
+  });
+
+  it("combines filters with AND semantics", () => {
+    const items = [
+      upstreamItem({ id: "a", name: "OpenAI", request_count: 500, error_rate: 1 }),
+      upstreamItem({ id: "b", name: "OpenAI EU", request_count: 50, error_rate: 1 }),
+      upstreamItem({ id: "c", name: "Claude", request_count: 900, error_rate: 0 }),
+    ];
+    const result = filterRankingsItems(items, {
+      ...NO_FILTERS,
+      query: "openai",
+      minRequests: 100,
+      errorsOnly: true,
+    });
+    expect(result).toHaveLength(1);
+    expect((result[0] as LeaderboardUpstreamItem).id).toBe("a");
+  });
+});
+
+describe("hasActiveFilters", () => {
+  it("reflects whether any filter deviates from the defaults", () => {
+    expect(hasActiveFilters(NO_FILTERS)).toBe(false);
+    expect(hasActiveFilters({ ...NO_FILTERS, query: "x" })).toBe(true);
+    expect(hasActiveFilters({ ...NO_FILTERS, minRequests: 1 })).toBe(true);
+    expect(hasActiveFilters({ ...NO_FILTERS, errorsOnly: true })).toBe(true);
+    expect(hasActiveFilters({ ...NO_FILTERS, upstream: "u" })).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

排行榜页（#229）工具栏新增搜索与过滤：名称搜索、最少请求数下限、仅看有错误开关，以及 models 维度的按所属上游过滤。全部条件进 URL 查询串，视图可分享、可回退。

## Related Issue

Closes #231

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Tests (adding or updating tests)

## Changes

- `rankings-url-state.ts`：`RankingsViewState` 扩展过滤字段（`q` / `min` / `errors` / `upstream`），非法值回退默认、默认值不写入 URL；新增纯函数 `filterRankingsItems`（AND 语义，前端过滤，leaderboard 接口一次返回全量聚合，无后端改动）与 `hasActiveFilters`
- `rankings/page.tsx`：工具栏新增搜索框（300ms debounce，本地回显）、最少请求数输入、「仅看有错误」开关、models 维度的上游 Select（选项聚合自当前数据集的 `upstream_distribution`）、有过滤激活时显示的重置按钮；切换维度时丢弃维度特有的 `upstream` 过滤，通用过滤保留
- `rankings-table.tsx`：新增 `emptyLabel` prop，过滤无匹配时显示「无匹配条目」，与原空态区分
- i18n：`en.json` / `zh-CN.json` 补齐 `rankings.filters.*` 与 `rankings.noMatch`

按 issue「视数据可得性分期」的约定：api_keys / users 按启用状态过滤因 leaderboard 数据不含状态字段，留待后续（需要后端在聚合结果中带出状态）。

## Test Plan

- [x] Local tests pass (`pnpm test:run`) — url-state/filter 单测 + RankingsTable 组件测试 20 项通过
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`)
- [x] Manual testing completed — 全量 `pnpm e2e` 29 项通过（新增 2 个 spec：搜索+阈值+重置、URL 直达恢复+按上游过滤+维度切换清理）；双主题（dark/light）浏览器实查工具栏布局、空态与窄视口换行

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [ ] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Additional Notes

- 过滤后的排名序号（#1/#2…）与环比箭头基于过滤后的视图顺序展示，环比的 prev_rank 仍是全量榜单排名，过滤视图下会有偏移；属展示层已知取舍，如需精确可在后续把原始排名随行透传
- 本地 git 443 出网中断，本分支通过 GitHub Data API 推送（blob/tree 与本地 commit 完全一致，commit 时区被 GitHub 规范为 UTC 导致 SHA 不同）
