### PR TITLE
refactor(proxy): 收敛流式失败与终态结算 (#263)

### DIFF
--- a/src/app/api/proxy/v1/[...path]/proxy-execution.ts
+++ b/src/app/api/proxy/v1/[...path]/proxy-execution.ts
@@ -8,6 +8,7 @@ import {
   type CompensationHeader,
   getProxyRequestErrorMetadata,
   type HeaderDiff,
+  type StreamMetrics,
   type ProxyResult,
 } from "@/lib/services/proxy-client";
 import {
@@ -742,7 +743,7 @@ export interface ProxyExecutionInput {
 }
 
 export interface ProxyExecutionResult {
-  result: ProxyResultWithStreamFailure;
+  result: ProxyResultWithStreamSettlement;
   selectedUpstream: Upstream;
   failedUpstreamIds: string[];
   failoverHistory: FailoverAttempt[];
@@ -1188,22 +1189,20 @@ export async function forwardWithFailover(
         // For streaming, wrap the stream to release connection when done
         // and handle mid-stream errors
         const originalStream = result.body as ReadableStream<Uint8Array>;
-        const upstreamStreamFailurePromise = (result as ProxyResultWithStreamFailure)
-          .streamFailurePromise;
-        const streamCancellationSignal = (result as ProxyResultWithStreamFailure)
+        const streamCancellationSignal = (result as ProxyResultWithStreamSettlement)
           .streamCancellationSignal;
         const streamAbortSignal = streamCancellationSignal
           ? AbortSignal.any([request.signal, streamCancellationSignal])
           : request.signal;
-        let resolveStreamFailure!: (settlement: StreamRuntimeFailureSettlement) => void;
-        const trackedStreamFailurePromise = new Promise<StreamRuntimeFailureSettlement>(
-          (resolve) => {
-            resolveStreamFailure = resolve;
-          }
-        );
-        const streamFailurePromise = upstreamStreamFailurePromise
-          ? Promise.race([trackedStreamFailurePromise, upstreamStreamFailurePromise])
-          : trackedStreamFailurePromise;
+        const streamMetricsPromise =
+          result.streamMetricsPromise ??
+          Promise.resolve({
+            usage: result.usage ?? null,
+            effectiveServiceTier: result.effectiveServiceTier ?? null,
+            ttftMs: result.ttftMs,
+          });
+        const { promise: streamSettlementPromise, resolve: resolveStreamSettlement } =
+          Promise.withResolvers<StreamRuntimeSettlement>();
         const wrappedStream = wrapStreamWithConnectionTracking(
           originalStream,
           selectedUpstream.id,
@@ -1239,12 +1238,22 @@ export async function forwardWithFailover(
                 occurredAt: new Date().toISOString(),
               };
             }
-            resolveStreamFailure(settlement);
+            resolveStreamSettlement({ type: "failure", failure: settlement });
             return settlement;
+          },
+          () => {
+            void streamMetricsPromise
+              .then((metrics) => resolveStreamSettlement({ type: "success", metrics }))
+              .catch((error) =>
+                log.error(
+                  { err: error, upstreamId: selectedUpstream.id },
+                  "failed to settle successful stream runtime outcome"
+                )
+              );
           }
         );
         return {
-          result: { ...result, body: wrappedStream, streamFailurePromise },
+          result: { ...result, body: wrappedStream, streamSettlementPromise },
           selectedUpstream,
           failedUpstreamIds,
           failoverHistory,
@@ -1716,8 +1725,12 @@ export interface StreamRuntimeFailureSettlement {
   occurredAt: string;
 }
 
-export interface ProxyResultWithStreamFailure extends ProxyResult {
-  streamFailurePromise?: Promise<StreamRuntimeFailureSettlement>;
+export type StreamRuntimeSettlement =
+  | { type: "success"; metrics: StreamMetrics }
+  | { type: "failure"; failure: StreamRuntimeFailureSettlement };
+
+export interface ProxyResultWithStreamSettlement extends ProxyResult {
+  streamSettlementPromise?: Promise<StreamRuntimeSettlement>;
 }
 
 /**
@@ -1770,7 +1783,8 @@ function wrapStreamWithConnectionTracking(
   onStreamFailure?: (failure: {
     errorType: StreamRuntimeFailureType;
     errorMessage: string;
-  }) => Promise<StreamRuntimeFailureSettlement>
+  }) => Promise<StreamRuntimeFailureSettlement>,
+  onStreamComplete?: () => void
 ): ReadableStream<Uint8Array> {
   let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
   let streamCompleted = false;
@@ -1792,8 +1806,9 @@ function wrapStreamWithConnectionTracking(
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     const timeoutPromise = new Promise<never>((_resolve, reject) => {
       timeoutId = setTimeout(() => {
-        void reader?.cancel("stream_idle_timeout").catch(() => undefined);
+        // Reject before cancelling so the pending read cannot win the race as a normal EOF.
         reject(new StreamIdleTimeoutError(streamIdleTimeoutMs));
+        void reader?.cancel("stream_idle_timeout").catch(() => undefined);
       }, streamIdleTimeoutMs);
     });
 
@@ -1854,6 +1869,7 @@ function wrapStreamWithConnectionTracking(
           // Stream completed successfully - mark healthy and record circuit breaker success.
           void markHealthy(upstreamId, 100);
           void recordSuccess(upstreamId);
+          onStreamComplete?.();
         }
       } catch (error) {
         // Check if this is due to client disconnect

--- a/src/app/api/proxy/v1/[...path]/proxy-request-lifecycle.ts
+++ b/src/app/api/proxy/v1/[...path]/proxy-request-lifecycle.ts
@@ -91,7 +91,7 @@ import {
   resolveUpstreamProvider,
   withQueueStreamFlag,
   type FailoverErrorWithHistory,
-  type ProxyResultWithStreamFailure,
+  type ProxyResultWithStreamSettlement,
 } from "./proxy-execution";
 import {
   settleNonStreamRequest,
@@ -1944,7 +1944,7 @@ export async function handleProxy(request: NextRequest, context: RouteContext): 
       finalSelectionReason,
       queue: queueLifecycle,
     } = proxySelection;
-    const result: ProxyResultWithStreamFailure = proxyResult;
+    const result: ProxyResultWithStreamSettlement = proxyResult;
     const upstreamForLogging: Upstream = selected;
     failoverHistory = history;
     excludedCapabilityCandidates = mergeExcludedCandidates(

--- a/src/app/api/proxy/v1/[...path]/proxy-stream-lifecycle.ts
+++ b/src/app/api/proxy/v1/[...path]/proxy-stream-lifecycle.ts
@@ -29,8 +29,9 @@ import type { RouteCapability } from "@/lib/route-capabilities";
 import { createLogger } from "@/lib/utils/logger";
 import {
   resolveUpstreamProvider,
-  type ProxyResultWithStreamFailure,
+  type ProxyResultWithStreamSettlement,
   type StreamRuntimeFailureSettlement,
+  type StreamRuntimeSettlement,
 } from "./proxy-execution";
 import type {
   EffectiveServiceTier,
@@ -93,7 +94,7 @@ export interface StreamLifecycleContext {
 }
 
 export interface StreamLifecycleTerminal {
-  result: ProxyResultWithStreamFailure;
+  result: ProxyResultWithStreamSettlement;
   upstream: Upstream;
   resolvedModel: string | null;
   routingType: "tiered" | "direct" | "provider_type" | null;
@@ -550,14 +551,12 @@ export function createStreamResponse(
       )
     );
 
-  const streamOutcomePromise: Promise<StreamOutcome> = terminal.result.streamFailurePromise
-    ? Promise.race([
-        metricsPromise.then((metrics) => ({ type: "metrics" as const, metrics })),
-        terminal.result.streamFailurePromise.then((failure) => ({
-          type: "failure" as const,
-          failure,
-        })),
-      ])
+  const streamOutcomePromise: Promise<StreamOutcome> = terminal.result.streamSettlementPromise
+    ? terminal.result.streamSettlementPromise.then((settlement: StreamRuntimeSettlement) =>
+        settlement.type === "failure"
+          ? { type: "failure" as const, failure: settlement.failure }
+          : { type: "metrics" as const, metrics: settlement.metrics }
+      )
     : metricsPromise.then((metrics) => ({ type: "metrics" as const, metrics }));
   let streamOutcome: StreamOutcome | null = null;
   let downstreamCompleted = false;

--- a/tests/unit/api/proxy/proxy-stream-lifecycle.test.ts
+++ b/tests/unit/api/proxy/proxy-stream-lifecycle.test.ts
@@ -268,6 +268,61 @@ describe("createStreamResponse", () => {
     expect(mocks.recordApiKeyTokenUsage).toHaveBeenCalledWith("key-1", 12, 10_000);
     expect(mocks.recordApiKeyTokenUsage).toHaveBeenCalledTimes(1);
   });
+  it("settles runtime stream failure when metrics finish before failure evidence", async () => {
+    const failure = Promise.withResolvers<{
+      type: "failure";
+      failure: {
+        errorType: "stream_idle_timeout";
+        errorMessage: string;
+        statusCode: number;
+        matchedFailureRule: null;
+        circuitBreakerRecorded: boolean;
+        occurredAt: string;
+      };
+    }>();
+    const terminal = makeTerminal(makeFiniteStream(["data: partial\n\n"]));
+    terminal.result.streamMetricsPromise = Promise.resolve({
+      usage: null,
+      effectiveServiceTier: null,
+      ttftMs: 42,
+    });
+    terminal.result.streamSettlementPromise = failure.promise;
+
+    const response = createStreamResponse(makeContext(new AbortController().signal), terminal);
+    const reader = response.body!.getReader();
+    await expect(reader.read()).resolves.toEqual(expect.objectContaining({ done: false }));
+    await expect(reader.read()).resolves.toEqual(expect.objectContaining({ done: true }));
+    expect(mocks.persistBillingSnapshot).not.toHaveBeenCalled();
+
+    failure.resolve({
+      type: "failure",
+      failure: {
+        errorType: "stream_idle_timeout",
+        errorMessage: "Upstream stream was idle for 1s",
+        statusCode: 504,
+        matchedFailureRule: null,
+        circuitBreakerRecorded: true,
+        occurredAt: "2026-08-07T00:00:00.000Z",
+      },
+    });
+    await expect.poll(() => mocks.persistBillingSnapshot.mock.calls.length).toBe(1);
+    await Promise.resolve();
+
+    expect(mocks.updateRequestLog).toHaveBeenCalledWith(
+      "log-1",
+      expect.objectContaining({
+        statusCode: 504,
+        errorMessage: "Upstream stream was idle for 1s",
+        failoverHistory: [
+          expect.objectContaining({
+            error_type: "stream_idle_timeout",
+          }),
+        ],
+      })
+    );
+    expect(mocks.persistBillingSnapshot).toHaveBeenCalledTimes(1);
+    expect(mocks.updateRequestLog).toHaveBeenCalledTimes(1);
+  });
   it("waits for downstream completion before settling stream success", async () => {
     const metrics = Promise.withResolvers<StreamMetrics>();
     const releaseStream = Promise.withResolvers<void>();

--- a/tests/unit/api/proxy/route.test.ts
+++ b/tests/unit/api/proxy/route.test.ts
@@ -5306,6 +5306,9 @@ describe("proxy route upstream selection", () => {
       await import("@/lib/services/load-balancer");
     const { markHealthy } = await import("@/lib/services/health-checker");
     const { recordSuccess } = await import("@/lib/services/circuit-breaker");
+    const { updateRequestLog } = await import("@/lib/services/request-logger");
+    const { calculateAndPersistRequestBillingSnapshot } =
+      await import("@/lib/services/billing-cost-service");
 
     const upstream = {
       ...DEFAULT_ACTIVE_UPSTREAMS[0],
@@ -5418,6 +5421,14 @@ describe("proxy route upstream selection", () => {
     expect(markHealthy).toHaveBeenCalledWith("up-release-stream", 100);
     expect(recordSuccess).toHaveBeenCalledTimes(1);
     expect(recordSuccess).toHaveBeenCalledWith("up-release-stream");
+    await expect
+      .poll(() => vi.mocked(calculateAndPersistRequestBillingSnapshot).mock.calls.length)
+      .toBe(1);
+    const settledLogWrites = vi
+      .mocked(updateRequestLog)
+      .mock.calls.filter(([, payload]) => payload?.statusCode === 200);
+    expect(settledLogWrites).toHaveLength(1);
+    expect(calculateAndPersistRequestBillingSnapshot).toHaveBeenCalledTimes(1);
   });
 
   it("should attribute failed upstream to last sent attempt when final exclusion is concurrency_full", async () => {
@@ -6988,8 +6999,7 @@ describe("proxy route upstream selection", () => {
     while (!(await reader!.read()).done) {
       // Drain the downstream response to trigger normal terminal settlement.
     }
-    await Promise.resolve();
-    await Promise.resolve();
+    await expect.poll(() => vi.mocked(buildFixture).mock.calls.length).toBe(1);
 
     expect(readStreamChunks).toHaveBeenCalledTimes(1);
     expect(buildFixture).toHaveBeenCalledTimes(1);
@@ -9261,10 +9271,13 @@ describe("proxy route upstream selection", () => {
     it("should settle logs and billing when stream idle timeout interrupts the response", async () => {
       const { db } = await import("@/lib/db");
       const { forwardRequest } = await import("@/lib/services/proxy-client");
-      const { selectFromProviderType } = await import("@/lib/services/load-balancer");
+      const { selectFromProviderType, releaseConnection } =
+        await import("@/lib/services/load-balancer");
       const { updateRequestLog } = await import("@/lib/services/request-logger");
       const { calculateAndPersistRequestBillingSnapshot } =
         await import("@/lib/services/billing-cost-service");
+      const { markUnhealthy } = await import("@/lib/services/health-checker");
+      const { recordFailure } = await import("@/lib/services/circuit-breaker");
 
       mockGetEffectiveCircuitBreakerConfig.mockResolvedValueOnce({
         ...DEFAULT_CIRCUIT_BREAKER_TIMEOUTS,
@@ -9314,20 +9327,12 @@ describe("proxy route upstream selection", () => {
         headers: new Headers({ "content-type": "text/event-stream" }),
         body: new ReadableStream<Uint8Array>({
           start(controller) {
-            controller.close();
+            controller.enqueue(new TextEncoder().encode("data: partial\n\n"));
           },
         }),
         isStream: true,
         streamMetricsPromise: new Promise(() => undefined),
-        streamFailurePromise: Promise.resolve({
-          errorType: "stream_idle_timeout",
-          errorMessage: "Upstream stream was idle for 0s",
-          statusCode: 504,
-          matchedFailureRule: null,
-          circuitBreakerRecorded: true,
-          occurredAt: "2026-05-17T00:00:00.000Z",
-        }),
-      } as Awaited<ReturnType<typeof forwardRequest>>);
+      });
 
       const abortController = new AbortController();
       const request = new NextRequest("http://localhost/api/proxy/v1/chat/completions", {
@@ -9350,25 +9355,35 @@ describe("proxy route upstream selection", () => {
       });
 
       expect(response.status).toBe(200);
+      const reader = response.body?.getReader();
+      expect(reader).toBeDefined();
+      while (!(await reader!.read()).done) {
+        // Drain the response to trigger the upstream idle timeout.
+      }
 
-      await expect
-        .poll(() =>
-          vi
-            .mocked(updateRequestLog)
-            .mock.calls.some(
-              ([, payload]) =>
-                payload.statusCode === 504 &&
-                payload.errorMessage === "Upstream stream was idle for 0s"
-            )
-        )
-        .toBe(true);
+      expect(releaseConnection).toHaveBeenCalledTimes(1);
+      await expect.poll(() => vi.mocked(markUnhealthy).mock.calls.length).toBe(1);
+      expect(markUnhealthy).toHaveBeenCalledWith(
+        "up-openai",
+        expect.stringContaining("Upstream stream was idle")
+      );
+      expect(recordFailure).toHaveBeenCalledWith("up-openai", "stream_idle_timeout");
+
+      const getTimeoutLogWrites = () =>
+        vi
+          .mocked(updateRequestLog)
+          .mock.calls.filter(
+            ([, payload]) =>
+              payload.statusCode === 504 &&
+              payload.errorMessage === "Upstream stream was idle for 0s"
+          );
+      await expect.poll(() => getTimeoutLogWrites().length).toBe(1);
       await expect
         .poll(() => vi.mocked(calculateAndPersistRequestBillingSnapshot).mock.calls.length)
         .toBe(1);
+      expect(calculateAndPersistRequestBillingSnapshot).toHaveBeenCalledTimes(1);
 
-      const failureLogPayload = vi
-        .mocked(updateRequestLog)
-        .mock.calls.find(([, payload]) => payload.statusCode === 504)?.[1];
+      const failureLogPayload = getTimeoutLogWrites()[0]?.[1];
       expect(failureLogPayload).toEqual(
         expect.objectContaining({
           requestedServiceTier: "fast",


### PR DESCRIPTION
## Summary

统一流式代理在上游流完整结束、流中失败、stream timeout 和下游取消场景下的终态结算。

## Related Issue

Closes #263

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (code improvement without changing functionality)
- [x] Tests (adding or updating tests)
- [ ] Build/CI (changes to build system or CI configuration)

## Changes

- Introduced a discriminated `StreamRuntimeSettlement` contract for success and runtime failure outcomes.
- Deferred successful stream settlement until upstream completion and metrics resolution.
- Routed stream timeout and mid-stream failures through the unified stream lifecycle while preserving failure-rule suppression, failure stage, error contract, and failover history.
- Fixed idle-timeout reader cancellation ordering so timeout is not misclassified as normal EOF.
- Preserved one-time request-log and billing settlement and connection cleanup for cancellation and failure paths.

## Test Plan

- [x] Local tests pass (`pnpm test:run`)
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`)
- [ ] Manual testing completed

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots

Not applicable; this is a backend proxy lifecycle refactor.

## Additional Notes

Focused proxy lifecycle tests passed: 104 passed, 1 skipped. Full Vitest passed: 3594 passed, 1 skipped across 241 test files. Prettier, ESLint, TypeScript, and `git diff --check` passed.

The full suite emits two expected error logs from existing `admin-upstreams` error-path tests; those tests pass.