### PR TITLE
refactor(proxy): 统一流式成功与下游断开结算 (#262)

### DIFF
--- a/src/app/api/proxy/v1/[...path]/proxy-execution.ts
+++ b/src/app/api/proxy/v1/[...path]/proxy-execution.ts
@@ -1179,6 +1179,11 @@ export async function forwardWithFailover(
         const originalStream = result.body as ReadableStream<Uint8Array>;
         const upstreamStreamFailurePromise = (result as ProxyResultWithStreamFailure)
           .streamFailurePromise;
+        const streamCancellationSignal = (result as ProxyResultWithStreamFailure)
+          .streamCancellationSignal;
+        const streamAbortSignal = streamCancellationSignal
+          ? AbortSignal.any([request.signal, streamCancellationSignal])
+          : request.signal;
         let resolveStreamFailure!: (settlement: StreamRuntimeFailureSettlement) => void;
         const trackedStreamFailurePromise = new Promise<StreamRuntimeFailureSettlement>(
           (resolve) => {
@@ -1192,7 +1197,7 @@ export async function forwardWithFailover(
           originalStream,
           selectedUpstream.id,
           releaseSelectedConnectionOnce,
-          request.signal,
+          streamAbortSignal,
           upstreamForProxy.streamIdleTimeout,
           async ({ errorType, errorMessage }) => {
             let settlement: StreamRuntimeFailureSettlement;

--- a/src/app/api/proxy/v1/[...path]/proxy-execution.ts
+++ b/src/app/api/proxy/v1/[...path]/proxy-execution.ts
@@ -139,6 +139,7 @@ function attachFailoverContext<T extends Error>(
   return enrichedError;
 }
 
+/** Add the streaming flag to a queued request log entry. */
 export function withQueueStreamFlag(
   queue: RoutingQueueLog | null | undefined,
   isStream: boolean
@@ -220,6 +221,7 @@ function isFailoverableError(error: unknown): boolean {
   return false;
 }
 
+/** Determine whether an error means no authorized upstreams are available. */
 export function isNoAuthorizedUpstreamsError(error: unknown): boolean {
   if (error instanceof NoAuthorizedUpstreamsError) {
     return true;
@@ -240,10 +242,12 @@ function isAllCandidatesConcurrencyFullError(error: unknown): boolean {
   return error.message.toLowerCase().includes("max concurrency");
 }
 
+/** Check whether an error represents a queue wait timeout. */
 export function isQueueWaitTimeoutError(error: unknown): error is UpstreamQueueWaitTimeoutError {
   return error instanceof UpstreamQueueWaitTimeoutError;
 }
 
+/** Check whether an error represents an aborted queue wait. */
 export function isQueueWaitAbortedError(error: unknown): error is UpstreamQueueWaitAbortedError {
   return error instanceof UpstreamQueueWaitAbortedError;
 }
@@ -259,6 +263,7 @@ function isDownstreamStreamingError(error: unknown): boolean {
   return hasStreamToken && hasDownstreamContext;
 }
 
+/** Classify the stage where a proxy request failure occurred. */
 export function resolveFailureStage(
   error: unknown,
   didSendUpstream: boolean,
@@ -293,6 +298,7 @@ export function resolveFailureStage(
   return "upstream_request";
 }
 
+/** Map a proxy request failure to its unified error reason. */
 export function resolveFailureReason(
   error: unknown,
   didSendUpstream: boolean,
@@ -328,6 +334,7 @@ export function resolveFailureReason(
   return "UPSTREAM_NETWORK_ERROR";
 }
 
+/** Extract candidates excluded because their circuit breakers are open. */
 export function getCircuitBlockedCandidates(error: unknown): CircuitBlockedCandidate[] {
   if (error instanceof NoHealthyUpstreamsError && error.circuitBlockedCandidates) {
     return error.circuitBlockedCandidates;
@@ -335,12 +342,14 @@ export function getCircuitBlockedCandidates(error: unknown): CircuitBlockedCandi
   return [];
 }
 
+/** Read whether a failover error dispatched a request upstream. */
 export function resolveDidSendUpstream(
   error: FailoverErrorWithHistory | null | undefined
 ): boolean {
   return error?.didSendUpstream === true;
 }
 
+/** Build a user-facing hint for a unified proxy error. */
 export function getUserHint(
   errorCode: UnifiedErrorCode,
   reason: UnifiedErrorReason,
@@ -401,6 +410,7 @@ export function getUserHint(
   return "请稍后重试，或联系管理员检查上游配置与健康状态";
 }
 
+/** Resolve the upstream provider for a route capability. */
 export function resolveUpstreamProvider(
   upstream: Pick<Upstream, "routeCapabilities"> | null | undefined,
   routeCapability: RouteCapability
@@ -743,6 +753,7 @@ export interface ProxyExecutionResult {
   queue: RoutingQueueLog | null;
 }
 
+/** Forward a request through the selected upstreams with failover handling. */
 export async function forwardWithFailover(
   input: ProxyExecutionInput
 ): Promise<ProxyExecutionResult> {

--- a/src/app/api/proxy/v1/[...path]/proxy-request-lifecycle.ts
+++ b/src/app/api/proxy/v1/[...path]/proxy-request-lifecycle.ts
@@ -66,8 +66,6 @@ import type {
 import {
   shouldRecordFixture,
   readRequestBody,
-  readStreamChunks,
-  teeStreamForRecording,
   buildFixture,
   recordTrafficFixture,
 } from "@/lib/services/traffic-recorder";
@@ -94,7 +92,6 @@ import {
   withQueueStreamFlag,
   type FailoverErrorWithHistory,
   type ProxyResultWithStreamFailure,
-  type StreamRuntimeFailureSettlement,
 } from "./proxy-execution";
 import {
   settleNonStreamRequest,
@@ -102,6 +99,13 @@ import {
   type NonStreamLifecycleContext,
   type NonStreamProxyResult,
 } from "./proxy-non-stream-lifecycle";
+import {
+  computeAffinityTokens,
+  createStreamResponse,
+  resolveEffectiveServiceTier,
+  type StreamLifecycleContext,
+  type StreamLifecycleTerminal,
+} from "./proxy-stream-lifecycle";
 import { extractRequestThinkingConfig } from "@/lib/utils/request-thinking-config";
 import { apiKeyQuotaTracker } from "@/lib/services/api-key-quota-tracker";
 import {
@@ -735,115 +739,6 @@ interface RoutingDecision {
   failoverHistory: FailoverAttempt[];
 }
 
-function wrapStreamWithDownstreamSettlement(
-  stream: ReadableStream<Uint8Array>,
-  abortSignal: AbortSignal | undefined,
-  onAbort: () => void
-): ReadableStream<Uint8Array> {
-  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
-  let streamCompleted = false;
-  let abortHandled = false;
-
-  const handleAbortOnce = () => {
-    if (streamCompleted || abortHandled) {
-      return;
-    }
-    abortHandled = true;
-    onAbort();
-  };
-
-  return new ReadableStream({
-    async start(controller) {
-      reader = stream.getReader();
-
-      const abortHandler = () => {
-        handleAbortOnce();
-        void reader?.cancel("Client disconnected").catch(() => undefined);
-        try {
-          controller.close();
-        } catch {
-          // Controller may already be closed.
-        }
-      };
-
-      if (abortSignal) {
-        abortSignal.addEventListener("abort", abortHandler, { once: true });
-      }
-
-      try {
-        while (true) {
-          if (abortSignal?.aborted) {
-            handleAbortOnce();
-            break;
-          }
-
-          const { done, value } = await reader.read();
-          if (done) {
-            streamCompleted = true;
-            break;
-          }
-
-          controller.enqueue(value);
-        }
-
-        controller.close();
-      } catch (error) {
-        if (abortSignal?.aborted) {
-          handleAbortOnce();
-          return;
-        }
-
-        controller.error(error);
-      } finally {
-        reader?.releaseLock();
-        reader = null;
-        if (abortSignal) {
-          abortSignal.removeEventListener("abort", abortHandler);
-        }
-      }
-    },
-    async cancel(reason) {
-      handleAbortOnce();
-      await reader?.cancel(reason);
-    },
-  });
-}
-
-/**
- * Compute total input tokens for affinity tracking without double counting cached tokens.
- *
- * OpenAI already reports cached tokens inside `promptTokens`. Anthropic should add cache tokens
- * only when `input_tokens` is greater than zero; otherwise the fallback `promptTokens` value already
- * equals the cache-token total. `rawInputTokens` lets us distinguish these cases precisely.
- */
-function computeAffinityTokens(
-  routeCapability: RouteCapability,
-  usage: {
-    promptTokens: number;
-    cacheReadTokens?: number;
-    cacheCreationTokens?: number;
-    rawInputTokens?: number;
-  }
-): number {
-  const prompt = usage.promptTokens || 0;
-
-  if (routeCapability !== "anthropic_messages" && routeCapability !== "claude_code_messages") {
-    return prompt;
-  }
-
-  const rawInput = usage.rawInputTokens ?? 0;
-  const cacheRead = usage.cacheReadTokens || 0;
-  const cacheCreation = usage.cacheCreationTokens || 0;
-
-  // rawInputTokens > 0: promptTokens is the raw input_tokens (excludes cache), add cache separately
-  // rawInputTokens === 0: promptTokens was already set to cacheRead + cacheCreation by fallback
-  if (rawInput > 0) {
-    return rawInput + cacheRead + cacheCreation;
-  }
-
-  return prompt;
-}
-
 /**
  * Request context extracted from incoming request
  */
@@ -902,16 +797,6 @@ function normalizeRequestedServiceTier(value: unknown): RequestedServiceTier | n
     return "fast";
   }
   return normalized === "default" ? "standard" : null;
-}
-
-function resolveEffectiveServiceTier(
-  requestedServiceTier: RequestedServiceTier | null,
-  confirmedServiceTier: RequestedServiceTier | null | undefined
-): EffectiveServiceTier | null {
-  if (confirmedServiceTier) {
-    return confirmedServiceTier;
-  }
-  return requestedServiceTier === "fast" ? "unknown" : null;
 }
 
 function normalizeReasoningEffort(value: unknown): ReasoningEffort | null {
@@ -1905,6 +1790,32 @@ export async function handleProxy(request: NextRequest, context: RouteContext): 
     persistBillingSnapshot: persistBillingSnapshotSafely,
     settlement: { response: null },
   };
+  const streamLifecycleContext: StreamLifecycleContext = {
+    request,
+    path,
+    requestId,
+    startTime,
+    apiKeyId: validApiKey.id,
+    apiKeyTpmLimit: validApiKey.tpmLimit,
+    apiKeySnapshot,
+    reasoningEffort,
+    requestedServiceTier,
+    thinkingConfig,
+    sessionId,
+    matchedRouteCapability,
+    inboundBody,
+    trafficRecordingSettings,
+    shouldRecordSuccess,
+    getCompensationHeaders: () => compensationHeaders,
+    getQueueStatePersistence: () => queueStatePersistence,
+    awaitRequestLogReady,
+    awaitRequestLogUpdate: () => requestLogRoutingUpdate,
+    getRequestLogId: () => requestLogId,
+    setRequestLogId: (value) => {
+      requestLogId = value;
+    },
+    persistBillingSnapshot: persistBillingSnapshotSafely,
+  };
   try {
     // Prepare affinity context if session ID is available
     const contentLength = parseInt(request.headers.get("content-length") ?? "", 10) || 0;
@@ -2113,482 +2024,23 @@ export async function handleProxy(request: NextRequest, context: RouteContext): 
         log.error({ err: error, requestId }, "failed to update request log upstream");
       });
 
-    // Create response headers
-    const responseHeaders = new Headers(result.headers);
-
     if (result.isStream) {
-      // Streaming response
-      const originalStream = result.body as ReadableStream<Uint8Array>;
-      let recordingStream: ReadableStream<Uint8Array> | null = null;
-      let responseStream = originalStream;
-      let streamTerminalStateSettled = false;
-
-      if (shouldRecordSuccess && inboundBody) {
-        const [clientStream, recordStream] = teeStreamForRecording(originalStream);
-        recordingStream = recordStream;
-        responseStream = clientStream;
-      }
-      const metricsPromise =
-        result.streamMetricsPromise ??
-        Promise.resolve({
-          usage: result.usage ?? null,
-          effectiveServiceTier: result.effectiveServiceTier ?? null,
-          ttftMs: result.ttftMs,
-        });
-
-      // TPM accounting must follow the upstream metrics settlement, not the
-      // downstream response lifecycle. proxy-client keeps draining its logging
-      // tee after a client disconnects, so settled usage must still constrain
-      // later requests even when stream log settlement is skipped.
-      void metricsPromise
-        .then(({ usage }) => {
-          recordApiKeyTokenUsage(validApiKey.id, usage?.totalTokens ?? 0, validApiKey.tpmLimit);
-        })
-        .catch((error) =>
-          log.error(
-            { err: error, requestId },
-            "failed to record settled stream API key token usage"
-          )
-        );
-
-      const streamOutcomePromise = result.streamFailurePromise
-        ? Promise.race([
-            metricsPromise.then((metrics) => ({ type: "metrics" as const, metrics })),
-            result.streamFailurePromise.then((failure) => ({
-              type: "failure" as const,
-              failure,
-            })),
-          ])
-        : metricsPromise.then((metrics) => ({ type: "metrics" as const, metrics }));
-
-      const settleStreamingDisconnect = async () => {
-        if (streamTerminalStateSettled) {
-          return;
-        }
-        streamTerminalStateSettled = true;
-
-        const disconnectRoutingDecisionLog: RoutingDecisionLog = {
-          ...finalRoutingDecisionLog,
-          failure_stage: "downstream_streaming",
-        };
-        const disconnectStatusCode = getHttpStatusForError("CLIENT_DISCONNECTED");
-        const disconnectErrorMessage = "Client disconnected during downstream streaming";
-        const disconnectDurationMs = Date.now() - startTime;
-        const disconnectUsageForBilling = {
-          promptTokens: 0,
-          completionTokens: 0,
-          totalTokens: 0,
-          cacheReadTokens: 0,
-          cacheWriteTokens: 0,
-        };
-
-        await awaitRequestLogReady();
-        if (requestLogId) {
-          const updatedLog = await updateRequestLog(requestLogId, {
-            ...apiKeySnapshot,
-            upstreamId: upstreamForLogging.id,
-            model: resolvedModel,
-            requestedServiceTier,
-            effectiveServiceTier: null,
-            statusCode: disconnectStatusCode,
-            durationMs: disconnectDurationMs,
-            routingDurationMs,
-            errorMessage: disconnectErrorMessage,
-            routingType: routingDecision.routingType,
-            priorityTier: routingDecision.priorityTier,
-            failoverAttempts: routingDecision.failoverAttempts,
-            failoverHistory:
-              routingDecision.failoverHistory.length > 0 ? routingDecision.failoverHistory : null,
-            routingDecision: disconnectRoutingDecisionLog,
-            thinkingConfig,
-            affinityHit: isAffinityHit,
-            affinityMigrated: isAffinityMigrated,
-            isStream: true,
-            sessionIdCompensated,
-            headerDiff,
-          });
-
-          await persistBillingSnapshotSafely({
-            requestLogId: updatedLog?.id ?? requestLogId,
-            apiKeyId: validApiKey.id,
-            upstreamId: upstreamForLogging.id,
-            model: resolvedModel,
-            requestedServiceTier,
-            effectiveServiceTier: null,
-            usage: disconnectUsageForBilling,
-            requestId,
-          });
-          return;
-        }
-
-        const createdLog = await logRequest({
-          apiKeyId: validApiKey.id,
-          ...apiKeySnapshot,
-          upstreamId: upstreamForLogging.id,
-          method: request.method,
-          path,
-          model: resolvedModel,
-          requestedServiceTier,
-          effectiveServiceTier: null,
-          promptTokens: 0,
-          completionTokens: 0,
-          totalTokens: 0,
-          statusCode: disconnectStatusCode,
-          durationMs: disconnectDurationMs,
-          routingDurationMs,
-          errorMessage: disconnectErrorMessage,
-          routingType: routingDecision.routingType,
-          priorityTier: routingDecision.priorityTier,
-          failoverAttempts: routingDecision.failoverAttempts,
-          failoverHistory:
-            routingDecision.failoverHistory.length > 0 ? routingDecision.failoverHistory : null,
-          routingDecision: disconnectRoutingDecisionLog,
-          thinkingConfig,
-          sessionId,
-          affinityHit: isAffinityHit,
-          affinityMigrated: isAffinityMigrated,
-          isStream: true,
-          sessionIdCompensated,
-          headerDiff,
-        });
-
-        await persistBillingSnapshotSafely({
-          requestLogId: createdLog.id,
-          apiKeyId: validApiKey.id,
-          upstreamId: upstreamForLogging.id,
-          model: resolvedModel,
-          requestedServiceTier,
-          effectiveServiceTier: null,
-          usage: disconnectUsageForBilling,
-          requestId,
-        });
+      const streamLifecycleTerminal: StreamLifecycleTerminal = {
+        result,
+        upstream: upstreamForLogging,
+        resolvedModel,
+        routingType: routingDecision.routingType,
+        priorityTier: routingDecision.priorityTier,
+        failoverHistory: routingDecision.failoverHistory,
+        routingDecision: finalRoutingDecisionLog,
+        finalSelectionReason,
+        affinityHit: isAffinityHit,
+        affinityMigrated: isAffinityMigrated,
+        sessionIdCompensated,
+        headerDiff,
+        routingDurationMs,
       };
-
-      const settleStreamingFailure = async (failure: StreamRuntimeFailureSettlement) => {
-        if (streamTerminalStateSettled) {
-          return;
-        }
-        streamTerminalStateSettled = true;
-
-        const failureRoutingDecisionLog: RoutingDecisionLog = {
-          ...finalRoutingDecisionLog,
-          failure_stage: "downstream_streaming",
-        };
-        const failureDurationMs = Date.now() - startTime;
-        const failureAttempt: FailoverAttempt = {
-          upstream_id: upstreamForLogging.id,
-          upstream_name: upstreamForLogging.name,
-          upstream_provider_type: resolveUpstreamProvider(
-            upstreamForLogging,
-            matchedRouteCapability
-          ),
-          upstream_base_url: upstreamForLogging.baseUrl,
-          attempted_at: failure.occurredAt,
-          error_type: failure.errorType,
-          error_message: failure.errorMessage,
-          status_code: null,
-          selection_reason: finalSelectionReason,
-          header_diff: headerDiff,
-          circuit_breaker_recorded: failure.circuitBreakerRecorded,
-          matched_failure_rule: failure.matchedFailureRule,
-        };
-        const failureHistory = [...routingDecision.failoverHistory, failureAttempt];
-        const failureUsageForBilling = {
-          promptTokens: 0,
-          completionTokens: 0,
-          totalTokens: 0,
-          cacheReadTokens: 0,
-          cacheWriteTokens: 0,
-        };
-
-        await awaitRequestLogReady();
-        if (requestLogId) {
-          const updatedLog = await updateRequestLog(requestLogId, {
-            ...apiKeySnapshot,
-            upstreamId: upstreamForLogging.id,
-            model: resolvedModel,
-            requestedServiceTier,
-            effectiveServiceTier: null,
-            statusCode: failure.statusCode,
-            durationMs: failureDurationMs,
-            routingDurationMs,
-            errorMessage: failure.errorMessage,
-            routingType: routingDecision.routingType,
-            priorityTier: routingDecision.priorityTier,
-            failoverAttempts: failureHistory.length,
-            failoverHistory: failureHistory,
-            routingDecision: failureRoutingDecisionLog,
-            thinkingConfig,
-            affinityHit: isAffinityHit,
-            affinityMigrated: isAffinityMigrated,
-            isStream: true,
-            sessionIdCompensated,
-            headerDiff,
-          });
-
-          await persistBillingSnapshotSafely({
-            requestLogId: updatedLog?.id ?? requestLogId,
-            apiKeyId: validApiKey.id,
-            upstreamId: upstreamForLogging.id,
-            model: resolvedModel,
-            requestedServiceTier,
-            effectiveServiceTier: null,
-            usage: failureUsageForBilling,
-            requestId,
-          });
-          return;
-        }
-
-        const createdLog = await logRequest({
-          apiKeyId: validApiKey.id,
-          ...apiKeySnapshot,
-          upstreamId: upstreamForLogging.id,
-          method: request.method,
-          path,
-          model: resolvedModel,
-          requestedServiceTier,
-          effectiveServiceTier: null,
-          promptTokens: 0,
-          completionTokens: 0,
-          totalTokens: 0,
-          statusCode: failure.statusCode,
-          durationMs: failureDurationMs,
-          routingDurationMs,
-          errorMessage: failure.errorMessage,
-          routingType: routingDecision.routingType,
-          priorityTier: routingDecision.priorityTier,
-          failoverAttempts: failureHistory.length,
-          failoverHistory: failureHistory,
-          routingDecision: failureRoutingDecisionLog,
-          thinkingConfig,
-          sessionId,
-          affinityHit: isAffinityHit,
-          affinityMigrated: isAffinityMigrated,
-          isStream: true,
-          sessionIdCompensated,
-          headerDiff,
-        });
-
-        await persistBillingSnapshotSafely({
-          requestLogId: createdLog.id,
-          apiKeyId: validApiKey.id,
-          upstreamId: upstreamForLogging.id,
-          model: resolvedModel,
-          requestedServiceTier,
-          effectiveServiceTier: null,
-          usage: failureUsageForBilling,
-          requestId,
-        });
-      };
-
-      void streamOutcomePromise
-        .then(async (outcome) => {
-          if (outcome.type === "failure") {
-            await settleStreamingFailure(outcome.failure);
-            return;
-          }
-
-          if (streamTerminalStateSettled || request.signal.aborted) {
-            return;
-          }
-          const { usage, ttftMs } = outcome.metrics;
-          const effectiveServiceTier = resolveEffectiveServiceTier(
-            requestedServiceTier,
-            outcome.metrics.effectiveServiceTier ?? result.effectiveServiceTier
-          );
-
-          // Update session affinity cumulative tokens if we have a session
-          if (affinityContext?.sessionId && usage) {
-            const affinityUsage: AffinityUsage = {
-              totalInputTokens: computeAffinityTokens(matchedRouteCapability, usage),
-            };
-            affinityStore.updateCumulativeTokens(
-              affinityContext.apiKeyId,
-              matchedRouteCapability,
-              affinityContext.sessionId,
-              affinityUsage
-            );
-            log.debug(
-              {
-                requestId,
-                sessionId: affinityContext.sessionId,
-                upstreamId: upstreamForLogging.id,
-                tokens: affinityUsage,
-              },
-              "session affinity: updated cumulative tokens"
-            );
-          }
-
-          const usageForBilling = {
-            promptTokens: usage?.promptTokens || 0,
-            completionTokens: usage?.completionTokens || 0,
-            totalTokens: usage?.totalTokens || 0,
-            cacheReadTokens: usage?.cacheReadTokens || 0,
-            cacheWriteTokens: usage?.cacheCreationTokens || 0,
-          };
-
-          await awaitRequestLogReady();
-          let persistedLogId: string | null = requestLogId;
-          if (requestLogId) {
-            const updatedLog = await updateRequestLog(requestLogId, {
-              ...apiKeySnapshot,
-              upstreamId: upstreamForLogging.id,
-              model: resolvedModel,
-              reasoningEffort,
-              requestedServiceTier,
-              effectiveServiceTier,
-              promptTokens: usageForBilling.promptTokens,
-              completionTokens: usageForBilling.completionTokens,
-              totalTokens: usageForBilling.totalTokens,
-              cachedTokens: usage?.cachedTokens || 0,
-              reasoningTokens: usage?.reasoningTokens || 0,
-              cacheCreationTokens: usage?.cacheCreationTokens || 0,
-              cacheCreation5mTokens: usage?.cacheCreation5mTokens || 0,
-              cacheCreation1hTokens: usage?.cacheCreation1hTokens || 0,
-              cacheReadTokens: usage?.cacheReadTokens || 0,
-              statusCode: result.statusCode,
-              durationMs: Date.now() - startTime,
-              routingDurationMs,
-              errorMessage: null,
-              routingType: routingDecision.routingType,
-              priorityTier: routingDecision.priorityTier,
-              failoverAttempts: routingDecision.failoverAttempts,
-              failoverHistory:
-                routingDecision.failoverHistory.length > 0 ? routingDecision.failoverHistory : null,
-              routingDecision: finalRoutingDecisionLog,
-              thinkingConfig,
-              affinityHit: isAffinityHit,
-              affinityMigrated: isAffinityMigrated,
-              ttftMs: ttftMs ?? null,
-              isStream: true,
-              sessionIdCompensated,
-              headerDiff,
-            });
-            persistedLogId = updatedLog?.id ?? requestLogId;
-          } else {
-            const createdLog = await logRequest({
-              apiKeyId: validApiKey.id,
-              ...apiKeySnapshot,
-              upstreamId: upstreamForLogging.id,
-              method: request.method,
-              path,
-              model: resolvedModel,
-              reasoningEffort,
-              requestedServiceTier,
-              effectiveServiceTier,
-              promptTokens: usageForBilling.promptTokens,
-              completionTokens: usageForBilling.completionTokens,
-              totalTokens: usageForBilling.totalTokens,
-              cachedTokens: usage?.cachedTokens || 0,
-              reasoningTokens: usage?.reasoningTokens || 0,
-              cacheCreationTokens: usage?.cacheCreationTokens || 0,
-              cacheCreation5mTokens: usage?.cacheCreation5mTokens || 0,
-              cacheCreation1hTokens: usage?.cacheCreation1hTokens || 0,
-              cacheReadTokens: usage?.cacheReadTokens || 0,
-              statusCode: result.statusCode,
-              durationMs: Date.now() - startTime,
-              routingDurationMs,
-              routingType: routingDecision.routingType,
-              priorityTier: routingDecision.priorityTier,
-              failoverAttempts: routingDecision.failoverAttempts,
-              failoverHistory:
-                routingDecision.failoverHistory.length > 0 ? routingDecision.failoverHistory : null,
-              routingDecision: finalRoutingDecisionLog,
-              thinkingConfig,
-              sessionId,
-              affinityHit: isAffinityHit,
-              affinityMigrated: isAffinityMigrated,
-              ttftMs: ttftMs ?? null,
-              isStream: true,
-              sessionIdCompensated,
-              headerDiff,
-            });
-            persistedLogId = createdLog.id;
-          }
-
-          if (persistedLogId) {
-            await persistBillingSnapshotSafely({
-              requestLogId: persistedLogId,
-              apiKeyId: validApiKey.id,
-              upstreamId: upstreamForLogging.id,
-              model: resolvedModel,
-              requestedServiceTier,
-              effectiveServiceTier,
-              usage: usageForBilling,
-              requestId,
-            });
-          }
-        })
-        .catch((e) => log.error({ err: e, requestId }, "failed to log request"));
-
-      responseStream = wrapStreamWithDownstreamSettlement(responseStream, request.signal, () => {
-        void settleStreamingDisconnect().catch((error) =>
-          log.error({ err: error, requestId }, "failed to settle downstream streaming disconnect")
-        );
-      });
-
-      // Set streaming headers
-      responseHeaders.set("Content-Type", "text/event-stream");
-      responseHeaders.set("Cache-Control", "no-cache");
-      responseHeaders.set("Connection", "keep-alive");
-
-      if (shouldRecordSuccess && inboundBody && recordingStream) {
-        const upstreamForProxy = prepareUpstreamForProxy(upstreamForLogging);
-        const outboundHeadersBase = filterHeaders(new Headers(request.headers)).filtered;
-        applyCompensationHeaders(outboundHeadersBase, compensationHeaders);
-        const outboundHeaders = injectAuthHeader(outboundHeadersBase, upstreamForProxy);
-        void readStreamChunks(recordingStream)
-          .then(async (chunks) => {
-            const streamRequestLogId = await awaitRequestLogReady();
-            const fixture = buildFixture({
-              requestId,
-              startTime,
-              providerType: resolveUpstreamProvider(upstreamForLogging, matchedRouteCapability),
-              route: path,
-              model: resolvedModel,
-              inboundRequest: {
-                method: request.method,
-                path,
-                headers: request.headers,
-                bodyText: inboundBody.text,
-                bodyJson: inboundBody.json,
-              },
-              upstream: {
-                id: upstreamForLogging.id,
-                name: upstreamForLogging.name,
-                providerType: resolveUpstreamProvider(upstreamForLogging, matchedRouteCapability),
-                baseUrl: upstreamForProxy.baseUrl,
-              },
-              outboundHeaders,
-              response: {
-                statusCode: result.statusCode,
-                headers: result.headers,
-                streamChunks: chunks,
-              },
-              outboundRequestSent: true,
-              outboundResponseSource: "upstream",
-              redactSensitive: trafficRecordingSettings.redactSensitive,
-            });
-            return recordTrafficFixture(fixture, {
-              requestLogId: streamRequestLogId,
-              apiKeyId: validApiKey.id,
-              upstreamId: upstreamForLogging.id,
-              method: request.method,
-              path,
-              model: resolvedModel,
-              statusCode: result.statusCode,
-              outcome: "success",
-            });
-          })
-          .catch((error) =>
-            log.error({ err: error, requestId }, "failed to record stream fixture")
-          );
-      }
-
-      return new Response(responseStream, {
-        status: result.statusCode,
-        headers: responseHeaders,
-      });
+      return createStreamResponse(streamLifecycleContext, streamLifecycleTerminal);
     } else {
       const bodyBytes = result.body as Uint8Array;
 

--- a/src/app/api/proxy/v1/[...path]/proxy-stream-lifecycle.ts
+++ b/src/app/api/proxy/v1/[...path]/proxy-stream-lifecycle.ts
@@ -1,0 +1,785 @@
+import type { Upstream } from "@/lib/db";
+import {
+  applyCompensationHeaders,
+  filterHeaders,
+  injectAuthHeader,
+  prepareUpstreamForProxy,
+  type CompensationHeader,
+  type HeaderDiff,
+  type StreamMetrics,
+  type TokenUsage,
+} from "@/lib/services/proxy-client";
+import {
+  logRequest,
+  updateRequestLog,
+  type FailoverAttempt,
+  type LogRequestInput,
+} from "@/lib/services/request-logger";
+import {
+  buildFixture,
+  readStreamChunks,
+  recordTrafficFixture,
+  teeStreamForRecording,
+  type InboundBody,
+} from "@/lib/services/traffic-recorder";
+import type { TrafficRecordingSettingsValue } from "@/lib/services/traffic-recording-service";
+import { affinityStore, type AffinityUsage } from "@/lib/services/session-affinity";
+import { getHttpStatusForError } from "@/lib/services/unified-error";
+import type { RouteCapability } from "@/lib/route-capabilities";
+import { createLogger } from "@/lib/utils/logger";
+import {
+  resolveUpstreamProvider,
+  type ProxyResultWithStreamFailure,
+  type StreamRuntimeFailureSettlement,
+} from "./proxy-execution";
+import type {
+  EffectiveServiceTier,
+  ReasoningEffort,
+  RequestedServiceTier,
+  RequestThinkingConfig,
+  RoutingDecisionLog,
+  RoutingSelectionReason,
+} from "@/types/api";
+import { recordApiKeyTokenUsage } from "@/lib/services/api-key-rate-limiter";
+
+const log = createLogger("proxy-stream-lifecycle");
+
+interface StreamApiKeySnapshot {
+  apiKeyName: string | null;
+  apiKeyPrefix: string | null;
+  userId: string | null;
+}
+
+interface StreamBillingUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}
+
+export interface StreamLifecycleContext {
+  request: Request;
+  path: string;
+  requestId: string;
+  startTime: number;
+  apiKeyId: string;
+  apiKeyTpmLimit: number | null | undefined;
+  apiKeySnapshot: StreamApiKeySnapshot;
+  reasoningEffort: ReasoningEffort | null;
+  requestedServiceTier: RequestedServiceTier | null;
+  thinkingConfig: RequestThinkingConfig | null;
+  sessionId: string | null;
+  matchedRouteCapability: RouteCapability;
+  inboundBody: InboundBody | null;
+  trafficRecordingSettings: Pick<TrafficRecordingSettingsValue, "redactSensitive">;
+  shouldRecordSuccess: boolean;
+  getCompensationHeaders: () => CompensationHeader[];
+  getQueueStatePersistence: () => Promise<void>;
+  awaitRequestLogReady: () => Promise<string | null>;
+  awaitRequestLogUpdate: () => Promise<void>;
+  getRequestLogId: () => string | null;
+  setRequestLogId: (requestLogId: string | null) => void;
+  persistBillingSnapshot: (input: {
+    requestLogId: string;
+    apiKeyId: string | null;
+    upstreamId: string | null;
+    model: string | null;
+    requestedServiceTier: RequestedServiceTier | null;
+    effectiveServiceTier: EffectiveServiceTier | null;
+    usage: StreamBillingUsage;
+    requestId: string;
+  }) => Promise<void>;
+}
+
+export interface StreamLifecycleTerminal {
+  result: ProxyResultWithStreamFailure;
+  upstream: Upstream;
+  resolvedModel: string | null;
+  routingType: "tiered" | "direct" | "provider_type" | null;
+  priorityTier: number | null;
+  failoverHistory: FailoverAttempt[];
+  routingDecision: RoutingDecisionLog;
+  finalSelectionReason: RoutingSelectionReason | null;
+  affinityHit: boolean;
+  affinityMigrated: boolean;
+  sessionIdCompensated: boolean;
+  headerDiff: HeaderDiff | null;
+  routingDurationMs: number | null;
+}
+
+type StreamLogFields = Omit<LogRequestInput, "apiKeyId">;
+type StreamTerminalOutcome = "success" | "failure" | "disconnect";
+type StreamOutcome =
+  | { type: "metrics"; metrics: StreamMetrics }
+  | { type: "failure"; failure: StreamRuntimeFailureSettlement };
+
+function toBillingUsage(usage: TokenUsage | null): StreamBillingUsage {
+  return {
+    promptTokens: usage?.promptTokens || 0,
+    completionTokens: usage?.completionTokens || 0,
+    totalTokens: usage?.totalTokens || 0,
+    cacheReadTokens: usage?.cacheReadTokens || 0,
+    cacheWriteTokens: usage?.cacheCreationTokens || 0,
+  };
+}
+
+/** Resolve the effective service tier used for stream settlement. */
+export function resolveEffectiveServiceTier(
+  requestedServiceTier: RequestedServiceTier | null,
+  confirmedServiceTier: RequestedServiceTier | null | undefined
+): EffectiveServiceTier | null {
+  if (confirmedServiceTier) {
+    return confirmedServiceTier;
+  }
+  return requestedServiceTier === "fast" ? "unknown" : null;
+}
+
+/** Calculate the token count used to update session affinity. */
+export function computeAffinityTokens(
+  routeCapability: RouteCapability,
+  usage: {
+    promptTokens: number;
+    cacheReadTokens?: number;
+    cacheCreationTokens?: number;
+    rawInputTokens?: number;
+  }
+): number {
+  const prompt = usage.promptTokens || 0;
+
+  if (routeCapability !== "anthropic_messages" && routeCapability !== "claude_code_messages") {
+    return prompt;
+  }
+
+  const rawInput = usage.rawInputTokens ?? 0;
+  const cacheRead = usage.cacheReadTokens || 0;
+  const cacheCreation = usage.cacheCreationTokens || 0;
+
+  if (rawInput > 0) {
+    return rawInput + cacheRead + cacheCreation;
+  }
+
+  return prompt;
+}
+
+function buildSuccessLogFields(
+  context: StreamLifecycleContext,
+  terminal: StreamLifecycleTerminal,
+  metrics: StreamMetrics,
+  usageForBilling: StreamBillingUsage,
+  durationMs: number
+): StreamLogFields {
+  const usage = metrics.usage;
+  return {
+    ...context.apiKeySnapshot,
+    upstreamId: terminal.upstream.id,
+    method: context.request.method,
+    path: context.path,
+    model: terminal.resolvedModel,
+    reasoningEffort: context.reasoningEffort,
+    requestedServiceTier: context.requestedServiceTier,
+    effectiveServiceTier: resolveEffectiveServiceTier(
+      context.requestedServiceTier,
+      metrics.effectiveServiceTier ?? terminal.result.effectiveServiceTier
+    ),
+    promptTokens: usageForBilling.promptTokens,
+    completionTokens: usageForBilling.completionTokens,
+    totalTokens: usageForBilling.totalTokens,
+    cachedTokens: usage?.cachedTokens || 0,
+    reasoningTokens: usage?.reasoningTokens || 0,
+    cacheCreationTokens: usage?.cacheCreationTokens || 0,
+    cacheCreation5mTokens: usage?.cacheCreation5mTokens || 0,
+    cacheCreation1hTokens: usage?.cacheCreation1hTokens || 0,
+    cacheReadTokens: usage?.cacheReadTokens || 0,
+    statusCode: terminal.result.statusCode,
+    durationMs,
+    errorMessage: null,
+    routingType: terminal.routingType,
+    priorityTier: terminal.priorityTier,
+    failoverAttempts: terminal.failoverHistory.length,
+    failoverHistory: terminal.failoverHistory.length > 0 ? terminal.failoverHistory : null,
+    routingDecision: terminal.routingDecision,
+    thinkingConfig: context.thinkingConfig,
+    sessionId: context.sessionId,
+    affinityHit: terminal.affinityHit,
+    affinityMigrated: terminal.affinityMigrated,
+    ttftMs: metrics.ttftMs ?? null,
+    isStream: true,
+    routingDurationMs: terminal.routingDurationMs,
+    sessionIdCompensated: terminal.sessionIdCompensated,
+    headerDiff: terminal.headerDiff,
+  };
+}
+
+function buildDisconnectLogFields(
+  context: StreamLifecycleContext,
+  terminal: StreamLifecycleTerminal,
+  durationMs: number
+): StreamLogFields {
+  return {
+    ...context.apiKeySnapshot,
+    upstreamId: terminal.upstream.id,
+    method: context.request.method,
+    path: context.path,
+    model: terminal.resolvedModel,
+    reasoningEffort: context.reasoningEffort,
+    requestedServiceTier: context.requestedServiceTier,
+    effectiveServiceTier: null,
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+    statusCode: getHttpStatusForError("CLIENT_DISCONNECTED"),
+    durationMs,
+    routingDurationMs: terminal.routingDurationMs,
+    errorMessage: "Client disconnected during downstream streaming",
+    routingType: terminal.routingType,
+    priorityTier: terminal.priorityTier,
+    failoverAttempts: terminal.failoverHistory.length,
+    failoverHistory: terminal.failoverHistory.length > 0 ? terminal.failoverHistory : null,
+    routingDecision: {
+      ...terminal.routingDecision,
+      failure_stage: "downstream_streaming",
+    },
+    thinkingConfig: context.thinkingConfig,
+    sessionId: context.sessionId,
+    affinityHit: terminal.affinityHit,
+    affinityMigrated: terminal.affinityMigrated,
+    isStream: true,
+    sessionIdCompensated: terminal.sessionIdCompensated,
+    headerDiff: terminal.headerDiff,
+  };
+}
+
+function buildFailureLogFields(
+  context: StreamLifecycleContext,
+  terminal: StreamLifecycleTerminal,
+  failure: StreamRuntimeFailureSettlement,
+  durationMs: number
+): { fields: StreamLogFields; failoverHistory: FailoverAttempt[] } {
+  const failureAttempt: FailoverAttempt = {
+    upstream_id: terminal.upstream.id,
+    upstream_name: terminal.upstream.name,
+    upstream_provider_type: resolveUpstreamProvider(
+      terminal.upstream,
+      context.matchedRouteCapability
+    ),
+    upstream_base_url: terminal.upstream.baseUrl,
+    attempted_at: failure.occurredAt,
+    error_type: failure.errorType,
+    error_message: failure.errorMessage,
+    status_code: null,
+    selection_reason: terminal.finalSelectionReason,
+    header_diff: terminal.headerDiff,
+    circuit_breaker_recorded: failure.circuitBreakerRecorded,
+    matched_failure_rule: failure.matchedFailureRule,
+  };
+  const failoverHistory = [...terminal.failoverHistory, failureAttempt];
+
+  return {
+    failoverHistory,
+    fields: {
+      ...context.apiKeySnapshot,
+      upstreamId: terminal.upstream.id,
+      method: context.request.method,
+      path: context.path,
+      model: terminal.resolvedModel,
+      reasoningEffort: context.reasoningEffort,
+      requestedServiceTier: context.requestedServiceTier,
+      effectiveServiceTier: null,
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      statusCode: failure.statusCode,
+      durationMs,
+      routingDurationMs: terminal.routingDurationMs,
+      errorMessage: failure.errorMessage,
+      routingType: terminal.routingType,
+      priorityTier: terminal.priorityTier,
+      failoverAttempts: failoverHistory.length,
+      failoverHistory,
+      routingDecision: {
+        ...terminal.routingDecision,
+        failure_stage: "downstream_streaming",
+      },
+      thinkingConfig: context.thinkingConfig,
+      sessionId: context.sessionId,
+      affinityHit: terminal.affinityHit,
+      affinityMigrated: terminal.affinityMigrated,
+      isStream: true,
+      sessionIdCompensated: terminal.sessionIdCompensated,
+      headerDiff: terminal.headerDiff,
+    },
+  };
+}
+
+async function persistTerminalRequestLog(
+  context: StreamLifecycleContext,
+  fields: StreamLogFields
+): Promise<string | null> {
+  try {
+    await context.getQueueStatePersistence();
+    await context.awaitRequestLogReady();
+    await context.awaitRequestLogUpdate();
+  } catch (error) {
+    log.error(
+      { err: error, requestId: context.requestId },
+      "failed to await streaming request log"
+    );
+  }
+
+  let requestLogId = context.getRequestLogId();
+  try {
+    if (requestLogId) {
+      const updatedLog = await updateRequestLog(requestLogId, fields);
+      requestLogId = updatedLog?.id ?? requestLogId;
+    } else {
+      const createdLog = await logRequest({
+        apiKeyId: context.apiKeyId,
+        ...fields,
+      });
+      requestLogId = createdLog.id;
+    }
+  } catch (error) {
+    log.error(
+      { err: error, requestId: context.requestId },
+      "failed to settle streaming request log"
+    );
+  }
+
+  context.setRequestLogId(requestLogId);
+  return requestLogId;
+}
+
+async function persistZeroUsageBilling(
+  context: StreamLifecycleContext,
+  terminal: StreamLifecycleTerminal,
+  requestLogId: string
+): Promise<void> {
+  await context.persistBillingSnapshot({
+    requestLogId,
+    apiKeyId: context.apiKeyId,
+    upstreamId: terminal.upstream.id,
+    model: terminal.resolvedModel,
+    requestedServiceTier: context.requestedServiceTier,
+    effectiveServiceTier: null,
+    usage: {
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    },
+    requestId: context.requestId,
+  });
+}
+
+function buildAndRecordSuccessFixture(
+  context: StreamLifecycleContext,
+  terminal: StreamLifecycleTerminal,
+  inboundBody: InboundBody,
+  requestLogId: string | null,
+  chunks: string[]
+): void {
+  try {
+    const upstreamForProxy = prepareUpstreamForProxy(terminal.upstream);
+    const outboundHeadersBase = filterHeaders(new Headers(context.request.headers)).filtered;
+    applyCompensationHeaders(outboundHeadersBase, context.getCompensationHeaders());
+    const outboundHeaders = injectAuthHeader(outboundHeadersBase, upstreamForProxy);
+    const providerType = resolveUpstreamProvider(terminal.upstream, context.matchedRouteCapability);
+    const fixture = buildFixture({
+      requestId: context.requestId,
+      startTime: context.startTime,
+      providerType,
+      route: context.path,
+      model: terminal.resolvedModel,
+      inboundRequest: {
+        method: context.request.method,
+        path: context.path,
+        headers: context.request.headers,
+        bodyText: inboundBody.text,
+        bodyJson: inboundBody.json,
+      },
+      upstream: {
+        id: terminal.upstream.id,
+        name: terminal.upstream.name,
+        providerType,
+        baseUrl: upstreamForProxy.baseUrl,
+      },
+      outboundHeaders,
+      response: {
+        statusCode: terminal.result.statusCode,
+        headers: terminal.result.headers,
+        streamChunks: chunks,
+      },
+      outboundRequestSent: true,
+      outboundResponseSource: "upstream",
+      redactSensitive: context.trafficRecordingSettings.redactSensitive,
+    });
+
+    void recordTrafficFixture(fixture, {
+      requestLogId,
+      apiKeyId: context.apiKeyId,
+      upstreamId: terminal.upstream.id,
+      method: context.request.method,
+      path: context.path,
+      model: terminal.resolvedModel,
+      statusCode: terminal.result.statusCode,
+      outcome: "success",
+    }).catch((error) =>
+      log.error({ err: error, requestId: context.requestId }, "failed to record stream fixture")
+    );
+  } catch (error) {
+    log.error({ err: error, requestId: context.requestId }, "failed to build stream fixture");
+  }
+}
+
+function wrapStreamWithDownstreamSettlement(
+  stream: ReadableStream<Uint8Array>,
+  abortSignal: AbortSignal | undefined,
+  onAbort: () => void,
+  onComplete: () => void
+): ReadableStream<Uint8Array> {
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let streamCompleted = false;
+  let abortHandled = false;
+
+  const handleAbortOnce = () => {
+    if (streamCompleted || abortHandled) {
+      return;
+    }
+    abortHandled = true;
+    onAbort();
+  };
+
+  return new ReadableStream({
+    async start(controller) {
+      reader = stream.getReader();
+
+      const abortHandler = () => {
+        handleAbortOnce();
+        void reader?.cancel("Client disconnected").catch(() => undefined);
+        try {
+          controller.close();
+        } catch {
+          // Controller may already be closed.
+        }
+      };
+
+      if (abortSignal) {
+        abortSignal.addEventListener("abort", abortHandler, { once: true });
+      }
+
+      try {
+        while (true) {
+          if (abortSignal?.aborted) {
+            handleAbortOnce();
+            break;
+          }
+
+          const { done, value } = await reader.read();
+          if (done) {
+            streamCompleted = true;
+            onComplete();
+            break;
+          }
+
+          controller.enqueue(value);
+        }
+
+        controller.close();
+      } catch (error) {
+        if (abortSignal?.aborted) {
+          handleAbortOnce();
+          return;
+        }
+
+        controller.error(error);
+      } finally {
+        reader?.releaseLock();
+        reader = null;
+        if (abortSignal) {
+          abortSignal.removeEventListener("abort", abortHandler);
+        }
+      }
+    },
+    async cancel(reason) {
+      handleAbortOnce();
+      await reader?.cancel(reason);
+    },
+  });
+}
+
+/**
+ * Adapt a successful upstream stream into the downstream SSE response and own
+ * every post-dispatch terminal side effect exactly once.
+ */
+export function createStreamResponse(
+  context: StreamLifecycleContext,
+  terminal: StreamLifecycleTerminal
+): Response {
+  const originalStream = terminal.result.body as ReadableStream<Uint8Array>;
+  let recordingStream: ReadableStream<Uint8Array> | null = null;
+  let responseStream = originalStream;
+
+  if (context.shouldRecordSuccess && context.inboundBody) {
+    const [clientStream, recordStream] = teeStreamForRecording(originalStream);
+    responseStream = clientStream;
+    recordingStream = recordStream;
+  }
+
+  const metricsPromise =
+    terminal.result.streamMetricsPromise ??
+    Promise.resolve({
+      usage: terminal.result.usage ?? null,
+      effectiveServiceTier: terminal.result.effectiveServiceTier ?? null,
+      ttftMs: terminal.result.ttftMs,
+    });
+
+  void metricsPromise
+    .then(({ usage }) => {
+      recordApiKeyTokenUsage(
+        context.apiKeyId,
+        usage?.totalTokens ?? 0,
+        context.apiKeyTpmLimit ?? null
+      );
+    })
+    .catch((error) =>
+      log.error(
+        { err: error, requestId: context.requestId },
+        "failed to record settled stream API key token usage"
+      )
+    );
+
+  const streamOutcomePromise: Promise<StreamOutcome> = terminal.result.streamFailurePromise
+    ? Promise.race([
+        metricsPromise.then((metrics) => ({ type: "metrics" as const, metrics })),
+        terminal.result.streamFailurePromise.then((failure) => ({
+          type: "failure" as const,
+          failure,
+        })),
+      ])
+    : metricsPromise.then((metrics) => ({ type: "metrics" as const, metrics }));
+  let streamOutcome: StreamOutcome | null = null;
+  let downstreamCompleted = false;
+
+  const { promise: terminalOutcomePromise, resolve: resolveTerminalOutcome } =
+    Promise.withResolvers<StreamTerminalOutcome>();
+  const { promise: terminalSettlementPromise, resolve: resolveTerminalSettlement } =
+    Promise.withResolvers<{
+      outcome: StreamTerminalOutcome;
+      requestLogId: string | null;
+    }>();
+  let terminalSettlement: Promise<void> | null = null;
+  const recordingAbortController = new AbortController();
+  const cancelRecording = () => {
+    if (!recordingAbortController.signal.aborted) {
+      recordingAbortController.abort();
+    }
+  };
+  const cancelActiveStreams = (reason: string) => {
+    terminal.result.cancelStream?.(reason);
+    cancelRecording();
+  };
+
+  const settleOnce = (
+    outcome: StreamTerminalOutcome,
+    settle: () => Promise<void>
+  ): Promise<void> => {
+    if (terminalSettlement) {
+      return terminalSettlement;
+    }
+
+    resolveTerminalOutcome(outcome);
+    terminalSettlement = Promise.resolve()
+      .then(settle)
+      .catch((error) => {
+        log.error(
+          { err: error, requestId: context.requestId, outcome },
+          "failed to settle streaming request"
+        );
+      })
+      .then(() => {
+        resolveTerminalSettlement({
+          outcome,
+          requestLogId: context.getRequestLogId(),
+        });
+      });
+    return terminalSettlement;
+  };
+
+  const settleDisconnect = () => {
+    if (!terminalSettlement) {
+      cancelActiveStreams("Client disconnected");
+    }
+    return settleOnce("disconnect", async () => {
+      const requestLogId = await persistTerminalRequestLog(
+        context,
+        buildDisconnectLogFields(context, terminal, Date.now() - context.startTime)
+      );
+      if (requestLogId) {
+        await persistZeroUsageBilling(context, terminal, requestLogId);
+      }
+    });
+  };
+
+  const settleFailure = (failure: StreamRuntimeFailureSettlement) => {
+    if (!terminalSettlement) {
+      cancelActiveStreams("Stream failed");
+    }
+    return settleOnce("failure", async () => {
+      const failureFields = buildFailureLogFields(
+        context,
+        terminal,
+        failure,
+        Date.now() - context.startTime
+      );
+      const requestLogId = await persistTerminalRequestLog(context, failureFields.fields);
+      if (requestLogId) {
+        await persistZeroUsageBilling(context, terminal, requestLogId);
+      }
+    });
+  };
+
+  const settleSuccess = (metrics: StreamMetrics) =>
+    settleOnce("success", async () => {
+      const usageForBilling = toBillingUsage(metrics.usage);
+      const effectiveServiceTier = resolveEffectiveServiceTier(
+        context.requestedServiceTier,
+        metrics.effectiveServiceTier ?? terminal.result.effectiveServiceTier
+      );
+
+      if (context.sessionId && metrics.usage) {
+        const affinityUsage: AffinityUsage = {
+          totalInputTokens: computeAffinityTokens(context.matchedRouteCapability, metrics.usage),
+        };
+        affinityStore.updateCumulativeTokens(
+          context.apiKeyId,
+          context.matchedRouteCapability,
+          context.sessionId,
+          affinityUsage
+        );
+        log.debug(
+          {
+            requestId: context.requestId,
+            sessionId: context.sessionId,
+            upstreamId: terminal.upstream.id,
+            tokens: affinityUsage,
+          },
+          "session affinity: updated cumulative tokens"
+        );
+      }
+
+      const logFields = buildSuccessLogFields(
+        context,
+        terminal,
+        metrics,
+        usageForBilling,
+        Date.now() - context.startTime
+      );
+      const requestLogId = await persistTerminalRequestLog(context, logFields);
+      if (requestLogId) {
+        await context.persistBillingSnapshot({
+          requestLogId,
+          apiKeyId: context.apiKeyId,
+          upstreamId: terminal.upstream.id,
+          model: terminal.resolvedModel,
+          requestedServiceTier: context.requestedServiceTier,
+          effectiveServiceTier,
+          usage: usageForBilling,
+          requestId: context.requestId,
+        });
+      }
+    });
+
+  const settleDownstreamCompletion = async (): Promise<void> => {
+    if (terminalSettlement) {
+      return;
+    }
+    downstreamCompleted = true;
+    if (context.request.signal.aborted) {
+      await settleDisconnect();
+      return;
+    }
+    if (!streamOutcome) {
+      return;
+    }
+    if (streamOutcome.type === "failure") {
+      await settleFailure(streamOutcome.failure);
+      return;
+    }
+    await settleSuccess(streamOutcome.metrics);
+  };
+
+  const settleStreamOutcome = (outcome: StreamOutcome) => {
+    streamOutcome = outcome;
+    if (outcome.type === "failure") {
+      return settleFailure(outcome.failure);
+    }
+    if (context.request.signal.aborted) {
+      return settleDisconnect();
+    }
+    if (downstreamCompleted) {
+      return settleSuccess(outcome.metrics);
+    }
+    return undefined;
+  };
+
+  void streamOutcomePromise
+    .then(settleStreamOutcome)
+    .catch((error) =>
+      log.error({ err: error, requestId: context.requestId }, "failed to settle stream outcome")
+    );
+
+  responseStream = wrapStreamWithDownstreamSettlement(
+    responseStream,
+    context.request.signal,
+    () => {
+      void settleDisconnect().catch((error) =>
+        log.error(
+          { err: error, requestId: context.requestId },
+          "failed to settle downstream streaming disconnect"
+        )
+      );
+    },
+    () => {
+      void settleDownstreamCompletion().catch((error) =>
+        log.error(
+          { err: error, requestId: context.requestId },
+          "failed to settle downstream stream completion"
+        )
+      );
+    }
+  );
+
+  if (recordingStream && context.inboundBody) {
+    void readStreamChunks(recordingStream, recordingAbortController.signal)
+      .then(async (chunks) => {
+        const outcome = await terminalOutcomePromise;
+        if (outcome !== "success") {
+          return;
+        }
+        const requestLogId =
+          context.getRequestLogId() ??
+          (await terminalSettlementPromise).requestLogId ??
+          (await context.awaitRequestLogReady());
+        buildAndRecordSuccessFixture(context, terminal, context.inboundBody!, requestLogId, chunks);
+      })
+      .catch(async (error) => {
+        const outcome = await terminalOutcomePromise;
+        if (outcome !== "success") {
+          return;
+        }
+        log.error({ err: error, requestId: context.requestId }, "failed to record stream fixture");
+      });
+  }
+
+  const responseHeaders = new Headers(terminal.result.headers);
+  responseHeaders.set("Content-Type", "text/event-stream");
+  responseHeaders.set("Cache-Control", "no-cache");
+  responseHeaders.set("Connection", "keep-alive");
+
+  return new Response(responseStream, {
+    status: terminal.result.statusCode,
+    headers: responseHeaders,
+  });
+}

--- a/src/lib/services/proxy-client.ts
+++ b/src/lib/services/proxy-client.ts
@@ -194,6 +194,8 @@ export interface ProxyResult {
   usage?: TokenUsage;
   effectiveServiceTier?: RequestedServiceTier;
   streamMetricsPromise?: Promise<StreamMetrics>;
+  cancelStream?: (reason?: string) => void;
+  streamCancellationSignal?: AbortSignal;
   ttftMs?: number;
   headerDiff?: HeaderDiff;
 }
@@ -941,8 +943,7 @@ export function createSSETransformer(
   });
 }
 
-async function drainStream(stream: ReadableStream<Uint8Array>): Promise<void> {
-  const reader = stream.getReader();
+async function drainStreamReader(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
   try {
     while (true) {
       const { done } = await reader.read();
@@ -1236,7 +1237,12 @@ export async function forwardRequest(
 
   // Abort the upstream fetch when either its timeout or the downstream request ends.
   const controller = new AbortController();
-  const fetchSignal = AbortSignal.any([request.signal, controller.signal]);
+  const streamCancellationController = new AbortController();
+  const fetchSignal = AbortSignal.any([
+    request.signal,
+    controller.signal,
+    streamCancellationController.signal,
+  ]);
   let timeoutTriggered = false;
   const timeoutId = setTimeout(() => {
     timeoutTriggered = true;
@@ -1334,9 +1340,10 @@ export async function forwardRequest(
       );
 
       const [clientStream, loggingStream] = transformedStream.tee();
+      const loggingReader = loggingStream.getReader();
       const streamMetricsPromise = (async (): Promise<StreamMetrics> => {
         try {
-          await drainStream(loggingStream);
+          await drainStreamReader(loggingReader);
         } catch {
           // Ignore stream consumption errors
         } finally {
@@ -1366,6 +1373,11 @@ export async function forwardRequest(
         usage,
         effectiveServiceTier,
         streamMetricsPromise,
+        cancelStream: (reason) => {
+          streamCancellationController.abort(reason);
+          void loggingReader.cancel(reason).catch(() => undefined);
+        },
+        streamCancellationSignal: streamCancellationController.signal,
         headerDiff: requestHeaderDiff,
       };
     } else {

--- a/src/lib/services/traffic-recorder.ts
+++ b/src/lib/services/traffic-recorder.ts
@@ -277,14 +277,29 @@ export async function readRequestBody(request: Request): Promise<InboundBody> {
  * instead of raw TCP frame boundaries. Each returned string is a complete SSE event.
  * Stops recording, without throwing, if total bytes exceed `MAX_RECORDING_BYTES`.
  */
-export async function readStreamChunks(stream: ReadableStream<Uint8Array>): Promise<string[]> {
+export async function readStreamChunks(
+  stream: ReadableStream<Uint8Array>,
+  abortSignal?: AbortSignal
+): Promise<string[]> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   const events: string[] = [];
   let totalBytes = 0;
   let buffer = "";
+  const abortHandler = () => {
+    void reader.cancel("Stream recording cancelled").catch(() => undefined);
+  };
+
+  if (abortSignal) {
+    abortSignal.addEventListener("abort", abortHandler, { once: true });
+  }
 
   try {
+    if (abortSignal?.aborted) {
+      await reader.cancel("Stream recording cancelled");
+      return events;
+    }
+
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
@@ -316,6 +331,7 @@ export async function readStreamChunks(stream: ReadableStream<Uint8Array>): Prom
     }
   } finally {
     reader.releaseLock();
+    abortSignal?.removeEventListener("abort", abortHandler);
   }
   return events;
 }

--- a/tests/unit/api/proxy/proxy-stream-lifecycle.test.ts
+++ b/tests/unit/api/proxy/proxy-stream-lifecycle.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import type { RoutingDecisionLog } from "@/types/api";
+import type { StreamMetrics } from "@/lib/services/proxy-client";
+
+const mocks = vi.hoisted(() => ({
+  logRequest: vi.fn(async () => ({ id: "log-1" })),
+  updateRequestLog: vi.fn(async () => ({ id: "log-1" })),
+  readStreamChunks: vi.fn(async (stream?: ReadableStream<Uint8Array>) => {
+    if (stream) {
+      const reader = stream.getReader();
+      await reader.read();
+      await reader.cancel("recording test complete");
+    }
+    return ["data: captured\n\n"];
+  }),
+  buildFixture: vi.fn((params: unknown) => params),
+  recordTrafficFixture: vi.fn(async () => "/tmp/fixture.json"),
+  persistBillingSnapshot: vi.fn(async () => undefined),
+  recordApiKeyTokenUsage: vi.fn(),
+  updateCumulativeTokens: vi.fn(),
+}));
+
+vi.mock("@/lib/services/proxy-client", () => ({
+  applyCompensationHeaders: vi.fn(() => []),
+  filterHeaders: vi.fn(() => ({ filtered: {}, dropped: [] })),
+  injectAuthHeader: vi.fn((headers: Record<string, string>) => headers),
+  prepareUpstreamForProxy: vi.fn(
+    (upstream: { id: string; name: string; providerType: string; baseUrl: string }) => ({
+      id: upstream.id,
+      name: upstream.name,
+      providerType: upstream.providerType,
+      baseUrl: upstream.baseUrl,
+      apiKey: "decrypted-key",
+      timeout: 60,
+    })
+  ),
+}));
+
+vi.mock("@/lib/services/request-logger", () => ({
+  logRequest: mocks.logRequest,
+  updateRequestLog: mocks.updateRequestLog,
+}));
+
+vi.mock("@/lib/services/traffic-recorder", () => ({
+  buildFixture: mocks.buildFixture,
+  readStreamChunks: mocks.readStreamChunks,
+  recordTrafficFixture: mocks.recordTrafficFixture,
+  teeStreamForRecording: (stream: ReadableStream<Uint8Array>) => stream.tee(),
+}));
+
+vi.mock("@/lib/services/session-affinity", () => ({
+  affinityStore: {
+    updateCumulativeTokens: mocks.updateCumulativeTokens,
+  },
+}));
+
+vi.mock("@/lib/services/unified-error", () => ({
+  getHttpStatusForError: vi.fn(() => 499),
+}));
+
+vi.mock("@/lib/services/api-key-rate-limiter", () => ({
+  recordApiKeyTokenUsage: mocks.recordApiKeyTokenUsage,
+}));
+
+vi.mock("@/lib/utils/logger", () => {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return {
+    createLogger: vi.fn(() => logger),
+  };
+});
+
+vi.mock("@/app/api/proxy/v1/[...path]/proxy-execution", () => ({
+  resolveUpstreamProvider: vi.fn(() => "openai"),
+}));
+
+const { createStreamResponse } =
+  await import("@/app/api/proxy/v1/[...path]/proxy-stream-lifecycle");
+
+type StreamLifecycleContext = Parameters<typeof createStreamResponse>[0];
+type StreamLifecycleTerminal = Parameters<typeof createStreamResponse>[1];
+
+const ROUTING_DECISION: RoutingDecisionLog = {
+  original_model: "gpt-4.1",
+  resolved_model: "gpt-4.1",
+  model_redirect_applied: false,
+  provider_type: "openai",
+  routing_type: "tiered",
+  candidates: [],
+  excluded: [],
+  candidate_count: 1,
+  final_candidate_count: 1,
+  selected_upstream_id: "upstream-1",
+  selection_strategy: "weighted",
+};
+
+const UPSTREAM = {
+  id: "upstream-1",
+  name: "openai-main",
+  providerType: "openai",
+  baseUrl: "https://upstream.example/v1",
+} as StreamLifecycleTerminal["upstream"];
+
+function makeContext(signal: AbortSignal): StreamLifecycleContext {
+  let requestLogId: string | null = "log-1";
+  const request = new Request("http://localhost/api/proxy/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer sk-test",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ model: "gpt-4.1", stream: true }),
+    signal,
+  });
+
+  return {
+    request,
+    path: "chat/completions",
+    requestId: "request-1",
+    startTime: Date.now(),
+    apiKeyId: "key-1",
+    apiKeyTpmLimit: 10_000,
+    apiKeySnapshot: {
+      apiKeyName: "test-key",
+      apiKeyPrefix: "sk-test",
+      userId: null,
+    },
+    reasoningEffort: null,
+    requestedServiceTier: "fast",
+    thinkingConfig: null,
+    sessionId: null,
+    matchedRouteCapability: "openai_chat_compatible",
+    inboundBody: {
+      text: JSON.stringify({ model: "gpt-4.1", stream: true }),
+      json: { model: "gpt-4.1", stream: true },
+      buffer: null,
+    },
+    trafficRecordingSettings: { redactSensitive: true },
+    shouldRecordSuccess: true,
+    getCompensationHeaders: () => [],
+    getQueueStatePersistence: vi.fn(async () => undefined),
+    awaitRequestLogReady: vi.fn(async () => requestLogId),
+    awaitRequestLogUpdate: vi.fn(async () => undefined),
+    getRequestLogId: () => requestLogId,
+    setRequestLogId: (value) => {
+      requestLogId = value;
+    },
+    persistBillingSnapshot: mocks.persistBillingSnapshot,
+  };
+}
+
+function makeTerminal(stream: ReadableStream<Uint8Array>): StreamLifecycleTerminal {
+  return {
+    result: {
+      statusCode: 200,
+      headers: new Headers({ "content-type": "text/event-stream" }),
+      body: stream,
+      isStream: true,
+      cancelStream: vi.fn(),
+      streamMetricsPromise: Promise.resolve({
+        usage: {
+          promptTokens: 7,
+          completionTokens: 5,
+          totalTokens: 12,
+          cachedTokens: 0,
+          reasoningTokens: 0,
+          cacheCreationTokens: 0,
+          cacheReadTokens: 0,
+        },
+        effectiveServiceTier: "standard",
+        ttftMs: 42,
+      }),
+    },
+    upstream: UPSTREAM,
+    resolvedModel: "gpt-4.1",
+    routingType: "tiered",
+    priorityTier: 0,
+    failoverHistory: [],
+    routingDecision: ROUTING_DECISION,
+    finalSelectionReason: null,
+    affinityHit: false,
+    affinityMigrated: false,
+    sessionIdCompensated: false,
+    headerDiff: null,
+    routingDurationMs: 3,
+  };
+}
+
+function makeFiniteStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.logRequest.mockResolvedValue({ id: "log-1" });
+  mocks.updateRequestLog.mockResolvedValue({ id: "log-1" });
+  mocks.readStreamChunks.mockImplementation(async (stream?: ReadableStream<Uint8Array>) => {
+    if (stream) {
+      const reader = stream.getReader();
+      await reader.read();
+      await reader.cancel("recording test complete");
+    }
+    return ["data: captured\n\n"];
+  });
+  mocks.recordTrafficFixture.mockResolvedValue("/tmp/fixture.json");
+  mocks.persistBillingSnapshot.mockResolvedValue(undefined);
+});
+
+describe("createStreamResponse", () => {
+  it("preserves SSE chunks and settles usage, log, billing, and recording once", async () => {
+    const controller = new AbortController();
+    const context = makeContext(controller.signal);
+    const response = createStreamResponse(
+      context,
+      makeTerminal(makeFiniteStream(["data: first\n\n", "data: [DONE]\n\n"]))
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let body = "";
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      body += decoder.decode(chunk.value, { stream: true });
+    }
+    body += decoder.decode();
+
+    expect(body).toBe("data: first\n\ndata: [DONE]\n\n");
+    await expect.poll(() => mocks.persistBillingSnapshot.mock.calls.length).toBe(1);
+    await expect.poll(() => mocks.recordTrafficFixture.mock.calls.length).toBe(1);
+
+    expect(mocks.updateRequestLog).toHaveBeenCalledTimes(1);
+    expect(mocks.updateRequestLog).toHaveBeenCalledWith(
+      "log-1",
+      expect.objectContaining({
+        statusCode: 200,
+        promptTokens: 7,
+        completionTokens: 5,
+        totalTokens: 12,
+        effectiveServiceTier: "standard",
+        isStream: true,
+      })
+    );
+    expect(mocks.persistBillingSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestLogId: "log-1",
+        requestedServiceTier: "fast",
+        effectiveServiceTier: "standard",
+        usage: expect.objectContaining({ totalTokens: 12 }),
+      })
+    );
+    expect(mocks.recordApiKeyTokenUsage).toHaveBeenCalledWith("key-1", 12, 10_000);
+    expect(mocks.recordApiKeyTokenUsage).toHaveBeenCalledTimes(1);
+  });
+  it("waits for downstream completion before settling stream success", async () => {
+    const metrics = Promise.withResolvers<StreamMetrics>();
+    const releaseStream = Promise.withResolvers<void>();
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("data: first\n\n"));
+      },
+      pull(controller) {
+        return releaseStream.promise.then(() => {
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        });
+      },
+    });
+    const terminal = makeTerminal(stream);
+    terminal.result.streamMetricsPromise = metrics.promise;
+    const response = createStreamResponse(makeContext(new AbortController().signal), terminal);
+    const reader = response.body!.getReader();
+
+    await expect(reader.read()).resolves.toEqual(expect.objectContaining({ done: false }));
+    metrics.resolve({
+      usage: {
+        promptTokens: 7,
+        completionTokens: 5,
+        totalTokens: 12,
+        cachedTokens: 0,
+        reasoningTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+      },
+      effectiveServiceTier: "standard",
+      ttftMs: 42,
+    });
+    await Promise.resolve();
+    expect(mocks.persistBillingSnapshot).not.toHaveBeenCalled();
+
+    releaseStream.resolve();
+    await expect(reader.read()).resolves.toEqual(expect.objectContaining({ done: false }));
+    await expect(reader.read()).resolves.toEqual(expect.objectContaining({ done: true }));
+    await expect.poll(() => mocks.persistBillingSnapshot.mock.calls.length).toBe(1);
+  });
+
+  it("settles downstream cancellation as non-success and skips success recording", async () => {
+    const controller = new AbortController();
+    const context = makeContext(controller.signal);
+    let upstreamCancelled = false;
+    const pendingStream = new ReadableStream<Uint8Array>({
+      start(streamController) {
+        streamController.enqueue(new TextEncoder().encode("data: partial\n\n"));
+      },
+      cancel() {
+        upstreamCancelled = true;
+      },
+    });
+    const terminal = makeTerminal(pendingStream);
+    terminal.result.streamMetricsPromise = Promise.withResolvers<StreamMetrics>().promise;
+
+    const response = createStreamResponse(context, terminal);
+    const reader = response.body!.getReader();
+    await expect(reader.read()).resolves.toEqual(expect.objectContaining({ done: false }));
+
+    await reader.cancel("Client disconnected");
+
+    await expect.poll(() => mocks.persistBillingSnapshot.mock.calls.length).toBe(1);
+    expect(mocks.updateRequestLog).toHaveBeenCalledTimes(1);
+    expect(mocks.updateRequestLog).toHaveBeenCalledWith(
+      "log-1",
+      expect.objectContaining({
+        statusCode: 499,
+        errorMessage: "Client disconnected during downstream streaming",
+        effectiveServiceTier: null,
+        isStream: true,
+      })
+    );
+    expect(mocks.persistBillingSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        usage: {
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        },
+      })
+    );
+    expect(mocks.buildFixture).not.toHaveBeenCalled();
+    expect(mocks.recordTrafficFixture).not.toHaveBeenCalled();
+    expect(terminal.result.cancelStream).toHaveBeenCalledWith("Client disconnected");
+    expect(upstreamCancelled).toBe(true);
+  });
+});

--- a/tests/unit/api/proxy/route.test.ts
+++ b/tests/unit/api/proxy/route.test.ts
@@ -6983,6 +6983,11 @@ describe("proxy route upstream selection", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("text/event-stream");
 
+    const reader = response.body?.getReader();
+    expect(reader).toBeDefined();
+    while (!(await reader!.read()).done) {
+      // Drain the downstream response to trigger normal terminal settlement.
+    }
     await Promise.resolve();
     await Promise.resolve();
 

--- a/tests/unit/services/proxy-client.test.ts
+++ b/tests/unit/services/proxy-client.test.ts
@@ -1935,6 +1935,43 @@ describe("proxy-client", () => {
       expect(streamMetrics?.ttftMs).toBeGreaterThanOrEqual(0);
     });
 
+    it("exposes cancellation for an active streaming response", async () => {
+      let upstreamCancelled = false;
+      const encoder = new TextEncoder();
+      const upstreamBody = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode("data: hello\n\n"));
+        },
+        cancel() {
+          upstreamCancelled = true;
+        },
+      });
+      global.fetch = vi.fn().mockResolvedValue(
+        new Response(upstreamBody, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      );
+
+      const request = new Request("http://localhost/api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "gpt-4", stream: true }),
+      });
+
+      const result = await forwardRequest(request, mockUpstream, "chat/completions", "req-123");
+      expect(result.cancelStream).toEqual(expect.any(Function));
+      const reader = (result.body as ReadableStream<Uint8Array>).getReader();
+      await expect(reader.read()).resolves.toEqual(expect.objectContaining({ done: false }));
+
+      result.cancelStream?.("Client disconnected");
+      await reader.cancel("Client disconnected");
+
+      await expect.poll(() => upstreamCancelled).toBe(true);
+      await expect(result.streamMetricsPromise).resolves.toEqual(
+        expect.objectContaining({ usage: null })
+      );
+    });
     it("should time out when a stream never emits content-bearing data", async () => {
       vi.useFakeTimers();
       const encoder = new TextEncoder();

--- a/tests/unit/services/traffic-recorder.test.ts
+++ b/tests/unit/services/traffic-recorder.test.ts
@@ -648,5 +648,23 @@ describe("traffic recorder", () => {
       expect(chunks[chunks.length - 1]).toBe("[RECORDING_TRUNCATED]");
       expect(cancelled).toBe(true);
     });
+    it("cancels the recording reader when the abort signal fires", async () => {
+      const abortController = new AbortController();
+      let cancelled = false;
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("data: partial\n\n"));
+        },
+        cancel() {
+          cancelled = true;
+        },
+      });
+
+      const chunksPromise = readStreamChunks(stream, abortController.signal);
+      abortController.abort();
+
+      await expect(chunksPromise).resolves.toEqual(["data: partial\n\n"]);
+      expect(cancelled).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary

将流式代理响应的终态结算集中到独立生命周期模块，统一处理正常结束、下游断开、usage、请求日志、billing snapshot 与 traffic recording。

## Related Issue

Closes #262

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (code improvement without changing functionality)
- [x] Tests (adding or updating tests)
- [ ] Build/CI (changes to build system or CI configuration)

## Changes

- 新增 `proxy-stream-lifecycle.ts`，以一次性终态门控处理成功、失败和下游断开。
- 仅在下游正常结束后结算成功，避免上游 logging tee 提前完成造成错误成功日志、计费或 recording。
- 下游断开时取消 recording reader、上游 logging reader 和 fetch，并通过组合 signal 避免将取消误判为上游故障。
- 增加正常 SSE、下游断开、上游取消释放和 recording abort 的行为测试。

## Test Plan

- [x] Local tests pass (`pnpm test:run`)
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`, 0 errors; 11 existing JSDoc warnings)
- [ ] Manual testing completed

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

Not applicable; backend proxy lifecycle change.

## Additional Notes

Full Vitest: 241 files, 3593 passed, 1 skipped. The run emitted two simulated `admin-upstreams` error logs from existing fixture cases, but all tests passed.