### PR TITLE
fix(ci): 等待部署 smoke 请求结算

### DIFF
--- a/.github/workflows/deploy-personal.yml
+++ b/.github/workflows/deploy-personal.yml
@@ -211,6 +211,48 @@ jobs:
 
               return parsedBody;
             }
+            async function waitForRequestSettlement(apiKeyId, expectedRequestCount) {
+              const deadline = Date.now() + 30_000;
+              let latestLogs = [];
+
+              while (Date.now() < deadline) {
+                const query = new URLSearchParams({
+                  api_key_id: apiKeyId,
+                  model: "gpt-4.1-smoke",
+                  page: "1",
+                  page_size: "10",
+                  sort: "created_at",
+                  order: "asc",
+                });
+                const result = await fetchJson(
+                  `${baseUrl}/api/admin/logs?${query.toString()}`,
+                  {
+                    headers: {
+                      authorization: `Bearer ${adminToken}`,
+                    },
+                  },
+                  [200]
+                );
+                latestLogs = Array.isArray(result?.items) ? result.items : [];
+
+                const settled = latestLogs.length >= expectedRequestCount &&
+                  latestLogs.slice(0, expectedRequestCount).every(
+                    (item) =>
+                      typeof item?.status_code === "number" &&
+                      Object.prototype.hasOwnProperty.call(item, "billing_status")
+                  );
+                if (settled) {
+                  return;
+                }
+
+                await delay(250);
+              }
+
+              throw new Error(
+                `Timed out waiting for ${expectedRequestCount} smoke request logs to settle; observed ${latestLogs.length}`
+              );
+            }
+
 
             async function main() {
               assert(adminToken, "Missing AUTOROUTER_ADMIN_TOKEN");
@@ -402,6 +444,7 @@ jobs:
                 assert(streamText.includes("[DONE]"), "Deployment smoke stream missing [DONE]");
 
                 assert(requests.length >= 2, "Deployment smoke mock upstream did not receive requests");
+                await waitForRequestSettlement(apiKey.id, 2);
               } finally {
                 for (const apiKeyId of resources.apiKeyIds) {
                   try {


### PR DESCRIPTION
## Summary
修复 Personal Deploy 的 smoke 验证在请求返回后立即删除测试 upstream，导致异步 billing snapshot 写入触发 upstream 外键错误的问题。

## Related Issue
无。

## Type of Change
- [x] Bug fix
- [x] Build/CI
- [x] Tests / validation
- [ ] Breaking change

## Root Cause
代理请求返回并不代表 request log 与 billing snapshot 已经完成异步结算。原 smoke 脚本在收到 completion 与 stream 响应后直接进入 `finally`，删除测试 upstream；随后 billing snapshot 写入使用已删除的 `upstream_id`，触发外键错误。

## Changes
- 在 cleanup 前通过 Admin Logs API 按 smoke API Key 查询两条请求。
- 轮询直到两条日志都具有终态 `status_code` 且 `billing_status` 字段已经出现，最多等待 30 秒，每 250ms 重试。
- 超时抛错使 smoke 验证失败；`finally` 仍执行 API Key、upstream 和 mock server 的 best-effort cleanup。
- 未修改生产代理逻辑、数据库 schema 或公共 API。

## Test Plan
- `pnpm exec prettier --check .github/workflows/deploy-personal.yml`：通过。
- `git diff --check`：通过。
- PR CI 将运行 actionlint、Quality、Production Build、Migration Consistency、Proxy Stability、Playwright E2E 与 Verify Status。

## Additional Notes
该修复只改变部署 smoke 的资源生命周期等待边界，不改变正常请求行为。