### PR TITLE
refactor(proxy): 收敛非流式故障转移与终态结算 (#261)

### DIFF
--- a/src/app/api/proxy/v1/[...path]/proxy-non-stream-lifecycle.ts
+++ b/src/app/api/proxy/v1/[...path]/proxy-non-stream-lifecycle.ts
@@ -1,0 +1,481 @@
+import type { Upstream } from "@/lib/db";
+import {
+  applyCompensationHeaders,
+  filterHeaders,
+  injectAuthHeader,
+  prepareUpstreamForProxy,
+  type CompensationHeader,
+  type HeaderDiff,
+  type ProxyResult,
+  type TokenUsage,
+} from "@/lib/services/proxy-client";
+import {
+  logRequest,
+  updateRequestLog,
+  type FailoverAttempt,
+  type LogRequestInput,
+} from "@/lib/services/request-logger";
+import {
+  buildFixture,
+  recordTrafficFixture,
+  type InboundBody,
+} from "@/lib/services/traffic-recorder";
+import type { TrafficRecordingSettingsValue } from "@/lib/services/traffic-recording-service";
+import { resolveUpstreamProvider } from "./proxy-execution";
+import type {
+  EffectiveServiceTier,
+  ReasoningEffort,
+  RequestedServiceTier,
+  RequestThinkingConfig,
+  RoutingDecisionLog,
+} from "@/types/api";
+import type { RouteCapability } from "@/lib/route-capabilities";
+import { createLogger } from "@/lib/utils/logger";
+
+const log = createLogger("proxy-non-stream-lifecycle");
+
+export interface NonStreamApiKeySnapshot {
+  apiKeyName: string | null;
+  apiKeyPrefix: string | null;
+  userId: string | null;
+}
+
+export interface NonStreamBillingUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}
+
+export interface NonStreamLifecycleContext {
+  request: Request;
+  path: string;
+  requestId: string;
+  startTime: number;
+  apiKeyId: string;
+  apiKeySnapshot: NonStreamApiKeySnapshot;
+  reasoningEffort: ReasoningEffort | null;
+  requestedServiceTier: RequestedServiceTier | null;
+  thinkingConfig: RequestThinkingConfig | null;
+  sessionId: string | null;
+  matchedRouteCapability: RouteCapability;
+  inboundBody: InboundBody | null;
+  trafficRecordingSettings: Pick<TrafficRecordingSettingsValue, "redactSensitive">;
+  shouldRecordSuccess: boolean;
+  shouldRecordFailure: boolean;
+  getCompensationHeaders: () => CompensationHeader[];
+  getQueueStatePersistence: () => Promise<void>;
+  awaitRequestLogReady: () => Promise<string | null>;
+  awaitRequestLogUpdate: () => Promise<void>;
+  getRequestLogId: () => string | null;
+  setRequestLogId: (requestLogId: string | null) => void;
+  persistBillingSnapshot: (input: {
+    requestLogId: string;
+    apiKeyId: string | null;
+    upstreamId: string | null;
+    model: string | null;
+    requestedServiceTier: RequestedServiceTier | null;
+    effectiveServiceTier: EffectiveServiceTier | null;
+    usage: NonStreamBillingUsage;
+    requestId: string;
+  }) => Promise<void>;
+  settlement: {
+    response: Response | null;
+  };
+}
+
+export type NonStreamProxyResult = Omit<ProxyResult, "body" | "isStream"> & {
+  body: Uint8Array;
+  isStream: false;
+};
+
+export interface NonStreamSuccessTerminal {
+  outcome: "success";
+  result: NonStreamProxyResult;
+  upstream: Upstream;
+  resolvedModel: string | null;
+  effectiveServiceTier: EffectiveServiceTier | null;
+  usage: TokenUsage | null;
+  routingType: "tiered" | "direct" | "provider_type" | null;
+  priorityTier: number | null;
+  failoverHistory: FailoverAttempt[];
+  routingDecision: RoutingDecisionLog;
+  affinityHit: boolean;
+  affinityMigrated: boolean;
+  sessionIdCompensated: boolean;
+  headerDiff: HeaderDiff | null;
+  routingDurationMs: number | null;
+}
+
+export interface NonStreamFailureFixtureUpstream {
+  id: string;
+  name: string;
+  providerType: string;
+  baseUrl: string;
+}
+
+export interface NonStreamFailureTerminal {
+  outcome: "failure";
+  response: Response;
+  errorStatusCode: number;
+  errorMessage: string;
+  actualUpstreamId: string | null;
+  resolvedModel: string | null;
+  didSendUpstream: boolean;
+  failoverHistory: FailoverAttempt[];
+  routingDecision: RoutingDecisionLog;
+  routingType: "tiered" | "direct" | "provider_type" | null;
+  priorityTier: number | null;
+  routingDurationMs: number | null;
+  sessionIdCompensated: boolean;
+  headerDiff: HeaderDiff | null;
+  fixture?: {
+    providerType: string;
+    responseSource: "upstream" | "gateway";
+    upstream: NonStreamFailureFixtureUpstream;
+    outboundHeaders: Headers | Record<string, string>;
+    response: {
+      statusCode: number;
+      headers: Headers | Record<string, string>;
+      bodyText?: string | null;
+      bodyJson?: unknown | null;
+    };
+    downstreamBody: unknown;
+  };
+}
+
+export type NonStreamTerminal = NonStreamSuccessTerminal | NonStreamFailureTerminal;
+type NonStreamLogFields = Omit<LogRequestInput, "apiKeyId">;
+
+function toBillingUsage(usage: TokenUsage | null): NonStreamBillingUsage {
+  return {
+    promptTokens: usage?.promptTokens || 0,
+    completionTokens: usage?.completionTokens || 0,
+    totalTokens: usage?.totalTokens || 0,
+    cacheReadTokens: usage?.cacheReadTokens || 0,
+    cacheWriteTokens: usage?.cacheCreationTokens || 0,
+  };
+}
+
+function buildSuccessLogFields(
+  context: NonStreamLifecycleContext,
+  terminal: NonStreamSuccessTerminal,
+  usageForBilling: NonStreamBillingUsage,
+  durationMs: number
+): NonStreamLogFields {
+  const { result } = terminal;
+  return {
+    ...context.apiKeySnapshot,
+    upstreamId: terminal.upstream.id,
+    method: context.request.method,
+    path: context.path,
+    model: terminal.resolvedModel,
+    reasoningEffort: context.reasoningEffort,
+    requestedServiceTier: context.requestedServiceTier,
+    effectiveServiceTier: terminal.effectiveServiceTier,
+    promptTokens: usageForBilling.promptTokens,
+    completionTokens: usageForBilling.completionTokens,
+    totalTokens: usageForBilling.totalTokens,
+    cachedTokens: terminal.usage?.cachedTokens || 0,
+    reasoningTokens: terminal.usage?.reasoningTokens || 0,
+    cacheCreationTokens: terminal.usage?.cacheCreationTokens || 0,
+    cacheCreation5mTokens: terminal.usage?.cacheCreation5mTokens || 0,
+    cacheCreation1hTokens: terminal.usage?.cacheCreation1hTokens || 0,
+    cacheReadTokens: terminal.usage?.cacheReadTokens || 0,
+    statusCode: result.statusCode,
+    durationMs,
+    errorMessage: null,
+    routingType: terminal.routingType,
+    priorityTier: terminal.priorityTier,
+    failoverAttempts: terminal.failoverHistory.length,
+    failoverHistory: terminal.failoverHistory.length > 0 ? terminal.failoverHistory : null,
+    routingDecision: terminal.routingDecision,
+    thinkingConfig: context.thinkingConfig,
+    sessionId: context.sessionId,
+    affinityHit: terminal.affinityHit,
+    affinityMigrated: terminal.affinityMigrated,
+    isStream: false,
+    routingDurationMs: terminal.routingDurationMs,
+    sessionIdCompensated: terminal.sessionIdCompensated,
+    headerDiff: terminal.headerDiff,
+  };
+}
+
+function buildFailureLogFields(
+  context: NonStreamLifecycleContext,
+  terminal: NonStreamFailureTerminal,
+  durationMs: number
+): NonStreamLogFields {
+  return {
+    ...context.apiKeySnapshot,
+    upstreamId: terminal.actualUpstreamId,
+    method: context.request.method,
+    path: context.path,
+    model: terminal.resolvedModel,
+    reasoningEffort: context.reasoningEffort,
+    requestedServiceTier: context.requestedServiceTier,
+    effectiveServiceTier: null,
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+    durationMs,
+    routingDurationMs: terminal.routingDurationMs,
+    errorMessage: terminal.errorMessage,
+    routingType: terminal.routingType,
+    priorityTier: terminal.priorityTier,
+    failoverAttempts: terminal.failoverHistory.length,
+    failoverHistory: terminal.failoverHistory.length > 0 ? terminal.failoverHistory : null,
+    routingDecision: terminal.routingDecision,
+    thinkingConfig: context.thinkingConfig,
+    sessionId: context.sessionId,
+    affinityHit: false,
+    affinityMigrated: false,
+    isStream: false,
+    statusCode: terminal.errorStatusCode,
+    sessionIdCompensated: terminal.sessionIdCompensated,
+    headerDiff: terminal.headerDiff,
+  };
+}
+
+async function persistTerminalRequestLog(
+  context: NonStreamLifecycleContext,
+  logFields: NonStreamLogFields
+): Promise<string | null> {
+  try {
+    await context.getQueueStatePersistence();
+    await context.awaitRequestLogReady();
+    await context.awaitRequestLogUpdate();
+  } catch (error) {
+    log.error(
+      { err: error, requestId: context.requestId },
+      "failed to await non-stream request log"
+    );
+  }
+
+  let requestLogId = context.getRequestLogId();
+  try {
+    if (requestLogId) {
+      const updatedLog = await updateRequestLog(requestLogId, logFields);
+      requestLogId = updatedLog?.id ?? requestLogId;
+    } else {
+      const createdLog = await logRequest({
+        apiKeyId: context.apiKeyId,
+        ...logFields,
+      });
+      requestLogId = createdLog.id;
+    }
+  } catch (error) {
+    log.error(
+      { err: error, requestId: context.requestId },
+      "failed to settle non-stream request log"
+    );
+  }
+
+  context.setRequestLogId(requestLogId);
+  return requestLogId;
+}
+
+async function settleNonStreamSuccess(
+  context: NonStreamLifecycleContext,
+  terminal: NonStreamSuccessTerminal
+): Promise<Response> {
+  const bodyBytes = terminal.result.body;
+  const durationMs = Date.now() - context.startTime;
+  const usageForBilling = toBillingUsage(terminal.usage);
+  const logFields = buildSuccessLogFields(context, terminal, usageForBilling, durationMs);
+  const persistedLogId = await persistTerminalRequestLog(context, logFields);
+
+  if (persistedLogId) {
+    await context.persistBillingSnapshot({
+      requestLogId: persistedLogId,
+      apiKeyId: context.apiKeyId,
+      upstreamId: terminal.upstream.id,
+      model: terminal.resolvedModel,
+      requestedServiceTier: context.requestedServiceTier,
+      effectiveServiceTier: terminal.effectiveServiceTier,
+      usage: usageForBilling,
+      requestId: context.requestId,
+    });
+  }
+
+  if (context.shouldRecordSuccess && context.inboundBody) {
+    try {
+      const upstreamForProxy = prepareUpstreamForProxy(terminal.upstream);
+      const outboundHeadersBase = filterHeaders(new Headers(context.request.headers)).filtered;
+      applyCompensationHeaders(outboundHeadersBase, context.getCompensationHeaders());
+      const outboundHeaders = injectAuthHeader(outboundHeadersBase, upstreamForProxy);
+      const responseText = bodyBytes.length > 0 ? new TextDecoder().decode(bodyBytes) : null;
+      let responseJson: unknown | null = null;
+      if (responseText) {
+        try {
+          responseJson = JSON.parse(responseText);
+        } catch {
+          responseJson = null;
+        }
+      }
+
+      const fixture = buildFixture({
+        requestId: context.requestId,
+        startTime: context.startTime,
+        providerType: resolveUpstreamProvider(terminal.upstream, context.matchedRouteCapability),
+        route: context.path,
+        model: terminal.resolvedModel,
+        inboundRequest: {
+          method: context.request.method,
+          path: context.path,
+          headers: context.request.headers,
+          bodyText: context.inboundBody.text,
+          bodyJson: context.inboundBody.json,
+        },
+        upstream: {
+          id: terminal.upstream.id,
+          name: terminal.upstream.name,
+          providerType: resolveUpstreamProvider(terminal.upstream, context.matchedRouteCapability),
+          baseUrl: upstreamForProxy.baseUrl,
+        },
+        outboundHeaders,
+        response: {
+          statusCode: terminal.result.statusCode,
+          headers: terminal.result.headers,
+          bodyText: responseText,
+          bodyJson: responseJson,
+        },
+        outboundRequestSent: true,
+        outboundResponseSource: "upstream",
+        redactSensitive: context.trafficRecordingSettings.redactSensitive,
+      });
+
+      void recordTrafficFixture(fixture, {
+        requestLogId: persistedLogId,
+        apiKeyId: context.apiKeyId,
+        upstreamId: terminal.upstream.id,
+        method: context.request.method,
+        path: context.path,
+        model: terminal.resolvedModel,
+        statusCode: terminal.result.statusCode,
+        outcome: "success",
+      }).catch((error) =>
+        log.error(
+          { err: error, requestId: context.requestId },
+          "failed to record non-stream fixture"
+        )
+      );
+    } catch (error) {
+      log.error({ err: error, requestId: context.requestId }, "failed to build non-stream fixture");
+    }
+  }
+
+  const response = new Response(Buffer.from(bodyBytes), {
+    status: terminal.result.statusCode,
+    headers: new Headers(terminal.result.headers),
+  });
+  context.settlement.response = response;
+  return response;
+}
+
+async function settleNonStreamFailure(
+  context: NonStreamLifecycleContext,
+  terminal: NonStreamFailureTerminal
+): Promise<Response> {
+  const durationMs = Date.now() - context.startTime;
+  const logFields = buildFailureLogFields(context, terminal, durationMs);
+  const persistedLogId = await persistTerminalRequestLog(context, logFields);
+
+  if (persistedLogId && terminal.didSendUpstream) {
+    await context.persistBillingSnapshot({
+      requestLogId: persistedLogId,
+      apiKeyId: context.apiKeyId,
+      upstreamId: terminal.actualUpstreamId,
+      model: terminal.resolvedModel,
+      requestedServiceTier: context.requestedServiceTier,
+      effectiveServiceTier: null,
+      usage: {
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      },
+      requestId: context.requestId,
+    });
+  }
+
+  if (
+    terminal.fixture &&
+    context.shouldRecordFailure &&
+    context.inboundBody &&
+    terminal.didSendUpstream
+  ) {
+    try {
+      const fixture = buildFixture({
+        requestId: context.requestId,
+        startTime: context.startTime,
+        providerType: terminal.fixture.providerType,
+        route: context.path,
+        model: terminal.resolvedModel,
+        inboundRequest: {
+          method: context.request.method,
+          path: context.path,
+          headers: context.request.headers,
+          bodyText: context.inboundBody.text,
+          bodyJson: context.inboundBody.json,
+        },
+        upstream: terminal.fixture.upstream,
+        outboundHeaders: terminal.fixture.outboundHeaders,
+        response: terminal.fixture.response,
+        outboundRequestSent: true,
+        outboundResponseSource: terminal.fixture.responseSource,
+        downstreamResponse: {
+          statusCode: terminal.errorStatusCode,
+          headers: { "content-type": "application/json" },
+          bodyJson: terminal.fixture.downstreamBody,
+        },
+        failoverHistory: terminal.failoverHistory.length > 0 ? terminal.failoverHistory : null,
+        redactSensitive: context.trafficRecordingSettings.redactSensitive,
+      });
+      void recordTrafficFixture(fixture, {
+        requestLogId: persistedLogId,
+        apiKeyId: context.apiKeyId,
+        upstreamId: terminal.actualUpstreamId,
+        method: context.request.method,
+        path: context.path,
+        model: terminal.resolvedModel,
+        statusCode: terminal.errorStatusCode,
+        outcome: "failure",
+      }).catch((error) =>
+        log.error(
+          { err: error, requestId: context.requestId },
+          "failed to record non-stream failure fixture"
+        )
+      );
+    } catch (error) {
+      log.error(
+        { err: error, requestId: context.requestId },
+        "failed to build non-stream failure fixture"
+      );
+    }
+  }
+
+  context.settlement.response = terminal.response;
+  return terminal.response;
+}
+
+/**
+ * Settle exactly one non-stream terminal state. The route owns authentication,
+ * routing and upstream execution; this seam owns the response plus terminal log,
+ * billing and recording side effects.
+ */
+export async function settleNonStreamRequest(
+  context: NonStreamLifecycleContext,
+  terminal: NonStreamTerminal
+): Promise<Response> {
+  if (context.settlement.response) {
+    return context.settlement.response;
+  }
+
+  if (terminal.outcome === "success") {
+    return settleNonStreamSuccess(context, terminal);
+  }
+  return settleNonStreamFailure(context, terminal);
+}

