### PR TITLE
fix(logs): 修正首次会话绑定状态展示

### DIFF
--- a/src/components/admin/logs-table.tsx
+++ b/src/components/admin/logs-table.tsx
@@ -862,6 +862,13 @@ export function LogsTable({
     const hasFailoverHistory =
       log.failover_attempts > 0 && !!log.failover_history && log.failover_history.length > 0;
     const hasFailoverWithoutHistory = log.failover_attempts > 0 && !hasFailoverHistory;
+    const displayedAffinityBindingState =
+      (log.affinity_binding_state === "unchanged" && log.affinity_hit) ||
+      (log.affinity_binding_state === "migrated" && log.affinity_migrated)
+        ? null
+        : log.affinity_binding_state;
+    const shouldShowAffinityMiss =
+      log.status_code != null && !log.affinity_hit && log.affinity_binding_state == null;
     const hasLifecycleFusion = Boolean(
       totalMs != null ||
       routingDecision ||
@@ -1334,13 +1341,13 @@ export function LogsTable({
                   {hasSession ? (
                     <>
                       <div className="flex flex-wrap items-center gap-1.5">
-                        {log.affinity_binding_state
+                        {displayedAffinityBindingState
                           ? renderMetricPill(
                               t("timelineAffinityBindingState"),
-                              t("affinityBindingState." + log.affinity_binding_state),
-                              log.affinity_binding_state === "created"
+                              t("affinityBindingState." + displayedAffinityBindingState),
+                              displayedAffinityBindingState === "created"
                                 ? "success"
-                                : log.affinity_binding_state === "none"
+                                : displayedAffinityBindingState === "none"
                                   ? "neutral"
                                   : "info"
                             )
@@ -1351,14 +1358,14 @@ export function LogsTable({
                                 "info"
                               )
                             : null}
+                        {shouldShowAffinityMiss
+                          ? renderMetricPill(t("timelineAffinityMissed"), "", "neutral")
+                          : null}
                         {log.affinity_hit && !log.affinity_migrated
                           ? renderMetricPill(t("timelineAffinityHit"), "", "success")
                           : null}
                         {log.affinity_migrated
                           ? renderMetricPill(t("timelineAffinityMigrated"), "", "warning")
-                          : null}
-                        {!log.affinity_hit
-                          ? renderMetricPill(t("timelineAffinityMissed"), "", "neutral")
                           : null}
                         {log.session_id_compensated ? (
                           <Badge variant="warning" className="px-1.5 py-0 text-[10px]">

--- a/src/components/admin/routing-decision-timeline.tsx
+++ b/src/components/admin/routing-decision-timeline.tsx
@@ -128,7 +128,11 @@ export function RoutingDecisionTimeline({
 }: RoutingDecisionTimelineProps) {
   const t = useTranslations("logs");
   const displayedAffinityBindingState =
-    affinityBindingState === "unchanged" ? null : affinityBindingState;
+    (affinityBindingState === "unchanged" && affinityHit === true) ||
+    (affinityBindingState === "migrated" && affinityMigrated === true)
+      ? null
+      : affinityBindingState;
+  const shouldShowAffinityMiss = statusCode != null && !affinityHit && affinityBindingState == null;
 
   const indicators = useMemo(() => {
     if (!routingDecision)
@@ -364,7 +368,7 @@ export function RoutingDecisionTimeline({
                   {t("timelineAffinityMigrated")}
                 </span>
               )}
-              {!affinityHit && (
+              {shouldShowAffinityMiss && (
                 <span className="flex items-center gap-1 text-muted-foreground">
                   {t("timelineAffinityMissed")}
                 </span>

--- a/tests/components/admin/routing-decision-timeline.test.tsx
+++ b/tests/components/admin/routing-decision-timeline.test.tsx
@@ -235,4 +235,30 @@ describe("RoutingDecisionTimeline", () => {
     expect(screen.getByText("timelineAffinityHit")).toBeInTheDocument();
     expect(screen.queryByText("affinityBindingState.unchanged")).not.toBeInTheDocument();
   });
+  it("shows created binding without an affinity-missed label", () => {
+    render(
+      <RoutingDecisionTimeline
+        routingDecision={{
+          ...baseRoutingDecision,
+          did_send_upstream: true,
+          candidate_upstream_id: "up-2",
+          actual_upstream_id: "up-2",
+          failure_stage: null,
+        }}
+        upstreamName="rc"
+        routingType="provider_type"
+        groupName={null}
+        failoverAttempts={0}
+        statusCode={200}
+        sessionId="session-created"
+        affinityHit={false}
+        affinityMigrated={false}
+        affinityBindingState="created"
+        compact={false}
+      />
+    );
+
+    expect(screen.getByText(/affinityBindingState\.created/)).toBeInTheDocument();
+    expect(screen.queryByText("timelineAffinityMissed")).not.toBeInTheDocument();
+  });
 });

--- a/tests/components/logs-table.test.tsx
+++ b/tests/components/logs-table.test.tsx
@@ -2243,6 +2243,7 @@ describe("LogsTable", () => {
       fireEvent.click(screen.getAllByRole("button", { name: "lifecycleDecision" })[0]);
 
       expect(screen.getAllByText("affinityBindingState.created").length).toBeGreaterThan(0);
+      expect(screen.queryByText("timelineAffinityMissed")).not.toBeInTheDocument();
     });
 
     it("shows queue termination chain in the request stage detail", () => {


### PR DESCRIPTION
## Summary
修正管理后台日志中首次会话绑定同时显示“已创建”和“无亲和性绑定”的矛盾状态。

## Related Issue
Follow-up to #273

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (code improvement without changing functionality)
- [x] Tests (adding or updating tests)
- [ ] Build/CI (changes to build system or CI configuration)

## Changes
- 以终端 `affinity_binding_state` 优先于选择阶段 `affinity_hit` 的展示结果。
- 首次成功绑定显示 `created`，不再追加误导性的 `timelineAffinityMissed`。
- 对 `none`、`unchanged`、`migrated`、`reselected` 和 pending 状态统一处理重复或过时标签。
- 仅修改管理后台前端组件和对应回归测试，不改变外部 API 或后端绑定语义。

## Test Plan
- [x] Local tests pass (`pnpm test:run`)
- [x] Type check passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`)
- [x] Manual testing completed (Playwright logs routing smoke test)

## Checklist
- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (not applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots
逻辑展示修正，无布局或视觉样式变化；已通过 Playwright 日志页面 smoke test。

## Additional Notes
完整 Vitest：3614 passed，1 skipped；聚焦会话亲和性组件测试：133 passed。