### PR TITLE
fix(proxy): fail over on empty upstream responses

### DIFF
--- a/src/app/api/proxy/v1/[...path]/route.ts
+++ b/src/app/api/proxy/v1/[...path]/route.ts
@@ -18,6 +18,7 @@ import {
   applyCompensationHeaders,
   FirstByteTimeoutError,
   StreamIdleTimeoutError,
+  UpstreamEmptyResponseError,
   UpstreamNoContentStreamError,
   type ProxyResult,
   type HeaderDiff,
@@ -869,6 +870,7 @@ function getErrorType(
 ): FailoverAttempt["error_type"] {
   if (error instanceof CircuitBreakerOpenError) return "circuit_open";
   if (error instanceof FirstByteTimeoutError) return "first_byte_timeout";
+  if (error instanceof UpstreamEmptyResponseError) return "upstream_empty_response";
   if (error instanceof UpstreamNoContentStreamError) return "upstream_no_content_stream";
   if (error instanceof StreamIdleTimeoutError) return "stream_idle_timeout";
   if (statusCode === 429) return "http_429";
@@ -893,6 +895,7 @@ function isFailoverableError(error: unknown): boolean {
   if (
     error instanceof FirstByteTimeoutError ||
     error instanceof StreamIdleTimeoutError ||
+    error instanceof UpstreamEmptyResponseError ||
     error instanceof UpstreamNoContentStreamError
   ) {
     return true;

--- a/src/lib/constants/failover-error-types.ts
+++ b/src/lib/constants/failover-error-types.ts
@@ -4,6 +4,7 @@ import type { FailoverErrorType } from "@/types/api";
 export const FAILOVER_ERROR_TYPES = [
   "timeout",
   "first_byte_timeout",
+  "upstream_empty_response",
   "upstream_no_content_stream",
   "stream_idle_timeout",
   "stream_error",

--- a/src/lib/services/proxy-client.ts
+++ b/src/lib/services/proxy-client.ts
@@ -88,6 +88,16 @@ export class StreamIdleTimeoutError extends Error {
 }
 
 /**
+ * Error raised when a successful non-streaming upstream response has no body.
+ */
+export class UpstreamEmptyResponseError extends Error {
+  constructor(public readonly statusCode: number) {
+    super(`Upstream returned HTTP ${statusCode} with an empty response body`);
+    this.name = "UpstreamEmptyResponseError";
+  }
+}
+
+/**
  * Error raised when an upstream SSE stream closes cleanly before producing any
  * content-bearing chunk. This is distinct from FirstByteTimeoutError: the
  * configured first-byte timer never fired — the upstream simply finished the
@@ -957,28 +967,30 @@ async function waitForFirstStreamContent(options: {
   abortController: AbortController;
   hasFirstContent: () => boolean;
 }): Promise<void> {
-  if (!options.timeoutMs || options.timeoutMs <= 0) {
-    return;
-  }
-
   const startedAt = Date.now();
+  const waiters: Promise<void>[] = [
+    options.onFirstContent,
+    options.onStreamDone.then(() => {
+      if (!options.hasFirstContent()) {
+        throw new UpstreamNoContentStreamError(Date.now() - startedAt, options.timeoutMs ?? 0);
+      }
+    }),
+  ];
 
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
-  const timeoutPromise = new Promise<never>((_resolve, reject) => {
-    timeoutId = setTimeout(() => {
-      options.abortController.abort();
-      reject(new FirstByteTimeoutError(options.timeoutMs ?? 0));
-    }, options.timeoutMs);
-  });
-
-  const streamDoneBeforeContentPromise = options.onStreamDone.then(() => {
-    if (!options.hasFirstContent()) {
-      throw new UpstreamNoContentStreamError(Date.now() - startedAt, options.timeoutMs ?? 0);
-    }
-  });
+  if (options.timeoutMs && options.timeoutMs > 0) {
+    waiters.push(
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(() => {
+          options.abortController.abort();
+          reject(new FirstByteTimeoutError(options.timeoutMs ?? 0));
+        }, options.timeoutMs);
+      })
+    );
+  }
 
   try {
-    await Promise.race([options.onFirstContent, streamDoneBeforeContentPromise, timeoutPromise]);
+    await Promise.race(waiters);
   } finally {
     if (timeoutId) {
       clearTimeout(timeoutId);
@@ -1247,6 +1259,11 @@ export async function forwardRequest(
     } else {
       // Regular response
       const bodyBytes = new Uint8Array(await upstreamResponse.arrayBuffer());
+      const isExpectedNoContentStatus =
+        upstreamResponse.status === 204 || upstreamResponse.status === 205;
+      if (upstreamResponse.ok && !isExpectedNoContentStatus && bodyBytes.length === 0) {
+        throw new UpstreamEmptyResponseError(upstreamResponse.status);
+      }
 
       // Try to extract usage from JSON response
       let usage: TokenUsage | undefined;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -869,6 +869,7 @@
     "retryErrorType": {
       "timeout": "timeout",
       "first_byte_timeout": "first-byte timeout",
+      "upstream_empty_response": "upstream empty response",
       "upstream_no_content_stream": "upstream no-content stream",
       "stream_idle_timeout": "stream idle timeout",
       "stream_error": "stream error",

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -869,6 +869,7 @@
     "retryErrorType": {
       "timeout": "超时",
       "first_byte_timeout": "首字超时",
+      "upstream_empty_response": "上游空响应",
       "upstream_no_content_stream": "上游空内容流",
       "stream_idle_timeout": "流空闲超时",
       "stream_error": "流异常",

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -545,6 +545,7 @@ export interface TestUpstreamResponse {
 export type FailoverErrorType =
   | "timeout"
   | "first_byte_timeout"
+  | "upstream_empty_response"
   | "upstream_no_content_stream"
   | "stream_idle_timeout"
   | "stream_error"

--- a/tests/unit/api/proxy/route.test.ts
+++ b/tests/unit/api/proxy/route.test.ts
@@ -130,6 +130,13 @@ vi.mock("@/lib/services/proxy-client", () => {
     }
   }
 
+  class UpstreamEmptyResponseError extends Error {
+    constructor(public readonly statusCode: number) {
+      super(`Upstream returned HTTP ${statusCode} with an empty response body`);
+      this.name = "UpstreamEmptyResponseError";
+    }
+  }
+
   class UpstreamNoContentStreamError extends Error {
     constructor(
       public readonly elapsedMs: number,
@@ -178,6 +185,7 @@ vi.mock("@/lib/services/proxy-client", () => {
     ),
     FirstByteTimeoutError,
     StreamIdleTimeoutError,
+    UpstreamEmptyResponseError,
     UpstreamNoContentStreamError,
   };
 });
@@ -4285,6 +4293,117 @@ describe("proxy route upstream selection", () => {
     expect(markUnhealthy).toHaveBeenCalledTimes(1);
     expect(markUnhealthy).toHaveBeenCalledWith("up-release-error", "fetch failed");
     expect(recordFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("should fail over when an upstream returns an empty successful response", async () => {
+    const { db } = await import("@/lib/db");
+    const { forwardRequest, UpstreamEmptyResponseError } =
+      await import("@/lib/services/proxy-client");
+    const { routeByModel } = await import("@/lib/services/model-router");
+    const { selectFromProviderType } = await import("@/lib/services/load-balancer");
+    const { updateRequestLog } = await import("@/lib/services/request-logger");
+
+    const firstUpstream = {
+      ...DEFAULT_ACTIVE_UPSTREAMS[0],
+      id: "up-first",
+      name: "empty-response",
+      providerType: "openai",
+      routeCapabilities: ["openai_chat_compatible"],
+    };
+    const secondUpstream = {
+      ...DEFAULT_ACTIVE_UPSTREAMS[0],
+      id: "up-second",
+      name: "valid-response",
+      providerType: "openai",
+      routeCapabilities: ["openai_chat_compatible"],
+    };
+
+    vi.mocked(db.query.apiKeys.findMany).mockResolvedValueOnce([
+      { id: "key-1", keyHash: "hash-1", expiresAt: null, isActive: true },
+    ]);
+    vi.mocked(db.query.upstreams.findMany).mockResolvedValueOnce([firstUpstream, secondUpstream]);
+    vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([
+      { upstreamId: firstUpstream.id },
+      { upstreamId: secondUpstream.id },
+    ]);
+    vi.mocked(routeByModel).mockResolvedValueOnce({
+      upstream: firstUpstream,
+      providerType: "openai",
+      resolvedModel: "gpt-5.2",
+      candidateUpstreams: [firstUpstream, secondUpstream],
+      excludedUpstreams: [],
+      routingDecision: {
+        originalModel: "gpt-5.2",
+        resolvedModel: "gpt-5.2",
+        providerType: "openai",
+        upstreamName: firstUpstream.name,
+        allowedModelsFilter: false,
+        modelRedirectApplied: false,
+        circuitBreakerFilter: false,
+        routingType: "provider_type",
+        candidateCount: 2,
+        finalCandidateCount: 2,
+      },
+    });
+    vi.mocked(selectFromProviderType)
+      .mockResolvedValueOnce({
+        upstream: firstUpstream,
+        providerType: "openai",
+        selectedTier: 0,
+        circuitBreakerFiltered: 0,
+        totalCandidates: 2,
+        selectionReason: null,
+      })
+      .mockResolvedValueOnce({
+        upstream: secondUpstream,
+        providerType: "openai",
+        selectedTier: 0,
+        circuitBreakerFiltered: 0,
+        totalCandidates: 2,
+        selectionReason: null,
+      });
+    vi.mocked(forwardRequest)
+      .mockRejectedValueOnce(new UpstreamEmptyResponseError(200))
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+        body: new TextEncoder().encode(JSON.stringify({ id: "valid-response" })),
+        isStream: false,
+        usage: null,
+        headerDiff: null,
+      });
+
+    const request = new NextRequest("http://localhost/api/proxy/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer sk-test",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-5.2",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ path: ["v1", "chat", "completions"] }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ id: "valid-response" });
+    expect(forwardRequest).toHaveBeenCalledTimes(2);
+    expect(updateRequestLog).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        failoverHistory: expect.arrayContaining([
+          expect.objectContaining({
+            upstream_id: firstUpstream.id,
+            error_type: "upstream_empty_response",
+            status_code: 200,
+          }),
+        ]),
+      })
+    );
   });
 
   it("should release a reserved slot exactly once after streaming completes", async () => {

--- a/tests/unit/services/proxy-client.test.ts
+++ b/tests/unit/services/proxy-client.test.ts
@@ -1692,6 +1692,47 @@ describe("proxy-client", () => {
       });
     });
 
+    it("should reject a successful non-streaming response with an empty body", async () => {
+      const mockResponse = new Response(null, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+      global.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      const request = new Request("http://localhost/api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "gpt-4" }),
+      });
+
+      await expect(
+        forwardRequest(request, mockUpstream, "chat/completions", "req-123")
+      ).rejects.toMatchObject({
+        name: "UpstreamEmptyResponseError",
+        statusCode: 200,
+      });
+    });
+
+    it.each([204, 205])(
+      "should preserve a successful no-content status %s without failing over",
+      async (statusCode) => {
+        const mockResponse = new Response(null, { status: statusCode });
+        global.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+        const request = new Request("http://localhost/api", {
+          method: "POST",
+          body: JSON.stringify({ model: "gpt-4" }),
+        });
+
+        const result = await forwardRequest(request, mockUpstream, "chat/completions", "req-123");
+
+        expect(result.statusCode).toBe(statusCode);
+        expect(result.isStream).toBe(false);
+        expect(result.body).toEqual(new Uint8Array());
+      }
+    );
+
     it("should handle streaming response", async () => {
       const sseData = 'data: {"id":"1"}\n\ndata: [DONE]\n\n';
       const mockResponse = new Response(sseData, {
@@ -1756,6 +1797,34 @@ describe("proxy-client", () => {
 
       await vi.runAllTimersAsync();
       await assertion;
+    });
+
+    it("should reject a stream that closes without content when first-byte timeout is disabled", async () => {
+      const sseData = 'data: {"type":"response.created"}\n\ndata: [DONE]\n\n';
+      const mockResponse = new Response(sseData, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+
+      global.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      const request = new Request("http://localhost/api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "gpt-4", stream: true }),
+      });
+
+      await expect(
+        forwardRequest(
+          request,
+          { ...mockUpstream, firstByteTimeout: undefined },
+          "chat/completions",
+          "req-123"
+        )
+      ).rejects.toMatchObject({
+        name: "UpstreamNoContentStreamError",
+        firstByteTimeoutMs: 0,
+      });
     });
 
     it("should raise UpstreamNoContentStreamError when stream closes before content-bearing data", async () => {


### PR DESCRIPTION
## Summary

修复上游返回空响应时被透传到下游的问题。成功但空 body 的非流式响应，以及没有产生有效内容就结束的 SSE 流，都会在响应提交前触发故障转移。

## Related Issue

未关联具体 Issue。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or updating tests)

## Changes

- 新增 `UpstreamEmptyResponseError`，拦截成功状态下的空非流式响应。
- 空 SSE 流不再依赖 `firstByteTimeout` 配置才进行检测。
- 将空响应加入现有故障转移、失败记录和失败规则类型。
- 增加 `proxy-client` 与代理路由回归测试，并补充中英文显示文本。

## Test Plan

- [x] Local tests pass（相关单元测试：`proxy-client` 94/94，代理路由 88 通过）
- [x] Type check passes（`pnpm exec tsc --noEmit`）
- [x] Lint passes（相关文件 ESLint；提交钩子 ESLint）
- [ ] Manual testing completed

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated（不适用）
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

不适用。

## Additional Notes

截图中的 HTTP 499 仍表示下游客户端断开，不属于本次空响应错误。