### PR TITLE
perf(auth): 延长 API Key 校验缓存 TTL

### DIFF
--- a/src/lib/utils/auth.ts
+++ b/src/lib/utils/auth.ts
@@ -15,7 +15,7 @@ const API_KEY_VERIFY_CACHE_KEY_PROMISE = webcrypto.subtle.importKey(
 // The proxy still loads the active key row before calling verifyApiKey, so this
 // cache only removes repeated bcrypt work; revocation, expiry, ownership, and
 // authorization changes remain database-authoritative on every request.
-const API_KEY_VERIFY_CACHE_TTL_MS = 10_000;
+const API_KEY_VERIFY_CACHE_TTL_MS = 120_000;
 const API_KEY_VERIFY_CACHE_MAX_ENTRIES = 2_048;
 const apiKeyVerificationCache = new Map<string, number>();
 

--- a/tests/unit/utils/auth.test.ts
+++ b/tests/unit/utils/auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import bcryptjs from "bcryptjs";
 import {
   hashApiKey,
   verifyApiKey,
@@ -59,6 +60,29 @@ describe("auth utilities", () => {
 
       const otherHash = await hashApiKey(otherKey);
       expect(await verifyApiKey(key, otherHash)).toBe(false);
+    });
+    it("should expire cached verification after the two-minute TTL", async () => {
+      const key = "sk-auto-cache-expiring-key12345678901234567890";
+      const hash = await hashApiKey(key);
+      const compareSpy = vi.spyOn(bcryptjs, "compare");
+      const baseTime = Date.now();
+      const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(baseTime);
+
+      try {
+        expect(await verifyApiKey(key, hash)).toBe(true);
+        expect(compareSpy).toHaveBeenCalledTimes(1);
+
+        dateNowSpy.mockReturnValue(baseTime + 119_999);
+        expect(await verifyApiKey(key, hash)).toBe(true);
+        expect(compareSpy).toHaveBeenCalledTimes(1);
+
+        dateNowSpy.mockReturnValue(baseTime + 120_000);
+        expect(await verifyApiKey(key, hash)).toBe(true);
+        expect(compareSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        dateNowSpy.mockRestore();
+        compareSpy.mockRestore();
+      }
     });
     it("should handle invalid hash gracefully", async () => {
       const key = "sk-auto-testkey123456789012345678901234";


### PR DESCRIPTION
## Summary
将 API Key bcrypt 成功校验缓存 TTL 从 10 秒延长到 120 秒，匹配生产请求间隔，降低重复请求的 cold-path 认证开销。

## Related Issue
无。

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (code improvement without changing functionality)
- [x] Tests (adding or updating tests)
- [ ] Build/CI (changes to build system or CI configuration)

## Changes
- `API_KEY_VERIFY_CACHE_TTL_MS`: `10_000` → `120_000`。
- 保持缓存容量 2048 不变。
- 增加 TTL 边界测试：119999ms 内命中，120000ms 后重新执行 bcrypt。
- 缓存仍只跳过 bcrypt；active、expiry、owner、upstream authorization 仍由每请求数据库路径校验。

## Test Plan
- [x] `pnpm test:run tests/unit/utils/auth.test.ts`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm lint`
- [ ] Manual testing completed

## Checklist
- [x] Code follows the project's coding standards
- [x] Tests have been added where necessary
- [x] Documentation has been updated (not applicable)
- [x] Changes do not introduce security vulnerabilities
- [x] Commit messages follow conventions

## Additional Notes
生产日志调查显示 beta3 发布后的请求间隔 P50 约 25 秒、P75 约 106 秒；10 秒 TTL 在最新请求中没有命中，120 秒覆盖当前样本约 63% 的相邻请求。