### PR TITLE
feat(proxy): 增加缓存模型列表聚合

### DIFF
--- a/src/app/api/proxy/v1/[...path]/proxy-request-lifecycle.ts
+++ b/src/app/api/proxy/v1/[...path]/proxy-request-lifecycle.ts
@@ -113,8 +113,11 @@ import {
   createApiKeyModelListResponseBody,
   isModelAllowedByApiKey,
   normalizeApiKeyAllowedModels,
-  pickUpstreamLocalModels,
 } from "@/lib/api-key-models";
+import {
+  resolveDownstreamModelList,
+  type DownstreamModelListResolution,
+} from "@/lib/services/downstream-model-catalog";
 
 const log = createLogger("proxy-route");
 
@@ -501,7 +504,7 @@ async function logApiKeyAdmissionRejectedRequest(input: {
   });
 }
 
-async function logLocalApiKeyModelListRequest(input: {
+async function logLocalModelListRequest(input: {
   apiKeyId: string;
   apiKeyName: string | null;
   apiKeyPrefix: string | null;
@@ -704,37 +707,6 @@ function filterCandidatesByModelRules(
   }
 
   return { allowed, excluded };
-}
-
-function getApiKeyVisibleModelList(
-  apiKeyAllowedModels: string[],
-  candidates: Upstream[]
-): string[] {
-  return apiKeyAllowedModels.filter((model) =>
-    candidates.some((candidate) => resolvePathRoutingModelForUpstream(model, candidate).matched)
-  );
-}
-
-/**
- * Collect the model names an upstream is known to serve, from local data only:
- * synced model catalog first, then declared allowed models, then exact model rules.
- * Used to answer /v1/models locally when no upstream candidate is reachable.
- */
-function collectLocalModelListFallbackModels(candidates: Upstream[]): string[] {
-  const models = new Set<string>();
-  for (const upstream of candidates) {
-    const upstreamModels = pickUpstreamLocalModels({
-      catalogModels: (upstream.modelCatalog ?? []).map((entry) => entry.model),
-      allowedModels: upstream.allowedModels ?? [],
-      exactRuleModels: (upstream.modelRules ?? [])
-        .filter((rule) => rule.type === "exact")
-        .map((rule) => rule.value),
-    });
-    for (const model of upstreamModels) {
-      models.add(model);
-    }
-  }
-  return [...models].sort((a, b) => a.localeCompare(b));
 }
 
 function mergeExcludedCandidates(
@@ -1395,46 +1367,52 @@ export async function executeProxyRequest(request: Request, path: string): Promi
       : activeUpstreams.map((upstream) => upstream.id);
   const allowedUpstreamIdSet = new Set(allowedUpstreamIds);
 
-  // Serve the OpenAI-compatible model list locally for keys that declare allowed
-  // models. Model listing is a discovery endpoint and must not be gated on a
-  // specific route capability (openai_chat_compatible): a key whose authorized
-  // upstreams only expose openai_responses / codex_cli_responses can still
-  // enumerate its allowed models, mirroring what those upstreams actually serve.
+  // Serve a complete cached model list before candidate selection. Model listing is
+  // a discovery endpoint and must not be gated on a specific route capability:
+  // authorized upstreams can expose models through any supported provider protocol.
   const apiKeyAllowedModels = normalizeApiKeyAllowedModels(validApiKey.allowedModels);
-  if (isOpenAIModelListRequest(request.method, path) && apiKeyAllowedModels) {
-    const authorizedActiveUpstreams = activeUpstreams.filter((upstream) =>
-      allowedUpstreamIdSet.has(upstream.id)
-    );
-    if (authorizedActiveUpstreams.length > 0) {
-      const visibleModels = getApiKeyVisibleModelList(
+  const modelListRequest = isOpenAIModelListRequest(request.method, path);
+  const authorizedActiveUpstreams = modelListRequest
+    ? activeUpstreams.filter((upstream) => allowedUpstreamIdSet.has(upstream.id))
+    : [];
+  const localModelListResolution: DownstreamModelListResolution | null = modelListRequest
+    ? resolveDownstreamModelList({
+        upstreams: activeUpstreams,
+        allowedUpstreamIds: allowedUpstreamIdSet,
         apiKeyAllowedModels,
-        authorizedActiveUpstreams
-      );
+      })
+    : null;
 
-      try {
-        await logLocalApiKeyModelListRequest({
-          apiKeyId: validApiKey.id,
-          apiKeyName: apiKeySnapshot.apiKeyName,
-          apiKeyPrefix: apiKeySnapshot.apiKeyPrefix,
-          userId: apiKeySnapshot.userId,
-          request,
-          path,
-          requestId,
-          startTime,
-          matchedRouteCapability,
-          routeMatchSource: matchedRouteMatchSource,
-        });
-      } catch (error) {
-        log.error({ err: error, requestId }, "failed to log local API key model list request");
-      }
+  if (
+    modelListRequest &&
+    authorizedActiveUpstreams.length > 0 &&
+    (apiKeyAllowedModels !== null || localModelListResolution?.complete)
+  ) {
+    const visibleModels = localModelListResolution?.models ?? [];
 
-      return new Response(Buffer.from(createApiKeyModelListResponseBody(visibleModels)), {
-        status: 200,
-        headers: {
-          "content-type": "application/json",
-        },
+    try {
+      await logLocalModelListRequest({
+        apiKeyId: validApiKey.id,
+        apiKeyName: apiKeySnapshot.apiKeyName,
+        apiKeyPrefix: apiKeySnapshot.apiKeyPrefix,
+        userId: apiKeySnapshot.userId,
+        request,
+        path,
+        requestId,
+        startTime,
+        matchedRouteCapability,
+        routeMatchSource: matchedRouteMatchSource,
       });
+    } catch (error) {
+      log.error({ err: error, requestId }, "failed to log local API key model list request");
     }
+
+    return new Response(Buffer.from(createApiKeyModelListResponseBody(visibleModels)), {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+      },
+    });
   }
 
   const primaryCandidatePool = resolveRouteCapabilityCandidatePool(
@@ -2367,16 +2345,14 @@ export async function executeProxyRequest(request: Request, path: string): Promi
     };
 
     // Model listing is a read-only discovery endpoint: when every candidate was
-    // blocked by circuit breakers, answer from the locally synced model catalog
-    // instead of failing the request. Other outage classes (concurrency saturation,
-    // plain unhealthy candidates, …) keep their 503 semantics.
+    // blocked by circuit breakers, answer from cached local model data instead of
+    // failing the request. Other outage classes (concurrency saturation, plain
+    // unhealthy candidates, …) keep their 503 semantics.
     if (
       failureReason === "UPSTREAM_CIRCUIT_OPEN" &&
       isOpenAIModelListRequest(request.method, path)
     ) {
-      const fallbackModels = collectLocalModelListFallbackModels(
-        activeUpstreams.filter((upstream) => allowedUpstreamIdSet.has(upstream.id))
-      );
+      const fallbackModels = localModelListResolution?.models ?? [];
       if (fallbackModels.length > 0) {
         log.warn(
           { requestId, path, failureReason, modelCount: fallbackModels.length },

--- a/src/lib/services/downstream-model-catalog.ts
+++ b/src/lib/services/downstream-model-catalog.ts
@@ -1,0 +1,135 @@
+import type { Upstream } from "@/lib/db";
+import { normalizeApiKeyAllowedModels } from "@/lib/api-key-models";
+import {
+  matchUpstreamModelRules,
+  normalizeUpstreamModelRules,
+} from "@/lib/services/upstream-model-rules";
+import type { UpstreamModelRule } from "@/lib/services/upstream-model-types";
+
+export interface ResolveDownstreamModelListInput {
+  upstreams: Upstream[];
+  allowedUpstreamIds: ReadonlySet<string>;
+  apiKeyAllowedModels: string[] | null;
+}
+
+export interface DownstreamModelListResolution {
+  models: string[];
+  authorizedUpstreamCount: number;
+  knownUpstreamCount: number;
+  complete: boolean;
+}
+
+function normalizeModelNames(models: readonly (string | null | undefined)[]): string[] {
+  const normalized = new Set<string>();
+
+  for (const model of models) {
+    if (typeof model !== "string") {
+      continue;
+    }
+
+    const value = model.trim();
+    if (value.length > 0) {
+      normalized.add(value);
+    }
+  }
+
+  return [...normalized];
+}
+
+function getModelsForUpstream(
+  upstream: Upstream,
+  rules: UpstreamModelRule[],
+  apiKeyAllowedModels: string[] | null
+): string[] {
+  if (apiKeyAllowedModels !== null) {
+    return apiKeyAllowedModels.filter(
+      (model) => rules.length === 0 || matchUpstreamModelRules(model, rules).matched
+    );
+  }
+
+  const catalogModels = normalizeModelNames(
+    (upstream.modelCatalog ?? []).map((entry) => entry.model)
+  );
+  if (rules.length === 0) {
+    return catalogModels;
+  }
+
+  const models = new Set<string>();
+  for (const model of catalogModels) {
+    if (matchUpstreamModelRules(model, rules).matched) {
+      models.add(model);
+    }
+  }
+
+  for (const rule of rules) {
+    if (rule.type === "exact" || rule.type === "alias") {
+      models.add(rule.value);
+    }
+  }
+
+  return [...models];
+}
+
+/**
+ * Resolves the public model list from authorized upstream cache and rules.
+ */
+export function resolveDownstreamModelList(
+  input: ResolveDownstreamModelListInput
+): DownstreamModelListResolution {
+  const authorizedUpstreams = input.upstreams.filter(
+    (upstream) => upstream.isActive !== false && input.allowedUpstreamIds.has(upstream.id)
+  );
+  const normalizedApiKeyAllowedModels =
+    input.apiKeyAllowedModels === null
+      ? null
+      : normalizeApiKeyAllowedModels(input.apiKeyAllowedModels);
+  const upstreamEntries = authorizedUpstreams.map((upstream) => ({
+    upstream,
+    rules:
+      normalizeUpstreamModelRules({
+        modelRules: upstream.modelRules,
+        allowedModels: upstream.allowedModels,
+        modelRedirects: upstream.modelRedirects,
+      }) ?? [],
+  }));
+  const aliasTargets = new Set<string>();
+
+  for (const { rules } of upstreamEntries) {
+    for (const rule of rules) {
+      if (rule.type === "alias" && rule.targetModel) {
+        aliasTargets.add(rule.targetModel);
+      }
+    }
+  }
+
+  const models = new Set<string>();
+  let knownUpstreamCount = 0;
+
+  for (const { upstream, rules } of upstreamEntries) {
+    const visibleModels = getModelsForUpstream(
+      upstream,
+      rules,
+      normalizedApiKeyAllowedModels
+    ).filter((model) => !aliasTargets.has(model));
+
+    if (visibleModels.length > 0) {
+      knownUpstreamCount += 1;
+    }
+
+    for (const model of visibleModels) {
+      models.add(model);
+    }
+  }
+
+  const resolvedModels =
+    normalizedApiKeyAllowedModels === null
+      ? [...models].sort((a, b) => a.localeCompare(b))
+      : [...models];
+
+  return {
+    models: resolvedModels,
+    authorizedUpstreamCount: authorizedUpstreams.length,
+    knownUpstreamCount,
+    complete: authorizedUpstreams.length > 0 && knownUpstreamCount === authorizedUpstreams.length,
+  };
+}

--- a/tests/unit/api/proxy/route.test.ts
+++ b/tests/unit/api/proxy/route.test.ts
@@ -8246,6 +8246,117 @@ describe("proxy route upstream selection", () => {
     expect(data.data.map((item: { id: string }) => item.id)).toEqual(["gpt-4.1", "gpt-5.2"]);
     expect(forwardRequest).not.toHaveBeenCalled();
   });
+  it("should resolve model aliases for normal routed requests", async () => {
+    const { db } = await import("@/lib/db");
+    const { forwardRequest, prepareUpstreamForProxy } = await import("@/lib/services/proxy-client");
+    const { selectFromProviderType } = await import("@/lib/services/load-balancer");
+    const { logRequestStart, updateRequestLog } = await import("@/lib/services/request-logger");
+
+    const aliasUpstream = {
+      id: "up-alias",
+      name: "openai-alias",
+      providerType: "openai",
+      routeCapabilities: ["openai_chat_compatible"],
+      baseUrl: "https://api.openai.com",
+      isDefault: false,
+      isActive: true,
+      timeout: 60,
+      priority: 0,
+      weight: 1,
+      modelRules: [
+        {
+          type: "alias",
+          value: "public-model",
+          targetModel: "internal-model",
+          source: "manual",
+          displayLabel: null,
+        },
+      ],
+      allowedModels: null,
+      modelRedirects: null,
+    };
+
+    vi.mocked(db.query.apiKeys.findMany).mockResolvedValueOnce([
+      {
+        id: "key-alias",
+        keyHash: "hash-alias",
+        keyPrefix: "sk-test",
+        name: "Alias Routing Key",
+        expiresAt: null,
+        isActive: true,
+        accessMode: "restricted",
+        allowedModels: null,
+      },
+    ]);
+    vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([
+      { upstreamId: "up-alias" },
+    ]);
+    vi.mocked(db.query.upstreams.findMany).mockResolvedValueOnce([aliasUpstream]);
+    vi.mocked(db.query.upstreamHealth.findMany).mockResolvedValueOnce([]);
+    vi.mocked(selectFromProviderType).mockResolvedValueOnce({
+      upstream: aliasUpstream,
+      providerType: "openai",
+      selectedTier: 0,
+      circuitBreakerFiltered: 0,
+      totalCandidates: 1,
+    });
+    vi.mocked(forwardRequest).mockResolvedValueOnce({
+      statusCode: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      body: new TextEncoder().encode(JSON.stringify({ id: "alias-response" })),
+      isStream: false,
+      usage: null,
+    });
+
+    const response = await executeProxyRequest(
+      new NextRequest("http://localhost/api/proxy/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer sk-test",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "public-model",
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      }),
+      "chat/completions"
+    );
+
+    expect(response.status).toBe(200);
+    expect(selectFromProviderType).toHaveBeenCalledWith(
+      ["up-alias"],
+      undefined,
+      undefined,
+      expect.objectContaining({ candidateSnapshot: expect.any(Array) })
+    );
+    expect(forwardRequest).toHaveBeenCalledTimes(1);
+    expect(prepareUpstreamForProxy).toHaveBeenCalledWith(
+      aliasUpstream,
+      DEFAULT_CIRCUIT_BREAKER_TIMEOUTS
+    );
+    expect(logRequestStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "internal-model",
+        routingDecision: expect.objectContaining({
+          original_model: "public-model",
+          resolved_model: "internal-model",
+          model_redirect_applied: true,
+        }),
+      })
+    );
+    expect(updateRequestLog).toHaveBeenCalledWith(
+      "log-id",
+      expect.objectContaining({
+        model: "internal-model",
+        routingDecision: expect.objectContaining({
+          original_model: "public-model",
+          resolved_model: "internal-model",
+          model_redirect_applied: true,
+        }),
+      })
+    );
+  });
 
   it("should return model list for keys bound only to non-chat-compatible upstreams", async () => {
     const { db } = await import("@/lib/db");

--- a/tests/unit/api/proxy/route.test.ts
+++ b/tests/unit/api/proxy/route.test.ts
@@ -7834,12 +7834,11 @@ describe("proxy route upstream selection", () => {
         name: "Model List Key",
         expiresAt: null,
         isActive: true,
+        accessMode: "unrestricted",
         allowedModels: null,
       },
     ]);
-    vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([
-      { upstreamId: "up-openai" },
-    ]);
+    vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([]);
     vi.mocked(db.query.upstreams.findMany).mockResolvedValueOnce([openaiUpstream]);
     vi.mocked(db.query.upstreamHealth.findMany).mockResolvedValueOnce([]);
     vi.mocked(selectFromProviderType).mockResolvedValueOnce({
@@ -7887,6 +7886,168 @@ describe("proxy route upstream selection", () => {
       undefined,
       expect.objectContaining({ candidateSnapshot: expect.any(Array) })
     );
+    expect(forwardRequest).toHaveBeenCalledTimes(1);
+  });
+  it("should aggregate a complete cached model list for unrestricted keys", async () => {
+    const { db } = await import("@/lib/db");
+    const { forwardRequest } = await import("@/lib/services/proxy-client");
+    const { routeByModel } = await import("@/lib/services/model-router");
+    const { selectFromProviderType } = await import("@/lib/services/load-balancer");
+    const { logRequest } = await import("@/lib/services/request-logger");
+
+    const cachedUpstreams = [
+      {
+        id: "up-openai",
+        name: "openai-main",
+        providerType: "openai",
+        baseUrl: "https://api.openai.com",
+        isDefault: false,
+        isActive: true,
+        timeout: 60,
+        priority: 0,
+        weight: 1,
+        routeCapabilities: ["openai_chat_compatible"],
+        modelCatalog: [{ model: "gpt-5.2", source: "native" }],
+        modelRules: null,
+        allowedModels: null,
+        modelRedirects: null,
+      },
+      {
+        id: "up-anthropic",
+        name: "anthropic-main",
+        providerType: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+        isDefault: false,
+        isActive: true,
+        timeout: 60,
+        priority: 0,
+        weight: 1,
+        routeCapabilities: ["anthropic_messages"],
+        modelCatalog: [{ model: "claude-3.7", source: "native" }],
+        modelRules: null,
+        allowedModels: null,
+        modelRedirects: null,
+      },
+    ];
+
+    vi.mocked(db.query.apiKeys.findMany).mockResolvedValueOnce([
+      {
+        id: "key-1",
+        keyHash: "hash-1",
+        keyPrefix: "sk-test",
+        name: "Unrestricted Cached Model List Key",
+        expiresAt: null,
+        isActive: true,
+        accessMode: "unrestricted",
+        allowedModels: null,
+      },
+    ]);
+    vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([]);
+    vi.mocked(db.query.upstreams.findMany).mockResolvedValueOnce(cachedUpstreams);
+    vi.mocked(db.query.upstreamHealth.findMany).mockResolvedValueOnce([]);
+
+    const request = new NextRequest("http://localhost/api/proxy/v1/v1/models", {
+      method: "GET",
+      headers: {
+        authorization: "Bearer sk-test",
+      },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["v1", "models"] }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.data.map((item: { id: string }) => item.id)).toEqual(["claude-3.7", "gpt-5.2"]);
+    expect(routeByModel).not.toHaveBeenCalled();
+    expect(selectFromProviderType).not.toHaveBeenCalled();
+    expect(forwardRequest).not.toHaveBeenCalled();
+    expect(logRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKeyId: "key-1",
+        upstreamId: null,
+        model: "(model-list)",
+        statusCode: 200,
+      })
+    );
+  });
+
+  it("should preserve upstream passthrough for an incomplete unrestricted cache", async () => {
+    const { db } = await import("@/lib/db");
+    const { forwardRequest } = await import("@/lib/services/proxy-client");
+    const { selectFromProviderType } = await import("@/lib/services/load-balancer");
+
+    const upstream = {
+      id: "up-openai",
+      name: "openai-main",
+      providerType: "openai",
+      baseUrl: "https://api.openai.com",
+      isDefault: false,
+      isActive: true,
+      timeout: 60,
+      priority: 0,
+      weight: 1,
+      routeCapabilities: ["openai_chat_compatible"],
+      modelCatalog: null,
+      modelRules: null,
+      allowedModels: null,
+      modelRedirects: null,
+    };
+
+    vi.mocked(db.query.apiKeys.findMany).mockResolvedValueOnce([
+      {
+        id: "key-1",
+        keyHash: "hash-1",
+        keyPrefix: "sk-test",
+        name: "Incomplete Cached Model List Key",
+        expiresAt: null,
+        isActive: true,
+        accessMode: "unrestricted",
+        allowedModels: null,
+      },
+    ]);
+    vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([]);
+    vi.mocked(db.query.upstreams.findMany).mockResolvedValueOnce([upstream]);
+    vi.mocked(db.query.upstreamHealth.findMany).mockResolvedValueOnce([]);
+    vi.mocked(selectFromProviderType).mockResolvedValueOnce({
+      upstream,
+      providerType: "openai",
+      selectedTier: 0,
+      circuitBreakerFiltered: 0,
+      totalCandidates: 1,
+    });
+    vi.mocked(forwardRequest).mockResolvedValueOnce({
+      statusCode: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      body: new TextEncoder().encode(
+        JSON.stringify({
+          object: "list",
+          data: [{ id: "live-model" }],
+        })
+      ),
+      isStream: false,
+      usage: null,
+    });
+
+    const request = new NextRequest("http://localhost/api/proxy/v1/models", {
+      method: "GET",
+      headers: {
+        authorization: "Bearer sk-test",
+      },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["models"] }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      object: "list",
+      data: [{ id: "live-model" }],
+    });
+    expect(selectFromProviderType).toHaveBeenCalled();
     expect(forwardRequest).toHaveBeenCalledTimes(1);
   });
 
@@ -7966,12 +8127,13 @@ describe("proxy route upstream selection", () => {
         name: "Restricted Model List Key",
         expiresAt: null,
         isActive: true,
-        allowedModels: ["gpt-4.1", "gpt-5.2", "gpt-5.3"],
+        allowedModels: ["gpt-4.1", "gpt-5.2", "gpt-5.2-internal", "gpt-5.3"],
       },
     ]);
     vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([
       { upstreamId: "up-openai" },
       { upstreamId: "up-alias" },
+      { upstreamId: "up-target" },
     ]);
     vi.mocked(db.query.upstreams.findMany).mockResolvedValueOnce([
       {
@@ -8013,6 +8175,29 @@ describe("proxy route upstream selection", () => {
             type: "alias",
             value: "gpt-5.2",
             targetModel: "gpt-5.2-internal",
+            source: "manual",
+            displayLabel: null,
+          },
+        ],
+        allowedModels: null,
+        modelRedirects: null,
+      },
+      {
+        id: "up-target",
+        name: "openai-target",
+        providerType: "openai",
+        routeCapabilities: ["openai_chat_compatible"],
+        baseUrl: "https://api.openai.com",
+        isDefault: false,
+        isActive: true,
+        timeout: 60,
+        priority: 0,
+        weight: 1,
+        modelRules: [
+          {
+            type: "exact",
+            value: "gpt-5.2-internal",
+            targetModel: null,
             source: "manual",
             displayLabel: null,
           },
@@ -8312,6 +8497,7 @@ describe("proxy route upstream selection", () => {
       },
     ]);
     vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([
+      { upstreamId: "up-unknown" },
       { upstreamId: "up-openai" },
     ]);
     vi.mocked(db.query.upstreams.findMany).mockResolvedValue([
@@ -8330,6 +8516,22 @@ describe("proxy route upstream selection", () => {
           { model: "gpt-5.5", source: "native" },
           { model: "gpt-5.2-mini", source: "native" },
         ],
+        modelRules: null,
+        allowedModels: null,
+        modelRedirects: null,
+      },
+      {
+        id: "up-unknown",
+        name: "unknown-model-source",
+        providerType: "openai",
+        routeCapabilities: ["openai_chat_compatible"],
+        baseUrl: "https://unknown.example.com",
+        isDefault: false,
+        isActive: true,
+        timeout: 60,
+        priority: 0,
+        weight: 1,
+        modelCatalog: null,
         modelRules: null,
         allowedModels: null,
         modelRedirects: null,
@@ -8402,6 +8604,7 @@ describe("proxy route upstream selection", () => {
     ]);
     vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([
       { upstreamId: "up-openai" },
+      { upstreamId: "up-unknown" },
     ]);
     vi.mocked(db.query.upstreams.findMany).mockResolvedValue([
       {
@@ -8416,6 +8619,22 @@ describe("proxy route upstream selection", () => {
         priority: 0,
         weight: 1,
         modelCatalog: [{ model: "gpt-5.5", source: "native" }],
+        modelRules: null,
+        allowedModels: null,
+        modelRedirects: null,
+      },
+      {
+        id: "up-unknown",
+        name: "unknown-model-source",
+        providerType: "openai",
+        routeCapabilities: ["openai_chat_compatible"],
+        baseUrl: "https://unknown.example.com",
+        isDefault: false,
+        isActive: true,
+        timeout: 60,
+        priority: 0,
+        weight: 1,
+        modelCatalog: null,
         modelRules: null,
         allowedModels: null,
         modelRedirects: null,
@@ -8476,6 +8695,7 @@ describe("proxy route upstream selection", () => {
     ]);
     vi.mocked(db.query.apiKeyUpstreams.findMany).mockResolvedValueOnce([
       { upstreamId: "up-openai" },
+      { upstreamId: "up-unknown" },
     ]);
     vi.mocked(db.query.upstreams.findMany).mockResolvedValue([
       {
@@ -8490,6 +8710,22 @@ describe("proxy route upstream selection", () => {
         priority: 0,
         weight: 1,
         modelCatalog: [{ model: "gpt-5.5", source: "native" }],
+        modelRules: null,
+        allowedModels: null,
+        modelRedirects: null,
+      },
+      {
+        id: "up-unknown",
+        name: "unknown-model-source",
+        providerType: "openai",
+        routeCapabilities: ["openai_chat_compatible"],
+        baseUrl: "https://unknown.example.com",
+        isDefault: false,
+        isActive: true,
+        timeout: 60,
+        priority: 0,
+        weight: 1,
+        modelCatalog: null,
         modelRules: null,
         allowedModels: null,
         modelRedirects: null,

--- a/tests/unit/services/downstream-model-catalog.test.ts
+++ b/tests/unit/services/downstream-model-catalog.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Upstream } from "@/lib/db";
+import { resolveDownstreamModelList } from "@/lib/services/downstream-model-catalog";
+
+function createUpstream(overrides: Partial<Upstream> = {}): Upstream {
+  return {
+    id: "upstream-1",
+    name: "OpenAI",
+    baseUrl: "https://api.openai.com/v1",
+    officialWebsiteUrl: null,
+    apiKeyEncrypted: "encrypted-key",
+    isDefault: false,
+    timeout: 60,
+    isActive: true,
+    currentConcurrency: 0,
+    maxConcurrency: null,
+    queuePolicy: null,
+    config: null,
+    weight: 1,
+    priority: 0,
+    routeCapabilities: ["openai_chat_compatible"],
+    allowedModels: null,
+    modelRedirects: null,
+    modelDiscovery: null,
+    modelCatalog: null,
+    modelCatalogUpdatedAt: null,
+    modelCatalogLastStatus: null,
+    modelCatalogLastError: null,
+    modelCatalogLastFailedAt: null,
+    modelRules: null,
+    affinityMigration: null,
+    billingInputMultiplier: 1,
+    billingOutputMultiplier: 1,
+    spendingRules: null,
+    createdAt: new Date("2026-04-25T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-25T00:00:00.000Z"),
+    ...overrides,
+  } as Upstream;
+}
+
+describe("resolveDownstreamModelList", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("aggregates authorized active catalogs in stable sorted order", () => {
+    const upstreams = [
+      createUpstream({
+        id: "up-openai",
+        modelCatalog: [
+          { model: "gpt-5.2", source: "native" },
+          { model: "gpt-4.1", source: "native" },
+        ],
+      }),
+      createUpstream({
+        id: "up-anthropic",
+        modelCatalog: [
+          { model: "claude-3.7", source: "native" },
+          { model: "gpt-4.1", source: "native" },
+        ],
+      }),
+    ];
+
+    expect(
+      resolveDownstreamModelList({
+        upstreams,
+        allowedUpstreamIds: new Set(["up-openai", "up-anthropic"]),
+        apiKeyAllowedModels: null,
+      })
+    ).toEqual({
+      models: ["claude-3.7", "gpt-4.1", "gpt-5.2"],
+      authorizedUpstreamCount: 2,
+      knownUpstreamCount: 2,
+      complete: true,
+    });
+  });
+
+  it("excludes inactive and unauthorized upstreams", () => {
+    const upstreams = [
+      createUpstream({
+        id: "authorized",
+        modelCatalog: [{ model: "visible", source: "native" }],
+      }),
+      createUpstream({
+        id: "inactive",
+        isActive: false,
+        modelCatalog: [{ model: "inactive-model", source: "native" }],
+      }),
+      createUpstream({
+        id: "unauthorized",
+        modelCatalog: [{ model: "private-model", source: "native" }],
+      }),
+    ];
+
+    expect(
+      resolveDownstreamModelList({
+        upstreams,
+        allowedUpstreamIds: new Set(["authorized", "inactive"]),
+        apiKeyAllowedModels: null,
+      })
+    ).toMatchObject({
+      models: ["visible"],
+      authorizedUpstreamCount: 1,
+      knownUpstreamCount: 1,
+      complete: true,
+    });
+  });
+
+  it("marks the local view incomplete when an authorized upstream has no source", () => {
+    const resolution = resolveDownstreamModelList({
+      upstreams: [
+        createUpstream({
+          id: "known",
+          modelCatalog: [{ model: "known-model", source: "native" }],
+        }),
+        createUpstream({ id: "unknown" }),
+      ],
+      allowedUpstreamIds: new Set(["known", "unknown"]),
+      apiKeyAllowedModels: null,
+    });
+
+    expect(resolution).toEqual({
+      models: ["known-model"],
+      authorizedUpstreamCount: 2,
+      knownUpstreamCount: 1,
+      complete: false,
+    });
+  });
+
+  it("reuses API-key allowlist order without requiring a catalog", () => {
+    const resolution = resolveDownstreamModelList({
+      upstreams: [createUpstream({ id: "upstream-without-catalog" })],
+      allowedUpstreamIds: new Set(["upstream-without-catalog"]),
+      apiKeyAllowedModels: [" gpt-5.5 ", "gpt-4.1", "gpt-5.5", "  "],
+    });
+
+    expect(resolution).toEqual({
+      models: ["gpt-5.5", "gpt-4.1"],
+      authorizedUpstreamCount: 1,
+      knownUpstreamCount: 1,
+      complete: true,
+    });
+  });
+
+  it("intersects API-key models with explicit upstream rules", () => {
+    const resolution = resolveDownstreamModelList({
+      upstreams: [
+        createUpstream({
+          modelRules: [
+            {
+              type: "exact",
+              value: "gpt-5.5",
+              targetModel: null,
+              source: "manual",
+              displayLabel: null,
+            },
+          ],
+        }),
+      ],
+      allowedUpstreamIds: new Set(["upstream-1"]),
+      apiKeyAllowedModels: ["gpt-4.1", "gpt-5.5"],
+    });
+
+    expect(resolution.models).toEqual(["gpt-5.5"]);
+  });
+
+  it("projects exact, alias, and regex rules over cached catalogs", () => {
+    const resolution = resolveDownstreamModelList({
+      upstreams: [
+        createUpstream({
+          modelCatalog: [
+            { model: "public-model", source: "native" },
+            { model: "internal-model", source: "native" },
+            { model: "claude-3-7-sonnet", source: "native" },
+            { model: "unmatched", source: "native" },
+          ],
+          modelRules: [
+            {
+              type: "alias",
+              value: "public-model",
+              targetModel: "internal-model",
+              source: "manual",
+              displayLabel: null,
+            },
+            {
+              type: "exact",
+              value: "internal-model",
+              targetModel: null,
+              source: "manual",
+              displayLabel: null,
+            },
+            {
+              type: "exact",
+              value: "configured-model",
+              targetModel: null,
+              source: "manual",
+              displayLabel: null,
+            },
+            {
+              type: "regex",
+              value: "^claude-3",
+              targetModel: null,
+              source: "manual",
+              displayLabel: null,
+            },
+          ],
+        }),
+      ],
+      allowedUpstreamIds: new Set(["upstream-1"]),
+      apiKeyAllowedModels: null,
+    });
+
+    expect(resolution.models).toEqual(["claude-3-7-sonnet", "configured-model", "public-model"]);
+  });
+
+  it("suppresses alias targets globally across authorized upstreams", () => {
+    const resolution = resolveDownstreamModelList({
+      upstreams: [
+        createUpstream({
+          id: "alias-owner",
+          modelRedirects: { "public-model": "internal-model" },
+        }),
+        createUpstream({
+          id: "catalog-owner",
+          modelCatalog: [
+            { model: "internal-model", source: "native" },
+            { model: "other-model", source: "native" },
+          ],
+        }),
+      ],
+      allowedUpstreamIds: new Set(["alias-owner", "catalog-owner"]),
+      apiKeyAllowedModels: null,
+    });
+
+    expect(resolution.models).toEqual(["other-model", "public-model"]);
+  });
+
+  it("normalizes legacy allowed models and redirects", () => {
+    const resolution = resolveDownstreamModelList({
+      upstreams: [
+        createUpstream({
+          allowedModels: [" legacy-model "],
+          modelRedirects: { " public-model ": " legacy-model " },
+        }),
+      ],
+      allowedUpstreamIds: new Set(["upstream-1"]),
+      apiKeyAllowedModels: null,
+    });
+
+    expect(resolution.models).toEqual(["public-model"]);
+  });
+
+  it("treats empty local data as unknown and ignores blank names", () => {
+    const resolution = resolveDownstreamModelList({
+      upstreams: [
+        createUpstream({
+          modelCatalog: [{ model: "  ", source: "native" }],
+          modelRules: [
+            {
+              type: "exact",
+              value: "   ",
+              targetModel: null,
+              source: "manual",
+              displayLabel: null,
+            },
+          ],
+        }),
+      ],
+      allowedUpstreamIds: new Set(["upstream-1"]),
+      apiKeyAllowedModels: null,
+    });
+
+    expect(resolution).toEqual({
+      models: [],
+      authorizedUpstreamCount: 1,
+      knownUpstreamCount: 0,
+      complete: false,
+    });
+  });
+
+  it("returns stale persisted data without making a network request", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const resolution = resolveDownstreamModelList({
+      upstreams: [
+        createUpstream({
+          modelCatalog: [{ model: "stale-model", source: "native" }],
+          modelCatalogLastStatus: "failed",
+          modelCatalogLastError: "upstream unavailable",
+        }),
+      ],
+      allowedUpstreamIds: new Set(["upstream-1"]),
+      apiKeyAllowedModels: null,
+    });
+
+    expect(resolution.models).toEqual(["stale-model"]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
为 OpenAI-compatible `/models` 和 `/v1/models` 增加基于持久化上游 catalog 的缓存模型发现与多上游聚合。

## Related Issue
N/A

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [x] Tests (adding or updating tests)
- [x] Refactoring (code improvement without changing functionality)

## Changes
- 新增纯函数 resolver，复用现有 API Key 上游授权与 upstream model rules。
- unrestricted Key 仅在所有授权 active upstream 都有本地模型来源时返回聚合缓存；缓存不完整时保留原有上游透传。
- API Key allowlist 在 catalog 为空时仍本地返回；alias target 全局隐藏，alias public name 保留。
- circuit-open fallback 复用同一缓存解析结果；并发耗尽等非 circuit failure 仍返回 503。
- 新增 resolver 单元测试、模型列表路由回归覆盖，以及正常 alias 路由解析覆盖。

## Test Plan
- [x] `pnpm test:run tests/unit/services/downstream-model-catalog.test.ts tests/unit/api/proxy/route.test.ts tests/unit/lib/api-key-models.test.ts tests/unit/services/upstream-model-rules.test.ts`（140 passed, 1 skipped）
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm lint`
- [x] Pre-commit hooks（Prettier、ESLint、tsc）通过
- [ ] Manual testing completed（本次为后端代理逻辑，无 UI 变更）

## Checklist
- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (not applicable; no public configuration or API shape changed)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Screenshots
Not applicable.

## Additional Notes
不修改数据库 schema、migration、catalog refresh 生命周期或 admin UI。