### PR TITLE
chore(release): 准备 v1.16.4-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autorouter",
-  "version": "0.0.0",
+  "version": "1.16.4-beta.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.12.0",


### PR DESCRIPTION
## Summary
将 `package.json` 版本同步为 `1.16.4-beta.1`，为代理生命周期重构后的 beta 预发布做准备。

## Related Issue
Related change: #271

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (code improvement without changing functionality)
- [ ] Tests (adding or updating tests)
- [x] Build/CI (changes to build system or CI configuration)

## Changes
- 更新 `package.json` 的 `version` 为 `1.16.4-beta.1`。
- 版本 tag 将使用 `v1.16.4-beta.1`，触发 GitHub Release workflow 的 beta 预发布路径。
- 不改变应用代码、数据库 schema 或运行时行为。

## Test Plan
- [x] Local tests pass (`pnpm test:run`)
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`)
- [ ] Manual testing completed

Additional checks for this version-only change: package version parsing and `git diff --check` passed. The source commit is based on merged `master` PR #271.

## Checklist
- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (if applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots
Not applicable; no UI changes.

## Additional Notes
This PR must merge into `master` before pushing `v1.16.4-beta.1`; the release workflow rejects tags that are not contained in `origin/master`. The beta tag will create a prerelease and will not update `latest` or the rolling `MAJOR.MINOR` image tag.