--- a/src/app/api/proxy/v1/[...path]/proxy-non-stream-lifecycle.ts
+++ b/src/app/api/proxy/v1/[...path]/proxy-non-stream-lifecycle.ts
@@ -18,6 +18,7 @@ import {
 import {
   buildFixture,
   recordTrafficFixture,
+  type BuildFixtureParams,
   type InboundBody,
 } from "@/lib/services/traffic-recorder";
 import type { TrafficRecordingSettingsValue } from "@/lib/services/traffic-recording-service";
@@ -34,13 +35,13 @@ import { createLogger } from "@/lib/utils/logger";
 
 const log = createLogger("proxy-non-stream-lifecycle");
 
-export interface NonStreamApiKeySnapshot {
+interface NonStreamApiKeySnapshot {
   apiKeyName: string | null;
   apiKeyPrefix: string | null;
   userId: string | null;
 }
 
-export interface NonStreamBillingUsage {
+interface NonStreamBillingUsage {
   promptTokens: number;
   completionTokens: number;
   totalTokens: number;
@@ -90,7 +91,7 @@ export type NonStreamProxyResult = Omit<ProxyResult, "body" | "isStream"> & {
   isStream: false;
 };
 
-export interface NonStreamSuccessTerminal {
+interface NonStreamSuccessTerminal {
   outcome: "success";
   result: NonStreamProxyResult;
   upstream: Upstream;
@@ -108,7 +109,7 @@ export interface NonStreamSuccessTerminal {
   routingDurationMs: number | null;
 }
 
-export interface NonStreamFailureFixtureUpstream {
+interface NonStreamFailureFixtureUpstream {
   id: string;
   name: string;
   providerType: string;
@@ -145,7 +146,7 @@ export interface NonStreamFailureTerminal {
   };
 }
 
-export type NonStreamTerminal = NonStreamSuccessTerminal | NonStreamFailureTerminal;
+type NonStreamTerminal = NonStreamSuccessTerminal | NonStreamFailureTerminal;
 type NonStreamLogFields = Omit<LogRequestInput, "apiKeyId">;
 
 function toBillingUsage(usage: TokenUsage | null): NonStreamBillingUsage {
@@ -275,6 +276,52 @@ async function persistTerminalRequestLog(
   context.setRequestLogId(requestLogId);
   return requestLogId;
 }
+type NonStreamFixtureBuildInput = Omit<
+  BuildFixtureParams,
+  "requestId" | "startTime" | "route" | "inboundRequest" | "redactSensitive"
+>;
+
+interface NonStreamFixtureMetadata {
+  upstreamId: string | null;
+  statusCode: number;
+  outcome: "success" | "failure";
+}
+
+function buildAndRecordNonStreamFixture(
+  context: NonStreamLifecycleContext,
+  inboundBody: InboundBody,
+  requestLogId: string | null,
+  input: NonStreamFixtureBuildInput,
+  metadata: NonStreamFixtureMetadata
+): void {
+  const fixture = buildFixture({
+    ...input,
+    requestId: context.requestId,
+    startTime: context.startTime,
+    route: context.path,
+    inboundRequest: {
+      method: context.request.method,
+      path: context.path,
+      headers: context.request.headers,
+      bodyText: inboundBody.text,
+      bodyJson: inboundBody.json,
+    },
+    redactSensitive: context.trafficRecordingSettings.redactSensitive,
+  });
+
+  void recordTrafficFixture(fixture, {
+    requestLogId,
+    apiKeyId: context.apiKeyId,
+    upstreamId: metadata.upstreamId,
+    method: context.request.method,
+    path: context.path,
+    model: input.model,
+    statusCode: metadata.statusCode,
+    outcome: metadata.outcome,
+  }).catch((error) =>
+    log.error({ err: error, requestId: context.requestId }, "failed to record non-stream fixture")
+  );
+}
 
 async function settleNonStreamSuccess(
   context: NonStreamLifecycleContext,
@@ -299,7 +346,8 @@ async function settleNonStreamSuccess(
     });
   }
 
-  if (context.shouldRecordSuccess && context.inboundBody) {
+  const inboundBody = context.inboundBody;
+  if (context.shouldRecordSuccess && inboundBody) {
     try {
       const upstreamForProxy = prepareUpstreamForProxy(terminal.upstream);
       const outboundHeadersBase = filterHeaders(new Headers(context.request.headers)).filtered;
@@ -315,51 +363,37 @@ async function settleNonStreamSuccess(
         }
       }
 
-      const fixture = buildFixture({
-        requestId: context.requestId,
-        startTime: context.startTime,
-        providerType: resolveUpstreamProvider(terminal.upstream, context.matchedRouteCapability),
-        route: context.path,
-        model: terminal.resolvedModel,
-        inboundRequest: {
-          method: context.request.method,
-          path: context.path,
-          headers: context.request.headers,
-          bodyText: context.inboundBody.text,
-          bodyJson: context.inboundBody.json,
-        },
-        upstream: {
-          id: terminal.upstream.id,
-          name: terminal.upstream.name,
+      buildAndRecordNonStreamFixture(
+        context,
+        inboundBody,
+        persistedLogId,
+        {
           providerType: resolveUpstreamProvider(terminal.upstream, context.matchedRouteCapability),
-          baseUrl: upstreamForProxy.baseUrl,
+          model: terminal.resolvedModel,
+          upstream: {
+            id: terminal.upstream.id,
+            name: terminal.upstream.name,
+            providerType: resolveUpstreamProvider(
+              terminal.upstream,
+              context.matchedRouteCapability
+            ),
+            baseUrl: upstreamForProxy.baseUrl,
+          },
+          outboundHeaders,
+          response: {
+            statusCode: terminal.result.statusCode,
+            headers: terminal.result.headers,
+            bodyText: responseText,
+            bodyJson: responseJson,
+          },
+          outboundRequestSent: true,
+          outboundResponseSource: "upstream",
         },
-        outboundHeaders,
-        response: {
+        {
+          upstreamId: terminal.upstream.id,
           statusCode: terminal.result.statusCode,
-          headers: terminal.result.headers,
-          bodyText: responseText,
-          bodyJson: responseJson,
-        },
-        outboundRequestSent: true,
-        outboundResponseSource: "upstream",
-        redactSensitive: context.trafficRecordingSettings.redactSensitive,
-      });
-
-      void recordTrafficFixture(fixture, {
-        requestLogId: persistedLogId,
-        apiKeyId: context.apiKeyId,
-        upstreamId: terminal.upstream.id,
-        method: context.request.method,
-        path: context.path,
-        model: terminal.resolvedModel,
-        statusCode: terminal.result.statusCode,
-        outcome: "success",
-      }).catch((error) =>
-        log.error(
-          { err: error, requestId: context.requestId },
-          "failed to record non-stream fixture"
-        )
+          outcome: "success",
+        }
       );
     } catch (error) {
       log.error({ err: error, requestId: context.requestId }, "failed to build non-stream fixture");
@@ -401,59 +435,37 @@ async function settleNonStreamFailure(
     });
   }
 
-  if (
-    terminal.fixture &&
-    context.shouldRecordFailure &&
-    context.inboundBody &&
-    terminal.didSendUpstream
-  ) {
+  const inboundBody = context.inboundBody;
+  const fixture = terminal.fixture;
+  if (fixture && context.shouldRecordFailure && inboundBody && terminal.didSendUpstream) {
     try {
-      const fixture = buildFixture({
-        requestId: context.requestId,
-        startTime: context.startTime,
-        providerType: terminal.fixture.providerType,
-        route: context.path,
-        model: terminal.resolvedModel,
-        inboundRequest: {
-          method: context.request.method,
-          path: context.path,
-          headers: context.request.headers,
-          bodyText: context.inboundBody.text,
-          bodyJson: context.inboundBody.json,
+      buildAndRecordNonStreamFixture(
+        context,
+        inboundBody,
+        persistedLogId,
+        {
+          providerType: fixture.providerType,
+          model: terminal.resolvedModel,
+          upstream: fixture.upstream,
+          outboundHeaders: fixture.outboundHeaders,
+          response: fixture.response,
+          outboundRequestSent: true,
+          outboundResponseSource: fixture.responseSource,
+          downstreamResponse: {
+            statusCode: terminal.errorStatusCode,
+            headers: { "content-type": "application/json" },
+            bodyJson: fixture.downstreamBody,
+          },
+          failoverHistory: terminal.failoverHistory.length > 0 ? terminal.failoverHistory : null,
         },
-        upstream: terminal.fixture.upstream,
-        outboundHeaders: terminal.fixture.outboundHeaders,
-        response: terminal.fixture.response,
-        outboundRequestSent: true,
-        outboundResponseSource: terminal.fixture.responseSource,
-        downstreamResponse: {
+        {
+          upstreamId: terminal.actualUpstreamId,
           statusCode: terminal.errorStatusCode,
-          headers: { "content-type": "application/json" },
-          bodyJson: terminal.fixture.downstreamBody,
-        },
-        failoverHistory: terminal.failoverHistory.length > 0 ? terminal.failoverHistory : null,
-        redactSensitive: context.trafficRecordingSettings.redactSensitive,
-      });
-      void recordTrafficFixture(fixture, {
-        requestLogId: persistedLogId,
-        apiKeyId: context.apiKeyId,
-        upstreamId: terminal.actualUpstreamId,
-        method: context.request.method,
-        path: context.path,
-        model: terminal.resolvedModel,
-        statusCode: terminal.errorStatusCode,
-        outcome: "failure",
-      }).catch((error) =>
-        log.error(
-          { err: error, requestId: context.requestId },
-          "failed to record non-stream failure fixture"
-        )
+          outcome: "failure",
+        }
       );
     } catch (error) {
-      log.error(
-        { err: error, requestId: context.requestId },
-        "failed to build non-stream failure fixture"
-      );
+      log.error({ err: error, requestId: context.requestId }, "failed to build non-stream fixture");
     }
   }
 

--- a/src/app/api/proxy/v1/[...path]/proxy-request-lifecycle.ts
+++ b/src/app/api/proxy/v1/[...path]/proxy-request-lifecycle.ts
@@ -8,6 +8,7 @@ import {
   filterHeaders,
   injectAuthHeader,
   applyCompensationHeaders,
+  type CompensationHeader,
 } from "@/lib/services/proxy-client";
 import {
   logRequest,
@@ -95,6 +96,12 @@ import {
   type ProxyResultWithStreamFailure,
   type StreamRuntimeFailureSettlement,
 } from "./proxy-execution";
+import {
+  settleNonStreamRequest,
+  type NonStreamFailureTerminal,
+  type NonStreamLifecycleContext,
+  type NonStreamProxyResult,
+} from "./proxy-non-stream-lifecycle";
 import { extractRequestThinkingConfig } from "@/lib/utils/request-thinking-config";
 import { apiKeyQuotaTracker } from "@/lib/services/api-key-quota-tracker";
 import {
@@ -300,7 +307,7 @@ async function logApiKeyQuotaRejectedRequest(input: {
   model: string | null;
   reasoningEffort: ReasoningEffort | null;
   requestedServiceTier: RequestedServiceTier | null;
-  thinkingConfig: import("@/types/api").RequestThinkingConfig | null;
+  thinkingConfig: RequestThinkingConfig | null;
   requestId: string;
   startTime: number;
   sessionId: string | null;
@@ -353,7 +360,7 @@ async function logApiKeyAdmissionRejectedRequest(input: {
   model: string | null;
   reasoningEffort: ReasoningEffort | null;
   requestedServiceTier: RequestedServiceTier | null;
-  thinkingConfig: import("@/types/api").RequestThinkingConfig | null;
+  thinkingConfig: RequestThinkingConfig | null;
   requestId: string;
   startTime: number;
   sessionId: string | null;
@@ -1760,6 +1767,7 @@ export async function handleProxy(request: NextRequest, context: RouteContext): 
   let failoverHistory: FailoverAttempt[] = [];
   let requestLogId: string | null = null;
   let requestLogReady: Promise<string | null> = Promise.resolve(null);
+  let requestLogRoutingUpdate: Promise<void> = Promise.resolve();
   let queueStatePersistence: Promise<void> = Promise.resolve();
   let isAffinityHit = false;
   let isAffinityMigrated = false;
@@ -1869,7 +1877,34 @@ export async function handleProxy(request: NextRequest, context: RouteContext): 
   };
 
   // Forward request to upstream
-  let compensationHeaders: import("@/lib/services/proxy-client").CompensationHeader[] = [];
+  let compensationHeaders: CompensationHeader[] = [];
+  const nonStreamLifecycleContext: NonStreamLifecycleContext = {
+    request,
+    path,
+    requestId,
+    startTime,
+    apiKeyId: validApiKey.id,
+    apiKeySnapshot,
+    reasoningEffort,
+    requestedServiceTier,
+    thinkingConfig,
+    sessionId,
+    matchedRouteCapability,
+    inboundBody,
+    trafficRecordingSettings,
+    shouldRecordSuccess,
+    shouldRecordFailure,
+    getCompensationHeaders: () => compensationHeaders,
+    getQueueStatePersistence: () => queueStatePersistence,
+    awaitRequestLogReady,
+    awaitRequestLogUpdate: () => requestLogRoutingUpdate,
+    getRequestLogId: () => requestLogId,
+    setRequestLogId: (value) => {
+      requestLogId = value;
+    },
+    persistBillingSnapshot: persistBillingSnapshotSafely,
+    settlement: { response: null },
+  };
   try {
     // Prepare affinity context if session ID is available
     const contentLength = parseInt(request.headers.get("content-length") ?? "", 10) || 0;
@@ -2057,9 +2092,8 @@ export async function handleProxy(request: NextRequest, context: RouteContext): 
         queue: withQueueStreamFlag(queueLifecycle, result.isStream),
       }
     );
-
-    // Complete the start log asynchronously without delaying response handling.
-    void Promise.all([requestLogReady, queueStatePersistence])
+    // Complete the start log before terminal settlement can overwrite it.
+    requestLogRoutingUpdate = Promise.all([requestLogReady, queueStatePersistence])
       .then(([readyLogId]) => {
         const currentLogId = requestLogId ?? readyLogId;
         if (!currentLogId) {
@@ -2074,9 +2108,10 @@ export async function handleProxy(request: NextRequest, context: RouteContext): 
           thinkingConfig,
         });
       })
-      .catch((error) =>
-        log.error({ err: error, requestId }, "failed to update request log upstream")
-      );
+      .then(() => undefined)
+      .catch((error) => {
+        log.error({ err: error, requestId }, "failed to update request log upstream");
+      });
 
     // Create response headers
     const responseHeaders = new Headers(result.headers);
@@ -2555,9 +2590,7 @@ export async function handleProxy(request: NextRequest, context: RouteContext): 
         headers: responseHeaders,
       });
     } else {
-      // Regular response
       const bodyBytes = result.body as Uint8Array;
-      const durationMs = Date.now() - startTime;
 
       // Try to extract usage from response
       let usage = result.usage;
@@ -2611,159 +2644,27 @@ export async function handleProxy(request: NextRequest, context: RouteContext): 
       // TPM likewise applies to the next request rather than this response.
       recordApiKeyTokenUsage(validApiKey.id, usageForBilling.totalTokens, validApiKey.tpmLimit);
 
-      // Log request
-      await queueStatePersistence;
-      await awaitRequestLogReady();
-      let persistedLogId: string | null = requestLogId;
-      if (requestLogId) {
-        const updatedLog = await updateRequestLog(requestLogId, {
-          ...apiKeySnapshot,
-          upstreamId: upstreamForLogging.id,
-          model: resolvedModel,
-          reasoningEffort,
-          requestedServiceTier,
-          effectiveServiceTier,
-          promptTokens: usageForBilling.promptTokens,
-          completionTokens: usageForBilling.completionTokens,
-          totalTokens: usageForBilling.totalTokens,
-          cachedTokens: usage?.cachedTokens || 0,
-          reasoningTokens: usage?.reasoningTokens || 0,
-          cacheCreationTokens: usage?.cacheCreationTokens || 0,
-          cacheCreation5mTokens: usage?.cacheCreation5mTokens || 0,
-          cacheCreation1hTokens: usage?.cacheCreation1hTokens || 0,
-          cacheReadTokens: usage?.cacheReadTokens || 0,
-          statusCode: result.statusCode,
-          durationMs,
-          routingDurationMs,
-          errorMessage: null,
-          routingType: routingDecision.routingType,
-          priorityTier: routingDecision.priorityTier,
-          failoverAttempts: routingDecision.failoverAttempts,
-          failoverHistory:
-            routingDecision.failoverHistory.length > 0 ? routingDecision.failoverHistory : null,
-          routingDecision: finalRoutingDecisionLog,
-          thinkingConfig,
-          affinityHit: isAffinityHit,
-          affinityMigrated: isAffinityMigrated,
-          isStream: false,
-          sessionIdCompensated,
-          headerDiff,
-        });
-        persistedLogId = updatedLog?.id ?? requestLogId;
-      } else {
-        const createdLog = await logRequest({
-          apiKeyId: validApiKey.id,
-          ...apiKeySnapshot,
-          upstreamId: upstreamForLogging.id,
-          method: request.method,
-          path,
-          model: resolvedModel,
-          reasoningEffort,
-          requestedServiceTier,
-          effectiveServiceTier,
-          promptTokens: usageForBilling.promptTokens,
-          completionTokens: usageForBilling.completionTokens,
-          totalTokens: usageForBilling.totalTokens,
-          cachedTokens: usage?.cachedTokens || 0,
-          reasoningTokens: usage?.reasoningTokens || 0,
-          cacheCreationTokens: usage?.cacheCreationTokens || 0,
-          cacheCreation5mTokens: usage?.cacheCreation5mTokens || 0,
-          cacheCreation1hTokens: usage?.cacheCreation1hTokens || 0,
-          cacheReadTokens: usage?.cacheReadTokens || 0,
-          statusCode: result.statusCode,
-          durationMs,
-          routingDurationMs,
-          routingType: routingDecision.routingType,
-          priorityTier: routingDecision.priorityTier,
-          failoverAttempts: routingDecision.failoverAttempts,
-          failoverHistory:
-            routingDecision.failoverHistory.length > 0 ? routingDecision.failoverHistory : null,
-          routingDecision: finalRoutingDecisionLog,
-          thinkingConfig,
-          sessionId,
-          affinityHit: isAffinityHit,
-          affinityMigrated: isAffinityMigrated,
-          isStream: false,
-          sessionIdCompensated,
-          headerDiff,
-        });
-        persistedLogId = createdLog.id;
-      }
-
-      if (persistedLogId) {
-        await persistBillingSnapshotSafely({
-          requestLogId: persistedLogId,
-          apiKeyId: validApiKey.id,
-          upstreamId: upstreamForLogging.id,
-          model: resolvedModel,
-          requestedServiceTier,
-          effectiveServiceTier,
-          usage: usageForBilling,
-          requestId,
-        });
-      }
-
-      if (shouldRecordSuccess && inboundBody) {
-        const upstreamForProxy = prepareUpstreamForProxy(upstreamForLogging);
-        const outboundHeadersBase = filterHeaders(new Headers(request.headers)).filtered;
-        applyCompensationHeaders(outboundHeadersBase, compensationHeaders);
-        const outboundHeaders = injectAuthHeader(outboundHeadersBase, upstreamForProxy);
-        const responseText = bodyBytes.length > 0 ? new TextDecoder().decode(bodyBytes) : null;
-        let responseJson: unknown | null = null;
-        if (responseText) {
-          try {
-            responseJson = JSON.parse(responseText);
-          } catch {
-            responseJson = null;
-          }
-        }
-
-        const fixture = buildFixture({
-          requestId,
-          startTime,
-          providerType: resolveUpstreamProvider(upstreamForLogging, matchedRouteCapability),
-          route: path,
-          model: resolvedModel,
-          inboundRequest: {
-            method: request.method,
-            path,
-            headers: request.headers,
-            bodyText: inboundBody.text,
-            bodyJson: inboundBody.json,
-          },
-          upstream: {
-            id: upstreamForLogging.id,
-            name: upstreamForLogging.name,
-            providerType: resolveUpstreamProvider(upstreamForLogging, matchedRouteCapability),
-            baseUrl: upstreamForProxy.baseUrl,
-          },
-          outboundHeaders,
-          response: {
-            statusCode: result.statusCode,
-            headers: result.headers,
-            bodyText: responseText,
-            bodyJson: responseJson,
-          },
-          outboundRequestSent: true,
-          outboundResponseSource: "upstream",
-          redactSensitive: trafficRecordingSettings.redactSensitive,
-        });
-
-        void recordTrafficFixture(fixture, {
-          requestLogId: persistedLogId,
-          apiKeyId: validApiKey.id,
-          upstreamId: upstreamForLogging.id,
-          method: request.method,
-          path,
-          model: resolvedModel,
-          statusCode: result.statusCode,
-          outcome: "success",
-        }).catch((error) => log.error({ err: error, requestId }, "failed to record fixture"));
-      }
-
-      return new Response(Buffer.from(bodyBytes), {
-        status: result.statusCode,
-        headers: responseHeaders,
+      const nonStreamResult: NonStreamProxyResult = {
+        ...result,
+        body: bodyBytes,
+        isStream: false,
+      };
+      return settleNonStreamRequest(nonStreamLifecycleContext, {
+        outcome: "success",
+        result: nonStreamResult,
+        upstream: upstreamForLogging,
+        resolvedModel,
+        effectiveServiceTier,
+        usage: usage ?? null,
+        routingType: routingDecision.routingType,
+        priorityTier: routingDecision.priorityTier,
+        failoverHistory: routingDecision.failoverHistory,
+        routingDecision: finalRoutingDecisionLog,
+        affinityHit: isAffinityHit,
+        affinityMigrated: isAffinityMigrated,
+        sessionIdCompensated,
+        headerDiff,
+        routingDurationMs,
       });
     }
   } catch (error) {
@@ -2841,7 +2742,9 @@ export async function handleProxy(request: NextRequest, context: RouteContext): 
       : null;
 
     const errorStatusCode = getHttpStatusForError(errorCode);
-    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    const errorMessage =
+      attributionFailoverAttempt?.error_message ??
+      (error instanceof Error ? error.message : "Unknown error");
     const failureHeaderDiff =
       attributionFailoverAttempt?.header_diff ??
       (error as FailoverErrorWithHistory | null)?.headerDiff ??
@@ -2959,6 +2862,127 @@ export async function handleProxy(request: NextRequest, context: RouteContext): 
           },
         });
       }
+    }
+
+    if (!requestedStream) {
+      const failureResponse = createUnifiedErrorResponse(errorCode, errorDetails);
+      let failureFixture: NonStreamFailureTerminal["fixture"];
+      if (shouldRecordFailure && inboundBody && didSendUpstream) {
+        const fallbackOutboundHeaders = filterHeaders(new Headers(request.headers)).filtered;
+        applyCompensationHeaders(fallbackOutboundHeaders, compensationHeaders);
+        const fallbackProviderType =
+          selectedCandidate != null
+            ? resolveUpstreamProvider(selectedCandidate, matchedRouteCapability)
+            : getProviderByRouteCapability(matchedRouteCapability);
+        const fallbackUpstream = {
+          id: selectedCandidate?.id ?? "unknown",
+          name: selectedCandidate?.name ?? "unknown",
+          providerType: fallbackProviderType,
+          baseUrl: selectedCandidate?.baseUrl ?? "unknown",
+        };
+        let outboundHeaders: Headers | Record<string, string> = fallbackOutboundHeaders;
+        let upstreamForFixture = fallbackUpstream;
+
+        if (attributionFailoverAttempt?.upstream_id) {
+          const attemptProvider =
+            attributionFailoverAttempt.upstream_provider_type === "openai" ||
+            attributionFailoverAttempt.upstream_provider_type === "anthropic" ||
+            attributionFailoverAttempt.upstream_provider_type === "google"
+              ? attributionFailoverAttempt.upstream_provider_type
+              : fallbackProviderType;
+          upstreamForFixture = {
+            id: attributionFailoverAttempt.upstream_id,
+            name: attributionFailoverAttempt.upstream_name,
+            providerType: attemptProvider,
+            baseUrl:
+              attributionFailoverAttempt.upstream_base_url ??
+              selectedCandidate?.baseUrl ??
+              "unknown",
+          };
+
+          try {
+            const attemptedUpstream = await db.query.upstreams.findFirst({
+              where: eq(upstreams.id, attributionFailoverAttempt.upstream_id),
+            });
+            if (attemptedUpstream) {
+              const attemptedUpstreamForProxy = prepareUpstreamForProxy(attemptedUpstream);
+              outboundHeaders = injectAuthHeader(
+                fallbackOutboundHeaders,
+                attemptedUpstreamForProxy
+              );
+              upstreamForFixture = {
+                id: attemptedUpstream.id,
+                name: attemptedUpstream.name,
+                providerType: resolveUpstreamProvider(attemptedUpstream, matchedRouteCapability),
+                baseUrl: attemptedUpstreamForProxy.baseUrl,
+              };
+            }
+          } catch (recorderBuildError) {
+            log.warn(
+              { err: recorderBuildError, requestId },
+              "failed to resolve attempted upstream for non-stream failure fixture"
+            );
+          }
+        } else if (selectedCandidate) {
+          try {
+            const upstreamForProxy = prepareUpstreamForProxy(selectedCandidate);
+            outboundHeaders = injectAuthHeader(fallbackOutboundHeaders, upstreamForProxy);
+            upstreamForFixture = {
+              id: selectedCandidate.id,
+              name: selectedCandidate.name,
+              providerType: resolveUpstreamProvider(selectedCandidate, matchedRouteCapability),
+              baseUrl: upstreamForProxy.baseUrl,
+            };
+          } catch (recorderBuildError) {
+            log.warn(
+              { err: recorderBuildError, requestId },
+              "failed to build upstream auth headers for non-stream failure fixture"
+            );
+          }
+        }
+
+        failureFixture = {
+          providerType: fallbackProviderType,
+          responseSource: attributionFailoverAttempt?.status_code != null ? "upstream" : "gateway",
+          upstream: upstreamForFixture,
+          outboundHeaders,
+          response: {
+            statusCode: attributionFailoverAttempt?.status_code ?? errorStatusCode,
+            headers: attributionFailoverAttempt?.response_headers ?? {},
+            bodyJson: attributionFailoverAttempt?.response_body_json ?? null,
+            bodyText:
+              attributionFailoverAttempt?.response_body_json == null
+                ? (attributionFailoverAttempt?.response_body_text ?? null)
+                : null,
+          },
+          downstreamBody: downstreamErrorBody,
+        };
+      }
+
+      if (error instanceof ClientDisconnectedError) {
+        log.warn({ requestId }, "client disconnected, no response sent");
+      }
+      if (errorCode === "SERVICE_UNAVAILABLE") {
+        log.error({ err: error, requestId }, "proxy error");
+      }
+
+      return settleNonStreamRequest(nonStreamLifecycleContext, {
+        outcome: "failure",
+        response: failureResponse,
+        errorStatusCode,
+        errorMessage,
+        actualUpstreamId,
+        resolvedModel,
+        didSendUpstream,
+        failoverHistory,
+        routingDecision: failureRoutingDecisionLog,
+        routingType,
+        priorityTier,
+        routingDurationMs,
+        sessionIdCompensated,
+        headerDiff: failureHeaderDiff,
+        ...(failureFixture ? { fixture: failureFixture } : {}),
+      });
     }
 
     if (shouldRecordFailure && inboundBody && didSendUpstream) {

--- a/tests/unit/api/proxy/route.test.ts
+++ b/tests/unit/api/proxy/route.test.ts
@@ -6096,6 +6096,9 @@ describe("proxy route upstream selection", () => {
     const { selectFromProviderType, NoHealthyUpstreamsError } =
       await import("@/lib/services/load-balancer");
     const { buildFixture, recordTrafficFixture } = await import("@/lib/services/traffic-recorder");
+    const { updateRequestLog } = await import("@/lib/services/request-logger");
+    const { calculateAndPersistRequestBillingSnapshot } =
+      await import("@/lib/services/billing-cost-service");
 
     vi.mocked(db.query.apiKeys.findMany).mockResolvedValueOnce([
       { id: "key-1", keyHash: "hash-1", expiresAt: null, isActive: true },
@@ -6242,6 +6245,17 @@ describe("proxy route upstream selection", () => {
     );
 
     expect(recordTrafficFixture).toHaveBeenCalledTimes(1);
+    expect(calculateAndPersistRequestBillingSnapshot).toHaveBeenCalledTimes(1);
+    const settledLogWrites = vi
+      .mocked(updateRequestLog)
+      .mock.calls.filter(([, payload]) => payload?.statusCode === 503);
+    expect(settledLogWrites).toHaveLength(1);
+    expect(settledLogWrites[0]?.[1]).toEqual(
+      expect.objectContaining({
+        errorMessage: expect.any(String),
+        failoverHistory: expect.arrayContaining([expect.any(Object)]),
+      })
+    );
   });
 
   it("should not record or bill a request that was never sent upstream", async () => {
@@ -6758,6 +6772,7 @@ describe("proxy route upstream selection", () => {
     expect(response.status).toBe(503);
     expect(buildFixture).not.toHaveBeenCalled();
     expect(recordTrafficFixture).not.toHaveBeenCalled();
+    expect(db.query.upstreams.findFirst).not.toHaveBeenCalled();
   });
 
   it("should record success fixture when RECORDER_MODE is success", async () => {


### PR DESCRIPTION
## Summary

将非流式代理请求的故障转移与终态结算统一收敛到代理请求生命周期 module，保持现有外部响应契约，同时避免终态副作用重复执行。

## Related Issue

Closes #261

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (code improvement without changing functionality)
- [x] Tests (adding or updating tests)
- [ ] Build/CI (changes to build system or CI configuration)

## Changes

- 新增非流式生命周期 seam，统一成功、部分失败和最终失败的响应、请求日志、billing snapshot 与 traffic recording 结算。
- 保留每次 upstream 尝试的 routing decision、failover history、失败原因和实际 upstream 信息。
- 保持可重试失败按既有 failover orchestration 继续转移，并保持候选耗尽的状态与错误契约。
- 通过幂等终态保护避免重复写入日志、计费快照和 recording。
- 将失败 fixture 元数据准备限制在 `shouldRecordFailure && inboundBody && didSendUpstream` 条件内，避免关闭录制时产生无谓的数据库与鉴权开销。
- 增加最终失败结算及录制模式回归断言。

## Test Plan

- [x] Local tests pass (`pnpm test:run`)
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`，0 errors；仅有既存 JSDoc warnings)
- [ ] Manual testing completed (not applicable; backend lifecycle change)

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (not applicable; no public API or UI change)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

Not applicable; no UI changes.

## Additional Notes

本地验证结果：240 个测试文件通过，3588 个测试通过，1 个跳过；TypeScript、lint、Prettier 检查均通过。